### PR TITLE
refactor: Tier 3 common/common.h coupling reduction + MSVC portability fix

### DIFF
--- a/benchmarks/src/classic_problems_benchmark.cpp
+++ b/benchmarks/src/classic_problems_benchmark.cpp
@@ -157,9 +157,6 @@ public:
 };
 
 class ComparativeBenchmark {
-private:
-    ClassicHMMProblems problems;
-
 public:
     template <typename ProblemType>
     BenchmarkResults runProblemComparison(ProblemType &problem, int sequence_length) {
@@ -427,7 +424,6 @@ int main() {
     cout << "Fixed random seed (42) for reproducibility" << endl;
 
     ComparativeBenchmark benchmark;
-    ClassicHMMProblems problems;
     vector<BenchmarkResults> results;
 
     // Test different sequence lengths for each problem

--- a/benchmarks/src/libhmm_vs_hmmlib_benchmark.cpp
+++ b/benchmarks/src/libhmm_vs_hmmlib_benchmark.cpp
@@ -262,7 +262,7 @@ public:
             // Benchmark Viterbi
             vector<unsigned int> hidden_sequence(obs_sequence.size());
             start = high_resolution_clock::now();
-            double viterbi_likelihood = hmm.viterbi(obs_sequence, hidden_sequence);
+            (void)hmm.viterbi(obs_sequence, hidden_sequence);
             end = high_resolution_clock::now();
             results.viterbi_time = duration_cast<microseconds>(end - start).count() / 1000.0;
 

--- a/benchmarks/src/simple_benchmark.cpp
+++ b/benchmarks/src/simple_benchmark.cpp
@@ -174,7 +174,7 @@ void benchmarkDistributions() {
                 if (x > 20)
                     x = 20; // Limit for discrete distributions
             }
-            distributions[i]->getProbability(x);
+            static_cast<void>(distributions[i]->getProbability(x));
         }
 
         double time_ms = timer.stop();

--- a/benchmarks/src/threeway_benchmark.cpp
+++ b/benchmarks/src/threeway_benchmark.cpp
@@ -241,7 +241,7 @@ public:
             // Benchmark Viterbi
             vector<unsigned int> hidden_sequence(obs_sequence.size());
             start = high_resolution_clock::now();
-            double viterbi_likelihood = hmm.viterbi(obs_sequence, hidden_sequence);
+            (void)hmm.viterbi(obs_sequence, hidden_sequence);
             end = high_resolution_clock::now();
             results.viterbi_time = duration_cast<microseconds>(end - start).count() / 1000.0;
 

--- a/include/libhmm/calculators/calculator.h
+++ b/include/libhmm/calculators/calculator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "libhmm/common/common.h"
+#include "libhmm/linalg/linalg_types.h"
 #include "libhmm/hmm.h"
 #include <stdexcept>
 #include <memory>

--- a/include/libhmm/common/common.h
+++ b/include/libhmm/common/common.h
@@ -12,6 +12,9 @@
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <iomanip> // std::setprecision, std::fixed, std::put_time — used in toString()
+                   // and file I/O throughout the library. Must be explicit: MSVC and
+                   // libstdc++ do not include <iomanip> transitively through <iostream>.
 #include <sstream>
 #include <stdexcept>
 #include <algorithm>

--- a/include/libhmm/common/common.h
+++ b/include/libhmm/common/common.h
@@ -1,11 +1,12 @@
 #pragma once
 
-/*
- * Standard Library includes - C++17 only, no external dependencies
- * Consolidated to reduce duplicate includes across the project
- */
+// Core C++ standard library headers used throughout the library.
+// Lean version: linalg types (Matrix, Vector, ObservationSet, etc.) and XML
+// serialization helpers now live in separate headers:
+//   libhmm/linalg/linalg_types.h  — type aliases and clear_* helpers
+//   libhmm/common/serialization.h — MatrixSerializer / VectorSerializer
+// Include those headers from files that need them.
 
-// Core C++ standard library headers
 #include <vector>
 #include <memory>
 #include <string>
@@ -17,255 +18,23 @@
 #include <functional>
 #include <utility>
 #include <type_traits>
-
-// Mathematical and numerical headers
 #include <cmath>
-// MSVC does not define M_PI by default; guard here once for all consumers.
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
 #include <cfloat>
 #include <climits>
 #include <cstddef>
 #include <limits>
 #include <cassert>
 
-// Platform/SIMD headers are in libhmm/platform/ (moved from performance/ in Phase 1 refactor)
-// Include libhmm/platform/simd_platform.h if you need SIMD intrinsics
-
-namespace libhmm {
-
-/*
- * If we make all observations as double, we can truncate as needed and still
- * retain tons of precision for most of the operations.
- */
-typedef double Observation;
-
-/*
- * We know that a state is an integral value, so...
- */
-typedef int StateIndex;
-
-} // namespace libhmm
-
-// linalg types live in libhmm/linalg/ (Phase 1 refactor).
-// Must be included after basic typedefs to avoid naming conflicts.
-#include "libhmm/linalg/basic_matrix.h"
-#include "libhmm/linalg/basic_vector.h"
-#include "libhmm/linalg/basic_matrix3d.h"
-
-// Constants extracted to their own header in Phase 1 refactor
+// Constants (includes M_PI guard)
 #include "libhmm/math/constants.h"
 
 namespace libhmm {
 
-// Type aliases
-using Matrix = BasicMatrix<Observation>;
-using Vector = BasicVector<Observation>;
-using ObservationSet = BasicVector<Observation>;
-using StateSequence = BasicVector<StateIndex>;
-using ObservationMatrix3D = BasicMatrix3D<Observation>;
+/// Scalar observation type. Using double gives sufficient precision for all
+/// currently supported distributions while keeping the linalg types concrete.
+typedef double Observation;
 
-template <typename T>
-using Matrix3DTemplate = BasicMatrix3D<T>;
+/// State index type.
+typedef int StateIndex;
 
-typedef std::vector<ObservationSet> ObservationLists;
-
-void clear_matrix(Matrix &m);
-void clear_vector(Vector &v);
-void clear_vector(StateSequence &v);
-
-} // namespace libhmm
-
-/*
- * Custom C++17 serialization functions for matrices and vectors.
- * These replace the Boost serialization functionality with lightweight,
- * standards-compliant serialization using simple XML format.
- *
- * Design Goals:
- * - Zero external dependencies (pure C++17)
- * - Backward compatibility with existing XML format where possible
- * - Simple, human-readable XML output
- * - Efficient parsing for HMM-specific use cases
- */
-namespace libhmm {
-namespace serialization {
-
-/**
- * Simple XML serialization for BasicMatrix objects
- * Replaces boost::serialization with lightweight implementation
- */
-template <typename T>
-class MatrixSerializer {
-public:
-    // Save matrix to XML format
-    static void save(std::ostream &os, const BasicMatrix<T> &matrix,
-                     const std::string &name = "matrix") {
-        os << "<" << name << ">\n";
-        os << "  <rows>" << matrix.size1() << "</rows>\n";
-        os << "  <cols>" << matrix.size2() << "</cols>\n";
-        os << "  <data>\n";
-
-        for (std::size_t i = 0; i < matrix.size1(); ++i) {
-            os << "    <row>";
-            for (std::size_t j = 0; j < matrix.size2(); ++j) {
-                os << matrix(i, j);
-                if (j < matrix.size2() - 1)
-                    os << " ";
-            }
-            os << "</row>\n";
-        }
-
-        os << "  </data>\n";
-        os << "</" << name << ">\n";
-    }
-
-    // Load matrix from XML format
-    static void load(std::istream &is, BasicMatrix<T> &matrix, const std::string &name = "matrix") {
-        std::string line;
-        std::size_t rows = 0, cols = 0;
-
-        // Simple XML parsing - find opening tag
-        while (std::getline(is, line)) {
-            if (line.find("<" + name + ">") != std::string::npos) {
-                break;
-            }
-        }
-
-        // Read dimensions
-        if (std::getline(is, line)) {
-            std::size_t start = line.find("<rows>") + 6;
-            std::size_t end = line.find("</rows>");
-            if (start != std::string::npos && end != std::string::npos) {
-                rows = std::stoull(line.substr(start, end - start));
-            }
-        }
-
-        if (std::getline(is, line)) {
-            std::size_t start = line.find("<cols>") + 6;
-            std::size_t end = line.find("</cols>");
-            if (start != std::string::npos && end != std::string::npos) {
-                cols = std::stoull(line.substr(start, end - start));
-            }
-        }
-
-        // Resize matrix
-        matrix.resize(rows, cols);
-
-        // Skip <data> tag
-        std::getline(is, line);
-
-        // Read matrix data
-        for (std::size_t i = 0; i < rows; ++i) {
-            if (std::getline(is, line)) {
-                std::size_t start = line.find("<row>") + 5;
-                std::size_t end = line.find("</row>");
-                if (start != std::string::npos && end != std::string::npos) {
-                    std::string data_str = line.substr(start, end - start);
-                    std::istringstream row_stream(data_str);
-
-                    for (std::size_t j = 0; j < cols; ++j) {
-                        T value;
-                        row_stream >> value;
-                        matrix(i, j) = value;
-                    }
-                }
-            }
-        }
-    }
-};
-
-/**
- * Simple XML serialization for BasicVector objects
- * Replaces boost::serialization with lightweight implementation
- */
-template <typename T>
-class VectorSerializer {
-public:
-    // Save vector to XML format
-    static void save(std::ostream &os, const BasicVector<T> &vector,
-                     const std::string &name = "vector") {
-        os << "<" << name << ">\n";
-        os << "  <size>" << vector.size() << "</size>\n";
-        os << "  <data>";
-
-        for (std::size_t i = 0; i < vector.size(); ++i) {
-            os << vector[i];
-            if (i < vector.size() - 1)
-                os << " ";
-        }
-
-        os << "</data>\n";
-        os << "</" << name << ">\n";
-    }
-
-    // Load vector from XML format
-    static void load(std::istream &is, BasicVector<T> &vector, const std::string &name = "vector") {
-        std::string line;
-        std::size_t size = 0;
-
-        // Simple XML parsing - find opening tag
-        while (std::getline(is, line)) {
-            if (line.find("<" + name + ">") != std::string::npos) {
-                break;
-            }
-        }
-
-        // Read size
-        if (std::getline(is, line)) {
-            std::size_t start = line.find("<size>") + 6;
-            std::size_t end = line.find("</size>");
-            if (start != std::string::npos && end != std::string::npos) {
-                size = std::stoull(line.substr(start, end - start));
-            }
-        }
-
-        // Resize vector
-        vector.resize(size);
-
-        // Read data
-        if (std::getline(is, line)) {
-            std::size_t start = line.find("<data>") + 6;
-            std::size_t end = line.find("</data>");
-            if (start != std::string::npos && end != std::string::npos) {
-                std::string data_str = line.substr(start, end - start);
-                std::istringstream data_stream(data_str);
-
-                for (std::size_t i = 0; i < size; ++i) {
-                    T value;
-                    data_stream >> value;
-                    vector[i] = value;
-                }
-            }
-        }
-    }
-};
-
-/**
- * Convenience functions to match the old boost::serialization style
- */
-
-// Matrix serialization convenience functions
-template <typename Archive, typename T>
-void save(Archive &ar, const BasicMatrix<T> &matrix, const std::string &name = "matrix") {
-    MatrixSerializer<T>::save(ar, matrix, name);
-}
-
-template <typename Archive, typename T>
-void load(Archive &ar, BasicMatrix<T> &matrix, const std::string &name = "matrix") {
-    MatrixSerializer<T>::load(ar, matrix, name);
-}
-
-// Vector serialization convenience functions
-template <typename Archive, typename T>
-void save(Archive &ar, const BasicVector<T> &vector, const std::string &name = "vector") {
-    VectorSerializer<T>::save(ar, vector, name);
-}
-
-template <typename Archive, typename T>
-void load(Archive &ar, BasicVector<T> &vector, const std::string &name = "vector") {
-    VectorSerializer<T>::load(ar, vector, name);
-}
-
-} // namespace serialization
 } // namespace libhmm

--- a/include/libhmm/common/serialization.h
+++ b/include/libhmm/common/serialization.h
@@ -1,0 +1,169 @@
+#pragma once
+
+// XML serialization helpers for libhmm linalg types.
+//
+// Provides MatrixSerializer<T> and VectorSerializer<T> used by the HMM XML
+// I/O layer (src/hmm.cpp, src/io/).  Extracted from common/common.h to keep
+// that header lean and avoid pulling serialization templates into every
+// translation unit that only needs basic types.
+
+#include <sstream>
+#include <string>
+
+#include "libhmm/linalg/linalg_types.h"
+
+namespace libhmm {
+namespace serialization {
+
+/**
+ * Simple XML serialization for BasicMatrix objects.
+ * Replaces boost::serialization with a lightweight C++17 implementation.
+ */
+template <typename T>
+class MatrixSerializer {
+public:
+    /// Save matrix to XML format
+    static void save(std::ostream &os, const BasicMatrix<T> &matrix,
+                     const std::string &name = "matrix") {
+        os << "<" << name << ">\n";
+        os << "  <rows>" << matrix.size1() << "</rows>\n";
+        os << "  <cols>" << matrix.size2() << "</cols>\n";
+        os << "  <data>\n";
+
+        for (std::size_t i = 0; i < matrix.size1(); ++i) {
+            os << "    <row>";
+            for (std::size_t j = 0; j < matrix.size2(); ++j) {
+                os << matrix(i, j);
+                if (j < matrix.size2() - 1)
+                    os << " ";
+            }
+            os << "</row>\n";
+        }
+
+        os << "  </data>\n";
+        os << "</" << name << ">\n";
+    }
+
+    /// Load matrix from XML format
+    static void load(std::istream &is, BasicMatrix<T> &matrix, const std::string &name = "matrix") {
+        std::string line;
+        std::size_t rows = 0, cols = 0;
+
+        while (std::getline(is, line)) {
+            if (line.find("<" + name + ">") != std::string::npos)
+                break;
+        }
+
+        if (std::getline(is, line)) {
+            std::size_t start = line.find("<rows>") + 6;
+            std::size_t end = line.find("</rows>");
+            if (start != std::string::npos && end != std::string::npos)
+                rows = std::stoull(line.substr(start, end - start));
+        }
+
+        if (std::getline(is, line)) {
+            std::size_t start = line.find("<cols>") + 6;
+            std::size_t end = line.find("</cols>");
+            if (start != std::string::npos && end != std::string::npos)
+                cols = std::stoull(line.substr(start, end - start));
+        }
+
+        matrix.resize(rows, cols);
+        std::getline(is, line); // skip <data>
+
+        for (std::size_t i = 0; i < rows; ++i) {
+            if (std::getline(is, line)) {
+                std::size_t start = line.find("<row>") + 5;
+                std::size_t end = line.find("</row>");
+                if (start != std::string::npos && end != std::string::npos) {
+                    std::istringstream row_stream(line.substr(start, end - start));
+                    for (std::size_t j = 0; j < cols; ++j) {
+                        T value;
+                        row_stream >> value;
+                        matrix(i, j) = value;
+                    }
+                }
+            }
+        }
+    }
+};
+
+/**
+ * Simple XML serialization for BasicVector objects.
+ * Replaces boost::serialization with a lightweight C++17 implementation.
+ */
+template <typename T>
+class VectorSerializer {
+public:
+    /// Save vector to XML format
+    static void save(std::ostream &os, const BasicVector<T> &vector,
+                     const std::string &name = "vector") {
+        os << "<" << name << ">\n";
+        os << "  <size>" << vector.size() << "</size>\n";
+        os << "  <data>";
+        for (std::size_t i = 0; i < vector.size(); ++i) {
+            os << vector[i];
+            if (i < vector.size() - 1)
+                os << " ";
+        }
+        os << "</data>\n";
+        os << "</" << name << ">\n";
+    }
+
+    /// Load vector from XML format
+    static void load(std::istream &is, BasicVector<T> &vector, const std::string &name = "vector") {
+        std::string line;
+        std::size_t size = 0;
+
+        while (std::getline(is, line)) {
+            if (line.find("<" + name + ">") != std::string::npos)
+                break;
+        }
+
+        if (std::getline(is, line)) {
+            std::size_t start = line.find("<size>") + 6;
+            std::size_t end = line.find("</size>");
+            if (start != std::string::npos && end != std::string::npos)
+                size = std::stoull(line.substr(start, end - start));
+        }
+
+        vector.resize(size);
+
+        if (std::getline(is, line)) {
+            std::size_t start = line.find("<data>") + 6;
+            std::size_t end = line.find("</data>");
+            if (start != std::string::npos && end != std::string::npos) {
+                std::istringstream data_stream(line.substr(start, end - start));
+                for (std::size_t i = 0; i < size; ++i) {
+                    T value;
+                    data_stream >> value;
+                    vector[i] = value;
+                }
+            }
+        }
+    }
+};
+
+// Convenience wrappers matching the old boost::serialization style
+template <typename Archive, typename T>
+void save(Archive &ar, const BasicMatrix<T> &matrix, const std::string &name = "matrix") {
+    MatrixSerializer<T>::save(ar, matrix, name);
+}
+
+template <typename Archive, typename T>
+void load(Archive &ar, BasicMatrix<T> &matrix, const std::string &name = "matrix") {
+    MatrixSerializer<T>::load(ar, matrix, name);
+}
+
+template <typename Archive, typename T>
+void save(Archive &ar, const BasicVector<T> &vector, const std::string &name = "vector") {
+    VectorSerializer<T>::save(ar, vector, name);
+}
+
+template <typename Archive, typename T>
+void load(Archive &ar, BasicVector<T> &vector, const std::string &name = "vector") {
+    VectorSerializer<T>::load(ar, vector, name);
+}
+
+} // namespace serialization
+} // namespace libhmm

--- a/include/libhmm/hmm.h
+++ b/include/libhmm/hmm.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <stdexcept>
 #include <algorithm>
-#include "libhmm/common/common.h"
+#include "libhmm/linalg/linalg_types.h"
 #include "libhmm/distributions/distributions.h"
 #include "libhmm/common/string_tokenizer.h"
 

--- a/include/libhmm/io/xml_file_reader.h
+++ b/include/libhmm/io/xml_file_reader.h
@@ -8,7 +8,6 @@
 #include <memory>
 // Removed boost include - using custom C++17 XML serialization
 
-#include "libhmm/common/common.h"
 #include "libhmm/hmm.h"
 
 namespace libhmm {

--- a/include/libhmm/io/xml_file_writer.h
+++ b/include/libhmm/io/xml_file_writer.h
@@ -8,7 +8,6 @@
 #include <memory>
 // Removed boost include - using custom C++17 XML serialization
 
-#include "libhmm/common/common.h"
 #include "libhmm/hmm.h"
 
 namespace libhmm {

--- a/include/libhmm/libhmm.h
+++ b/include/libhmm/libhmm.h
@@ -28,7 +28,7 @@
  * For large projects or when compilation time is critical, consider including
  * only the specific headers you need instead of this master header.
  *
- * @version 2.8.0
+ * @version 3.3.0
  * @author libhmm development team
  */
 
@@ -36,7 +36,9 @@
 // CORE FOUNDATION
 //==============================================================================
 
-/// Core types, constants, and mathematical utilities
+/// Core types, constants, and mathematical utilities.
+/// linalg types (Matrix, Vector, ObservationSet, etc.) are provided
+/// transitively through hmm.h → linalg/linalg_types.h.
 #include "libhmm/common/common.h"
 
 /// Main HMM class and state machine implementation

--- a/include/libhmm/linalg/linalg_types.h
+++ b/include/libhmm/linalg/linalg_types.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// Linalg types for libhmm.
+//
+// Provides the concrete matrix/vector types and the type aliases that the HMM
+// engine, calculators, trainers, and IO layer depend on.  Distribution headers
+// do NOT need to include this file — they work with std::span<double> and do
+// not expose or store linalg types in their public signatures.
+//
+// Include this header from any file that uses Matrix, Vector, ObservationSet,
+// ObservationLists, StateSequence, or the clear_* helpers.
+
+#include <vector>
+
+#include "libhmm/common/common.h" // Observation, StateIndex, STL headers
+#include "libhmm/linalg/basic_matrix.h"
+#include "libhmm/linalg/basic_matrix3d.h"
+#include "libhmm/linalg/basic_vector.h"
+
+namespace libhmm {
+
+// Core linalg type aliases
+using Matrix = BasicMatrix<Observation>;
+using Vector = BasicVector<Observation>;
+using ObservationSet = BasicVector<Observation>;
+using StateSequence = BasicVector<StateIndex>;
+using ObservationMatrix3D = BasicMatrix3D<Observation>;
+
+template <typename T>
+using Matrix3DTemplate = BasicMatrix3D<T>;
+
+/// Sequence of observation vectors, one per training sequence.
+typedef std::vector<ObservationSet> ObservationLists;
+
+// Utility helpers — implementations in src/common/common.cpp
+void clear_matrix(Matrix &m);
+void clear_vector(Vector &v);
+void clear_vector(StateSequence &v);
+
+} // namespace libhmm

--- a/include/libhmm/math/constants.h
+++ b/include/libhmm/math/constants.h
@@ -95,6 +95,11 @@ inline constexpr std::size_t SIMD_ALIGNMENT = 32;
 
 /// Mathematical constants
 namespace math {
+// Provide M_PI for code that tests for it (non-standard but widely expected).
+// Defined before PI so both are available in the same translation unit.
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 inline constexpr double PI = 3.141592653589793238462643383279502884;
 inline constexpr double LN2 = 0.6931471805599453094172321214581766;
 inline constexpr double LN_10 = 2.302585092994046;

--- a/include/libhmm/math/numerical_stability.h
+++ b/include/libhmm/math/numerical_stability.h
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include "libhmm/common/common.h"
+#include "libhmm/linalg/linalg_types.h"
 
 namespace libhmm {
 namespace numerical {

--- a/include/libhmm/training/segmental_kmeans_trainer.h
+++ b/include/libhmm/training/segmental_kmeans_trainer.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <memory>
 #include <stdexcept>
-#include "libhmm/common/common.h"
+#include "libhmm/linalg/linalg_types.h"
 #include "libhmm/training/trainer.h"
 
 namespace libhmm {

--- a/include/libhmm/training/trainer.h
+++ b/include/libhmm/training/trainer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "libhmm/common/common.h"
+#include "libhmm/linalg/linalg_types.h"
 #include "libhmm/hmm.h"
 #include <functional>
 #include <stdexcept>

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -1,4 +1,4 @@
-#include "libhmm/common/common.h"
+#include "libhmm/linalg/linalg_types.h"
 
 namespace libhmm {
 

--- a/tests/common/test_common.cpp
+++ b/tests/common/test_common.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "libhmm/common/common.h"
+#include "libhmm/linalg/linalg_types.h"
 #include "libhmm/common/string_tokenizer.h"
 #include <string>
 #include <cmath>

--- a/tests/distributions/test_pareto_distribution.cpp
+++ b/tests/distributions/test_pareto_distribution.cpp
@@ -14,7 +14,6 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
-#include "libhmm/common/common.h"
 
 using libhmm::Observation;
 using libhmm::ParetoDistribution;

--- a/tests/distributions/test_rayleigh_distribution.cpp
+++ b/tests/distributions/test_rayleigh_distribution.cpp
@@ -14,7 +14,6 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
-#include "libhmm/common/common.h"
 
 using libhmm::Observation;
 using libhmm::RayleighDistribution;

--- a/tools/fb_contour_sweep.cpp
+++ b/tools/fb_contour_sweep.cpp
@@ -23,7 +23,7 @@ namespace fs = std::filesystem;
 namespace {
 
 constexpr double LOG_ZERO = -std::numeric_limits<double>::infinity();
-constexpr std::size_t FB_MAX_REDUCE_FORCE_PAIRWISE_MAX_STATES = 2;
+[[maybe_unused]] constexpr std::size_t FB_MAX_REDUCE_FORCE_PAIRWISE_MAX_STATES = 2;
 volatile double g_sink_double = 0.0;
 
 struct Config {

--- a/tools/hotspot_breakdown.cpp
+++ b/tools/hotspot_breakdown.cpp
@@ -21,7 +21,7 @@ using Millis = std::chrono::duration<double, std::milli>;
 namespace {
 
 constexpr double LOG_ZERO = -std::numeric_limits<double>::infinity();
-constexpr std::size_t FB_MAX_REDUCE_FORCE_PAIRWISE_MAX_STATES = 2;
+[[maybe_unused]] constexpr std::size_t FB_MAX_REDUCE_FORCE_PAIRWISE_MAX_STATES = 2;
 volatile double g_sink_double = 0.0;
 volatile int g_sink_int = 0;
 


### PR DESCRIPTION
## Summary

Tier 3 of the code quality refactoring roadmap: splits the `common/common.h` god header to break the transitive linalg coupling that caused all 15 distribution headers to pull in ~695 SLOC of matrix/vector type definitions they never used.

Includes a one-line MSVC portability fix discovered during Windows verification: `<iomanip>` was being silently provided by Apple Clang through `<iostream>` but is required explicitly by MSVC and libstdc++.

## Changes

### `common/common.h` split (Tier 3)
- **`include/libhmm/linalg/linalg_types.h`** (new): type aliases `Matrix`, `Vector`, `ObservationSet`, `StateSequence`, `ObservationLists` and `clear_*` helpers — include only where linalg types are genuinely needed (calculators, trainers, HMM core, IO)
- **`include/libhmm/common/serialization.h`** (new): `MatrixSerializer<T>` and `VectorSerializer<T>` extracted from `common.h` — include only from `src/hmm.cpp` and the IO layer
- **`include/libhmm/common/common.h`**: linalg and serialization content removed; now a lean header of core STL facilities and `Observation`/`StateIndex` type aliases
- Distribution headers no longer include `common/common.h` for linalg types they don't use

### MSVC portability fix
- Added `#include <iomanip>` to `common.h` with an explanatory comment: `std::setprecision`/`std::fixed`/`std::put_time` are used throughout the library but Apple Clang silently provides `<iomanip>` transitively through `<iostream>` while MSVC and libstdc++ do not

## Verification

- Built and tested on **M1/macOS Tahoe** (Apple Clang, arm64) during Tier 3 development — 37/37 tests passing
- Built and tested on **Windows/MSVC** (AVX2, this PR) — 37/37 tests passing, only pre-existing C4244/C4267 from `<memory>` template instantiation
- All pre-commit hooks pass

## Roadmap

Tier 3 complete. Remaining:
- **Tier 4**: `hmm.cpp::operator>>` decomposition (CC 18, length 258)
- **Tier 5** (deferred): SIMD tier boilerplate
- Version bump to 3.4.0 after Tier 4 completion

**Plan:** https://app.warp.dev/drive/notebook/niAbtAHXXGBa2zwkv2pe6R  
**Session:** https://app.warp.dev/conversation/ca60ff01-fa5e-45cf-be1a-5dd234ddd87c

Co-Authored-By: Oz <oz-agent@warp.dev>