### PR TITLE
fix/gtest-migration: migrate legacy assert tests to GTest; bump to v3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1] - 2026-05-09
+
+Test infrastructure patch. 37 test executables / 37 passing.
+
+### Added
+
+- **GTest migration** of 15 legacy distribution-specific test files
+  (`tests/distributions/test_*_distribution.cpp`): the `assert()`/`main()`
+  pattern replaced with `TEST()`/`EXPECT_*` macros throughout. The old
+  pattern silently produced false-green results in Release builds because
+  `-DNDEBUG` compiles `assert()` to a no-op; tests now fire
+  unconditionally. Closes #10.
+  - Includes the v3.5.0 post-release hotfix (six IO assertions that had
+    contained wrong format strings since v2.7.0, first detected in a
+    non-Release build — commit 56014e2).
+- **`WeightedStats` unit tests** added to `tests/common/test_common.cpp`:
+  direct tests for `detail::compute_weighted_stats` and
+  `detail::compute_weighted_mean`, which underpin the weighted `fit()` path
+  in 9+ distributions but had no unit test of their own. Covers known-value
+  cases (uniform and non-uniform weights), single-element (variance = 0),
+  empty spans, zero-weight sum, and NaN weight (all `nullopt` guard paths).
+- **`json::Reader` unit tests** added to `tests/io/test_hmm_json.cpp`:
+  direct tests for the handwritten JSON parser, exercising error paths
+  (`consume` mismatch, EOF on consume/peek/read_double, unterminated string,
+  non-numeric double, array size-cap throw) not reachable through the
+  HMM-level `from_json()` tests. Also tests `write_double` and `write_array`
+  round-trip at the parser level.
+
 ## [3.5.0] - 2026-05-06
 
 cppcheck quality pass and V2 numerical framework removal. 37/37 tests pass.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if(APPLE AND NOT CMAKE_CXX_COMPILER)
 endif()
 
 project(libhmm
-    VERSION 3.5.0
+    VERSION 3.5.1
     DESCRIPTION "Modern C++20 Hidden Markov Model Library"
     LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://isocpp.org/std/the-standard)
 [![CMake](https://img.shields.io/badge/CMake-3.20%2B-blue.svg)](https://cmake.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-3.5.0-brightgreen.svg)](https://github.com/OldCrow/libhmm/releases)
+[![Version](https://img.shields.io/badge/Version-3.5.1-brightgreen.svg)](https://github.com/OldCrow/libhmm/releases)
 [![Tests](https://img.shields.io/badge/Tests-37%2F37_Passing-success.svg)](tests/)
 [![SIMD](https://img.shields.io/badge/SIMD-AVX--512%2FAVX2%2FSSE2%2FNEON-blue.svg)](src/distributions/)
 [![CI](https://github.com/OldCrow/libhmm/actions/workflows/ci.yml/badge.svg)](https://github.com/OldCrow/libhmm/actions)

--- a/WARP.md
+++ b/WARP.md
@@ -6,7 +6,7 @@ This file provides guidance to Warp (warp.dev) when working in this repository.
 
 ## Current Status
 
-**Version**: v3.3.0 — latest tag and published release on `main`.
+**Version**: v3.5.1 — pending release on `fix/gtest-migration`; v3.5.0 is the latest published tag on `main`.
 **Tests**: 37/37 passing on all four CI platforms (Linux/GCC, Linux/Clang, macOS/AppleClang, Windows/MSVC).
 **Active phase**: Complete. All phases through Post-Phase 5 (CI/tooling, benchmarks) are done.
 

--- a/include/libhmm/libhmm.h
+++ b/include/libhmm/libhmm.h
@@ -28,7 +28,7 @@
  * For large projects or when compilation time is critical, consider including
  * only the specific headers you need instead of this master header.
  *
- * @version 3.4.0
+ * @version 3.5.1
  * @author libhmm development team
  */
 
@@ -91,7 +91,7 @@
  * provided by the Hidden Markov Model library. Key components include:
  *
  * - **Core Classes**: Hmm, ObservationSet, StateSequence
- * - **Distributions**: 14+ probability distributions for discrete and continuous data
+ * - **Distributions**: 15 probability distributions for discrete and continuous data
  * - **Calculators**: Forward-Backward and Viterbi algorithms with SIMD optimization
  * - **Trainers**: Baum-Welch, Viterbi, and clustering-based parameter estimation
  * - **I/O**: XML file reading/writing and general file management

--- a/tests/common/test_common.cpp
+++ b/tests/common/test_common.cpp
@@ -1,8 +1,10 @@
 #include <gtest/gtest.h>
 #include "libhmm/linalg/linalg_types.h"
 #include "libhmm/common/string_tokenizer.h"
+#include "libhmm/math/weighted_stats.h"
 #include <string>
 #include <cmath>
+#include <limits>
 
 using namespace libhmm;
 
@@ -334,6 +336,85 @@ TEST_F(CommonErrorHandlingTest, MatrixVectorEdgeCases) {
     // Zero-size should work
     EXPECT_NO_THROW(Matrix(0, 0));
     EXPECT_NO_THROW(Vector(0));
+}
+
+// =============================================================================
+// WeightedStats tests
+// compute_weighted_stats and compute_weighted_mean are shared helpers used
+// by the weighted fit() paths in 9+ distributions.  Bugs here silently
+// corrupt all weighted fits, so they deserve a direct unit test.
+// =============================================================================
+
+using libhmm::detail::compute_weighted_stats;
+using libhmm::detail::compute_weighted_mean;
+
+TEST(WeightedStatsTest, UniformWeightsKnownValue) {
+    // Uniform weights: result must equal unweighted mean/variance.
+    const std::vector<double> data    = {1.0, 2.0, 3.0};
+    const std::vector<double> weights = {1.0, 1.0, 1.0};
+
+    auto r = compute_weighted_stats(data, weights);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_NEAR(r->mean, 2.0, 1e-12);       // (1+2+3)/3
+    EXPECT_NEAR(r->variance, 2.0/3.0, 1e-12); // biased: ((1)^2+(0)^2+(1)^2)/3
+}
+
+TEST(WeightedStatsTest, NonUniformWeightsKnownValue) {
+    // data={0,2,4}, weights={1,2,1}: sumW=4, mean=(0+4+4)/4=2,
+    // var=(1*(0-2)^2+2*(2-2)^2+1*(4-2)^2)/4=(4+0+4)/4=2.
+    const std::vector<double> data    = {0.0, 2.0, 4.0};
+    const std::vector<double> weights = {1.0, 2.0, 1.0};
+
+    auto r = compute_weighted_stats(data, weights);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_NEAR(r->mean, 2.0, 1e-12);
+    EXPECT_NEAR(r->variance, 2.0, 1e-12);
+}
+
+TEST(WeightedStatsTest, SingleElementVarianceIsZero) {
+    const std::vector<double> data    = {5.0};
+    const std::vector<double> weights = {1.0};
+
+    auto r = compute_weighted_stats(data, weights);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_NEAR(r->mean, 5.0, 1e-15);
+    EXPECT_NEAR(r->variance, 0.0, 1e-15);
+}
+
+TEST(WeightedStatsTest, EmptySpansReturnNullopt) {
+    const std::vector<double> empty;
+    auto r = compute_weighted_stats(empty, empty);
+    EXPECT_FALSE(r.has_value());
+
+    auto m = compute_weighted_mean(empty, empty);
+    EXPECT_FALSE(m.has_value());
+}
+
+TEST(WeightedStatsTest, ZeroWeightSumReturnNullopt) {
+    const std::vector<double> data    = {1.0, 2.0, 3.0};
+    const std::vector<double> weights = {0.0, 0.0, 0.0};
+
+    EXPECT_FALSE(compute_weighted_stats(data, weights).has_value());
+    EXPECT_FALSE(compute_weighted_mean(data, weights).has_value());
+}
+
+TEST(WeightedStatsTest, NanWeightReturnNullopt) {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const std::vector<double> data    = {1.0, 2.0};
+    const std::vector<double> weights = {nan, 1.0};
+
+    EXPECT_FALSE(compute_weighted_stats(data, weights).has_value());
+    EXPECT_FALSE(compute_weighted_mean(data, weights).has_value());
+}
+
+TEST(WeightedMeanTest, NonUniformWeightsKnownValue) {
+    // data={1,2,3}, weights={0.5,1.0,0.5}: sumW=2, mean=(0.5+2+1.5)/2=2.
+    const std::vector<double> data    = {1.0, 2.0, 3.0};
+    const std::vector<double> weights = {0.5, 1.0, 0.5};
+
+    auto m = compute_weighted_mean(data, weights);
+    ASSERT_TRUE(m.has_value());
+    EXPECT_NEAR(*m, 2.0, 1e-12);
 }
 
 int main(int argc, char **argv) {

--- a/tests/common/test_common.cpp
+++ b/tests/common/test_common.cpp
@@ -345,24 +345,24 @@ TEST_F(CommonErrorHandlingTest, MatrixVectorEdgeCases) {
 // corrupt all weighted fits, so they deserve a direct unit test.
 // =============================================================================
 
-using libhmm::detail::compute_weighted_stats;
 using libhmm::detail::compute_weighted_mean;
+using libhmm::detail::compute_weighted_stats;
 
 TEST(WeightedStatsTest, UniformWeightsKnownValue) {
     // Uniform weights: result must equal unweighted mean/variance.
-    const std::vector<double> data    = {1.0, 2.0, 3.0};
+    const std::vector<double> data = {1.0, 2.0, 3.0};
     const std::vector<double> weights = {1.0, 1.0, 1.0};
 
     auto r = compute_weighted_stats(data, weights);
     ASSERT_TRUE(r.has_value());
-    EXPECT_NEAR(r->mean, 2.0, 1e-12);       // (1+2+3)/3
-    EXPECT_NEAR(r->variance, 2.0/3.0, 1e-12); // biased: ((1)^2+(0)^2+(1)^2)/3
+    EXPECT_NEAR(r->mean, 2.0, 1e-12);           // (1+2+3)/3
+    EXPECT_NEAR(r->variance, 2.0 / 3.0, 1e-12); // biased: ((1)^2+(0)^2+(1)^2)/3
 }
 
 TEST(WeightedStatsTest, NonUniformWeightsKnownValue) {
     // data={0,2,4}, weights={1,2,1}: sumW=4, mean=(0+4+4)/4=2,
     // var=(1*(0-2)^2+2*(2-2)^2+1*(4-2)^2)/4=(4+0+4)/4=2.
-    const std::vector<double> data    = {0.0, 2.0, 4.0};
+    const std::vector<double> data = {0.0, 2.0, 4.0};
     const std::vector<double> weights = {1.0, 2.0, 1.0};
 
     auto r = compute_weighted_stats(data, weights);
@@ -372,7 +372,7 @@ TEST(WeightedStatsTest, NonUniformWeightsKnownValue) {
 }
 
 TEST(WeightedStatsTest, SingleElementVarianceIsZero) {
-    const std::vector<double> data    = {5.0};
+    const std::vector<double> data = {5.0};
     const std::vector<double> weights = {1.0};
 
     auto r = compute_weighted_stats(data, weights);
@@ -391,7 +391,7 @@ TEST(WeightedStatsTest, EmptySpansReturnNullopt) {
 }
 
 TEST(WeightedStatsTest, ZeroWeightSumReturnNullopt) {
-    const std::vector<double> data    = {1.0, 2.0, 3.0};
+    const std::vector<double> data = {1.0, 2.0, 3.0};
     const std::vector<double> weights = {0.0, 0.0, 0.0};
 
     EXPECT_FALSE(compute_weighted_stats(data, weights).has_value());
@@ -400,7 +400,7 @@ TEST(WeightedStatsTest, ZeroWeightSumReturnNullopt) {
 
 TEST(WeightedStatsTest, NanWeightReturnNullopt) {
     const double nan = std::numeric_limits<double>::quiet_NaN();
-    const std::vector<double> data    = {1.0, 2.0};
+    const std::vector<double> data = {1.0, 2.0};
     const std::vector<double> weights = {nan, 1.0};
 
     EXPECT_FALSE(compute_weighted_stats(data, weights).has_value());
@@ -409,7 +409,7 @@ TEST(WeightedStatsTest, NanWeightReturnNullopt) {
 
 TEST(WeightedMeanTest, NonUniformWeightsKnownValue) {
     // data={1,2,3}, weights={0.5,1.0,0.5}: sumW=2, mean=(0.5+2+1.5)/2=2.
-    const std::vector<double> data    = {1.0, 2.0, 3.0};
+    const std::vector<double> data = {1.0, 2.0, 3.0};
     const std::vector<double> weights = {0.5, 1.0, 0.5};
 
     auto m = compute_weighted_mean(data, weights);

--- a/tests/distributions/test_beta_distribution.cpp
+++ b/tests/distributions/test_beta_distribution.cpp
@@ -1,18 +1,12 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <limits>
 #include <chrono>
 #include <iomanip>
 #include "libhmm/distributions/beta_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::BetaDistribution;
 using libhmm::Observation;
@@ -20,118 +14,111 @@ using libhmm::Observation;
 /**
  * Test basic Beta distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Beta distribution functionality..." << std::endl;
+TEST(BetaDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     BetaDistribution beta;
-    assert(beta.getAlpha() == 1.0);
-    assert(beta.getBeta() == 1.0);
+    EXPECT_EQ(beta.getAlpha(), 1.0);
+    EXPECT_EQ(beta.getBeta(), 1.0);
 
     // Test parameterized constructor
     BetaDistribution beta2(2.5, 1.5);
-    assert(beta2.getAlpha() == 2.5);
-    assert(beta2.getBeta() == 1.5);
+    EXPECT_EQ(beta2.getAlpha(), 2.5);
+    EXPECT_EQ(beta2.getBeta(), 1.5);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(BetaDistributionTest, Probabilities) {
 
     BetaDistribution beta(2.0, 3.0); // Alpha=2, Beta=3
 
     // Test that probability is zero for values outside [0,1]
-    assert(beta.getProbability(-0.1) == 0.0);
-    assert(beta.getProbability(1.1) == 0.0);
-    assert(beta.getProbability(-1.0) == 0.0);
-    assert(beta.getProbability(2.0) == 0.0);
+    EXPECT_EQ(beta.getProbability(-0.1), 0.0);
+    EXPECT_EQ(beta.getProbability(1.1), 0.0);
+    EXPECT_EQ(beta.getProbability(-1.0), 0.0);
+    EXPECT_EQ(beta.getProbability(2.0), 0.0);
 
     // Test that probability is positive for values in [0,1]
     double prob1 = beta.getProbability(0.2);
     double prob2 = beta.getProbability(0.5);
     double prob3 = beta.getProbability(0.8);
 
-    assert(prob1 > 0.0);
-    assert(prob2 > 0.0);
-    assert(prob3 > 0.0);
+    EXPECT_GT(prob1, 0.0);
+    EXPECT_GT(prob2, 0.0);
+    EXPECT_GT(prob3, 0.0);
 
     // For Beta(2,3), mode is at (α-1)/(α+β-2) = 1/3 ≈ 0.333
     // So probability should be higher at 0.2 than at 0.8
-    assert(prob1 > prob3);
+    EXPECT_GT(prob1, prob3);
 
     // Test boundary values
     double probAt0 = beta.getProbability(0.0);
     double probAt1 = beta.getProbability(1.0);
-    assert(probAt0 >= 0.0); // Should be 0 for Beta(2,3) since α > 1
-    assert(probAt1 >= 0.0); // Should be 0 for Beta(2,3) since β > 1
+    EXPECT_TRUE(probAt0 >= 0.0); // Should be 0 for Beta(2,3) since α > 1
+    EXPECT_TRUE(probAt1 >= 0.0); // Should be 0 for Beta(2,3) since β > 1
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(BetaDistributionTest, Fitting) {
 
     BetaDistribution beta;
 
     // Test with known data
     std::vector<Observation> data = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7};
     beta.fit(data);
-    assert(beta.getAlpha() > 0.0); // Should have some reasonable value
-    assert(beta.getBeta() > 0.0);  // Should have some reasonable value
+    EXPECT_GT(beta.getAlpha(), 0.0); // Should have some reasonable value
+    EXPECT_GT(beta.getBeta(), 0.0);  // Should have some reasonable value
 
     // Test with empty data (should reset to default)
     std::vector<Observation> emptyData;
     beta.fit(emptyData);
-    assert(beta.getAlpha() == 1.0);
-    assert(beta.getBeta() == 1.0);
+    EXPECT_EQ(beta.getAlpha(), 1.0);
+    EXPECT_EQ(beta.getBeta(), 1.0);
 
     // Test with single point (should reset to default for insufficient data)
     std::vector<Observation> singlePoint = {0.5};
     beta.fit(singlePoint);
-    assert(beta.getAlpha() == 1.0);
-    assert(beta.getBeta() == 1.0);
+    EXPECT_EQ(beta.getAlpha(), 1.0);
+    EXPECT_EQ(beta.getBeta(), 1.0);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(BetaDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
     try {
         BetaDistribution beta(0.0, 1.0); // Zero alpha
-        assert(false);                   // Should not reach here
+        ADD_FAILURE();                   // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         BetaDistribution beta(-1.0, 1.0); // Negative alpha
-        assert(false);                    // Should not reach here
+        ADD_FAILURE();                    // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         BetaDistribution beta(1.0, 0.0); // Zero beta
-        assert(false);                   // Should not reach here
+        ADD_FAILURE();                   // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         BetaDistribution beta(1.0, -1.0); // Negative beta
-        assert(false);                    // Should not reach here
+        ADD_FAILURE();                    // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
@@ -140,101 +127,75 @@ void testParameterValidation() {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        BetaDistribution beta(nan_val, 1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(BetaDistribution beta(nan_val, 1.0), std::invalid_argument);
 
-    try {
-        BetaDistribution beta(1.0, inf_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(BetaDistribution beta(1.0, inf_val), std::invalid_argument);
 
     // Test setters validation
     BetaDistribution beta(1.0, 1.0);
 
-    try {
-        beta.setAlpha(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(beta.setAlpha(0.0), std::invalid_argument);
 
-    try {
-        beta.setBeta(-1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(beta.setBeta(-1.0), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(BetaDistributionTest, StringRepresentation) {
 
     BetaDistribution beta(2.5, 1.5);
     std::string str = beta.toString();
 
     // Should contain key information based on actual output format:
     // "Beta Distribution:\n      α (alpha) = 2.5\n      β (beta) = 1.5\n"
-    assert(str.find("Beta") != std::string::npos);
-    assert(str.find("Distribution") != std::string::npos);
-    assert(str.find("2.5") != std::string::npos);
-    assert(str.find("1.5") != std::string::npos);
-    assert(str.find("α") != std::string::npos || str.find("alpha") != std::string::npos);
-    assert(str.find("β") != std::string::npos || str.find("beta") != std::string::npos);
+    EXPECT_NE(str.find("Beta"), std::string::npos);
+    EXPECT_NE(str.find("Distribution"), std::string::npos);
+    EXPECT_NE(str.find("2.5"), std::string::npos);
+    EXPECT_NE(str.find("1.5"), std::string::npos);
+    EXPECT_NE(str.find("α"), std::string::npos || str.find("alpha") != std::string::npos);
+    EXPECT_NE(str.find("β"), std::string::npos || str.find("beta") != std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(BetaDistributionTest, CopyMoveSemantics) {
 
     BetaDistribution original(3.14, 2.71);
 
     // Test copy constructor
     BetaDistribution copied(original);
-    assert(copied.getAlpha() == original.getAlpha());
-    assert(copied.getBeta() == original.getBeta());
+    EXPECT_EQ(copied.getAlpha(), original.getAlpha());
+    EXPECT_EQ(copied.getBeta(), original.getBeta());
 
     // Test copy assignment
     BetaDistribution assigned;
     assigned = original;
-    assert(assigned.getAlpha() == original.getAlpha());
-    assert(assigned.getBeta() == original.getBeta());
+    EXPECT_EQ(assigned.getAlpha(), original.getAlpha());
+    EXPECT_EQ(assigned.getBeta(), original.getBeta());
 
     // Test move constructor
     BetaDistribution moved(std::move(original));
-    assert(moved.getAlpha() == 3.14);
-    assert(moved.getBeta() == 2.71);
+    EXPECT_EQ(moved.getAlpha(), 3.14);
+    EXPECT_EQ(moved.getBeta(), 2.71);
 
     // Test move assignment
     BetaDistribution moveAssigned;
     BetaDistribution temp(1.41, 1.73);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getAlpha() == 1.41);
-    assert(moveAssigned.getBeta() == 1.73);
+    EXPECT_EQ(moveAssigned.getAlpha(), 1.41);
+    EXPECT_EQ(moveAssigned.getBeta(), 1.73);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test invalid input handling
  */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(BetaDistributionTest, InvalidInputHandling) {
 
     BetaDistribution beta(2.0, 3.0);
 
@@ -243,39 +204,35 @@ void testInvalidInputHandling() {
     double inf_val = std::numeric_limits<double>::infinity();
     double neg_inf_val = -std::numeric_limits<double>::infinity();
 
-    assert(beta.getProbability(nan_val) == 0.0);
-    assert(beta.getProbability(inf_val) == 0.0);
-    assert(beta.getProbability(neg_inf_val) == 0.0);
+    EXPECT_EQ(beta.getProbability(nan_val), 0.0);
+    EXPECT_EQ(beta.getProbability(inf_val), 0.0);
+    EXPECT_EQ(beta.getProbability(neg_inf_val), 0.0);
 
     // Values outside [0,1] should return 0
-    assert(beta.getProbability(-0.1) == 0.0);
-    assert(beta.getProbability(1.1) == 0.0);
-    assert(beta.getProbability(-5.0) == 0.0);
-    assert(beta.getProbability(10.0) == 0.0);
+    EXPECT_EQ(beta.getProbability(-0.1), 0.0);
+    EXPECT_EQ(beta.getProbability(1.1), 0.0);
+    EXPECT_EQ(beta.getProbability(-5.0), 0.0);
+    EXPECT_EQ(beta.getProbability(10.0), 0.0);
 
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
 }
 
 /**
  * Test reset functionality
  */
-void testResetFunctionality() {
-    std::cout << "Testing reset functionality..." << std::endl;
+TEST(BetaDistributionTest, ResetFunctionality) {
 
     BetaDistribution beta(10.0, 5.0);
     beta.reset();
 
-    assert(beta.getAlpha() == 1.0);
-    assert(beta.getBeta() == 1.0);
+    EXPECT_EQ(beta.getAlpha(), 1.0);
+    EXPECT_EQ(beta.getBeta(), 1.0);
 
-    std::cout << "✓ Reset functionality tests passed" << std::endl;
 }
 
 /**
  * Test log probability function for numerical stability
  */
-void testLogProbability() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(BetaDistributionTest, LogProbability) {
 
     BetaDistribution beta(2.0, 3.0); // alpha=2, beta=3
 
@@ -294,9 +251,9 @@ void testLogProbability() {
 
     // Note: For continuous distributions, PDF can be > 1, so log(PDF) can be positive
     // We just verify they are finite and reasonable
-    assert(std::isfinite(logP1));
-    assert(std::isfinite(logP2));
-    assert(std::isfinite(logP3));
+    EXPECT_TRUE(std::isfinite(logP1));
+    EXPECT_TRUE(std::isfinite(logP2));
+    EXPECT_TRUE(std::isfinite(logP3));
 
     // For Beta(2,3): log(f(x)) = log(x) + 2*log(1-x) - log(B(2,3))
     // where B(2,3) = Γ(2)Γ(3)/Γ(5) = 1*2/(4*3*2*1) = 2/24 = 1/12
@@ -306,22 +263,21 @@ void testLogProbability() {
     double expectedLogP2 = std::log(x2) + 2.0 * std::log(1.0 - x2) - logBeta23;
     double expectedLogP3 = std::log(x3) + 2.0 * std::log(1.0 - x3) - logBeta23;
 
-    assert(std::abs(logP1 - expectedLogP1) < 1e-10);
-    assert(std::abs(logP2 - expectedLogP2) < 1e-10);
-    assert(std::abs(logP3 - expectedLogP3) < 1e-10);
+    EXPECT_NEAR(logP1, expectedLogP1, 1e-10);
+    EXPECT_NEAR(logP2, expectedLogP2, 1e-10);
+    EXPECT_NEAR(logP3, expectedLogP3, 1e-10);
 
     // Verify consistency with getProbability
     double p1 = beta.getProbability(x1);
     double p2 = beta.getProbability(x2);
 
-    assert(p1 > 0.0);
-    assert(p2 > 0.0);
+    EXPECT_GT(p1, 0.0);
+    EXPECT_GT(p2, 0.0);
 
     // Test invalid inputs return -infinity
-    assert(beta.getLogProbability(-0.1) == -std::numeric_limits<double>::infinity());
-    assert(beta.getLogProbability(1.1) == -std::numeric_limits<double>::infinity());
-    assert(beta.getLogProbability(std::numeric_limits<double>::quiet_NaN()) ==
-           -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(beta.getLogProbability(-0.1), -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(beta.getLogProbability(1.1), -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(beta.getLogProbability(std::numeric_limits<double>::quiet_NaN()), -std::numeric_limits<double>::infinity());
 
     // Test boundary cases
     BetaDistribution uniform(1.0, 1.0); // Uniform on [0,1]
@@ -329,111 +285,93 @@ void testLogProbability() {
     double logP1_boundary = uniform.getLogProbability(1.0);
 
     // For uniform distribution, log(f(x)) = -log(B(1,1)) = -log(1) = 0
-    assert(std::abs(logP0 - 0.0) < 1e-10);
-    assert(std::abs(logP1_boundary - 0.0) < 1e-10);
+    EXPECT_NEAR(logP0, 0.0, 1e-10);
+    EXPECT_NEAR(logP1_boundary, 0.0, 1e-10);
 
-    std::cout << "✓ Log probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test Beta distribution properties
  */
-void testBetaProperties() {
-    std::cout << "Testing Beta distribution properties..." << std::endl;
+TEST(BetaDistributionTest, BetaProperties) {
 
     // Test uniform distribution (Beta(1,1))
     BetaDistribution uniform(1.0, 1.0);
-    assert(std::abs(uniform.getMean() - 0.5) < 1e-10);
-    assert(std::abs(uniform.getVariance() - (1.0 / 12.0)) < 1e-10);
+    EXPECT_NEAR(uniform.getMean(), 0.5, 1e-10);
+    EXPECT_NEAR(uniform.getVariance(), (1.0 / 12.0), 1e-10);
 
     // Test symmetric distribution (Beta(2,2))
     BetaDistribution symmetric(2.0, 2.0);
-    assert(std::abs(symmetric.getMean() - 0.5) < 1e-10);
+    EXPECT_NEAR(symmetric.getMean(), 0.5, 1e-10);
 
     // Test skewed distribution (Beta(2,5))
     BetaDistribution skewed(2.0, 5.0);
     double expectedMean = 2.0 / (2.0 + 5.0);
-    assert(std::abs(skewed.getMean() - expectedMean) < 1e-10);
-    assert(skewed.getMean() < 0.5); // Should be skewed toward 0
+    EXPECT_NEAR(skewed.getMean(), expectedMean, 1e-10);
+    EXPECT_LT(skewed.getMean(), 0.5); // Should be skewed toward 0
 
     // Test that probability is only defined on [0,1]
-    assert(uniform.getProbability(-0.1) == 0.0);
-    assert(uniform.getProbability(1.1) == 0.0);
-    assert(uniform.getProbability(0.5) > 0.0);
+    EXPECT_EQ(uniform.getProbability(-0.1), 0.0);
+    EXPECT_EQ(uniform.getProbability(1.1), 0.0);
+    EXPECT_GT(uniform.getProbability(0.5), 0.0);
 
-    std::cout << "✓ Beta property tests passed" << std::endl;
 }
 
 /**
  * Test fitting validation
  */
-void testFittingValidation() {
-    std::cout << "Testing fitting validation..." << std::endl;
+TEST(BetaDistributionTest, FittingValidation) {
 
     BetaDistribution beta;
 
     // Test with data containing values outside [0,1]
     std::vector<Observation> invalidData = {0.2, 0.5, 1.5, 0.8}; // 1.5 is out of range
 
-    try {
-        beta.fit(invalidData);
-        assert(false); // Should throw exception
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(beta.fit(invalidData), std::invalid_argument);
 
     // Test with negative values
     std::vector<Observation> negativeData = {0.2, 0.5, -0.1, 0.8}; // -0.1 is invalid
-    try {
-        beta.fit(negativeData);
-        assert(false); // Should throw exception
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(beta.fit(negativeData), std::invalid_argument);
 
     // Test with valid data in boundary cases
     std::vector<Observation> boundaryData = {0.0, 0.5, 1.0};
     try {
         beta.fit(boundaryData);
         // Should work fine, check that parameters are reasonable
-        assert(beta.getAlpha() > 0.0);
-        assert(beta.getBeta() > 0.0);
+        EXPECT_GT(beta.getAlpha(), 0.0);
+        EXPECT_GT(beta.getBeta(), 0.0);
     } catch (const std::exception &) {
         // Also acceptable if implementation rejects boundary values
     }
 
-    std::cout << "✓ Fitting validation tests passed" << std::endl;
 }
 
 /**
  * Test statistical moments
  */
-void testStatisticalMoments() {
-    std::cout << "Testing statistical moments..." << std::endl;
+TEST(BetaDistributionTest, StatisticalMoments) {
 
     BetaDistribution beta(3.0, 2.0);
 
     // Test mean: α/(α+β) = 3/(3+2) = 0.6
     double expectedMean = 3.0 / 5.0;
-    assert(std::abs(beta.getMean() - expectedMean) < 1e-10);
+    EXPECT_NEAR(beta.getMean(), expectedMean, 1e-10);
 
     // Test variance: αβ/((α+β)²(α+β+1)) = 6/(25*6) = 0.04
     double expectedVar = (3.0 * 2.0) / (5.0 * 5.0 * 6.0);
-    assert(std::abs(beta.getVariance() - expectedVar) < 1e-10);
+    EXPECT_NEAR(beta.getVariance(), expectedVar, 1e-10);
 
     // Test standard deviation
     double expectedStd = std::sqrt(expectedVar);
-    assert(std::abs(beta.getStandardDeviation() - expectedStd) < 1e-10);
+    EXPECT_NEAR(beta.getStandardDeviation(), expectedStd, 1e-10);
 
-    std::cout << "✓ Statistical moments tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics to verify optimizations
  * This serves as a benchmark and regression test for performance
  */
-void testPerformance() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(BetaDistributionTest, Performance) {
 
     using namespace std::chrono;
     BetaDistribution beta(2.5, 3.5);
@@ -490,14 +428,13 @@ void testPerformance() {
 
     // Basic performance assertions (adjust thresholds based on typical performance)
     // These should be conservative to avoid false failures on different hardware
-    assert(pdf_per_call < 2.0); // Should be well under 2 microseconds per PDF call
-    assert(log_pdf_per_call <
-           1.0); // Should be well under 1 microsecond per log PDF call (faster due to no exp)
-    assert(fit_per_point < 5.0); // Should be well under 5 microseconds per fit datapoint
+    EXPECT_LT(pdf_per_call, 2.0); // Should be well under 2 microseconds per PDF call
+    EXPECT_LT(log_pdf_per_call, 1.0); // Should be well under 1 microsecond per log PDF call (faster due to no exp)
+    EXPECT_LT(fit_per_point, 5.0); // Should be well under 5 microseconds per fit datapoint
 
     // Verify correctness (prevent compiler optimization removal)
-    assert(sum_pdf > 0.0);
-    assert(std::isfinite(sum_log_pdf));
+    EXPECT_GT(sum_pdf, 0.0);
+    EXPECT_TRUE(std::isfinite(sum_log_pdf));
 
     std::cout << std::fixed << std::setprecision(3);
     std::cout << "  PDF timing:       " << pdf_per_call << " μs/call (" << pdf_iterations
@@ -506,68 +443,62 @@ void testPerformance() {
               << " calls)" << std::endl;
     std::cout << "  Fit timing:       " << fit_per_point << " μs/point (" << fit_datapoints
               << " points)" << std::endl;
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
 /**
  * Test CDF calculations (Gold Standard)
  */
-void testCDFCalculations() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(BetaDistributionTest, CDFCalculations) {
 
     BetaDistribution beta(2.0, 3.0);
 
     // Test boundary values
-    assert(beta.getCumulativeProbability(-0.1) == 0.0);
-    assert(beta.getCumulativeProbability(0.0) == 0.0);
-    assert(beta.getCumulativeProbability(1.0) == 1.0);
-    assert(beta.getCumulativeProbability(1.1) == 1.0);
+    EXPECT_EQ(beta.getCumulativeProbability(-0.1), 0.0);
+    EXPECT_EQ(beta.getCumulativeProbability(0.0), 0.0);
+    EXPECT_EQ(beta.getCumulativeProbability(1.0), 1.0);
+    EXPECT_EQ(beta.getCumulativeProbability(1.1), 1.0);
 
     // Test monotonicity
     double cdf1 = beta.getCumulativeProbability(0.2);
     double cdf2 = beta.getCumulativeProbability(0.5);
     double cdf3 = beta.getCumulativeProbability(0.8);
-    assert(cdf1 < cdf2);
-    assert(cdf2 < cdf3);
+    EXPECT_LT(cdf1, cdf2);
+    EXPECT_LT(cdf2, cdf3);
 
     // Test that CDF values are in [0,1]
-    assert(cdf1 >= 0.0 && cdf1 <= 1.0);
-    assert(cdf2 >= 0.0 && cdf2 <= 1.0);
-    assert(cdf3 >= 0.0 && cdf3 <= 1.0);
+    EXPECT_TRUE(cdf1 >= 0.0 && cdf1 <= 1.0);
+    EXPECT_TRUE(cdf2 >= 0.0 && cdf2 <= 1.0);
+    EXPECT_TRUE(cdf3 >= 0.0 && cdf3 <= 1.0);
 
-    std::cout << "✓ CDF calculation tests passed" << std::endl;
 }
 
 /**
  * Test equality and I/O operators (Gold Standard)
  */
-void testEqualityAndIO() {
-    std::cout << "Testing equality and I/O operators..." << std::endl;
+TEST(BetaDistributionTest, EqualityAndIO) {
 
     BetaDistribution b1(2.0, 1.5);
     BetaDistribution b2(2.0, 1.5);
     BetaDistribution b3(3.0, 1.5);
 
-    assert(b1 == b2);
-    assert(b2 == b1);
-    assert(!(b1 == b3));
-    assert(b1 != b3);
+    EXPECT_EQ(b1, b2);
+    EXPECT_EQ(b2, b1);
+    EXPECT_FALSE(b1 == b3);
+    EXPECT_NE(b1, b3);
 
     std::ostringstream oss;
     oss << b1;
     std::string output = oss.str();
-    assert(output.find("Beta Distribution") != std::string::npos);
-    assert(output.find("2.0") != std::string::npos);
-    assert(output.find("1.5") != std::string::npos);
+    EXPECT_NE(output.find("Beta Distribution"), std::string::npos);
+    EXPECT_NE(output.find("2.0"), std::string::npos);
+    EXPECT_NE(output.find("1.5"), std::string::npos);
 
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
 }
 
 /**
  * Test numerical stability (Gold Standard)
  */
-void testNumericalStability() {
-    std::cout << "Testing numerical stability..." << std::endl;
+TEST(BetaDistributionTest, NumericalStability) {
 
     // Test extreme parameter values
     BetaDistribution smallAlpha(0.1, 1.0);
@@ -578,24 +509,22 @@ void testNumericalStability() {
     double probLarge = largeAlpha.getProbability(0.1);
     double probBoth = largeBoth.getProbability(0.5);
 
-    assert(probSmall > 0.0 && std::isfinite(probSmall));
-    assert(probLarge > 0.0 && std::isfinite(probLarge));
-    assert(probBoth > 0.0 && std::isfinite(probBoth));
+    EXPECT_TRUE(probSmall > 0.0 && std::isfinite(probSmall));
+    EXPECT_TRUE(probLarge > 0.0 && std::isfinite(probLarge));
+    EXPECT_TRUE(probBoth > 0.0 && std::isfinite(probBoth));
 
     // Test log probability with extreme values
     double logProbSmall = smallAlpha.getLogProbability(0.1);
     double logProbLarge = largeAlpha.getLogProbability(0.1);
-    assert(std::isfinite(logProbSmall));
-    assert(std::isfinite(logProbLarge));
+    EXPECT_TRUE(std::isfinite(logProbSmall));
+    EXPECT_TRUE(std::isfinite(logProbLarge));
 
-    std::cout << "✓ Numerical stability tests passed" << std::endl;
 }
 
 /**
  * Test caching mechanism (Gold Standard)
  */
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
+TEST(BetaDistributionTest, Caching) {
 
     BetaDistribution beta(2.0, 1.0);
 
@@ -608,21 +537,21 @@ void testCaching() {
     double prob2 = beta.getProbability(0.5);
     double logProb2 = beta.getLogProbability(0.5);
 
-    assert(prob1 != prob2);       // Should be different after parameter change
-    assert(logProb1 != logProb2); // Should be different after parameter change
+    EXPECT_NE(prob1, prob2);       // Should be different after parameter change
+    EXPECT_NE(logProb1, logProb2); // Should be different after parameter change
 
     // Change beta parameter
     beta.setBeta(2.0);
     double prob3 = beta.getProbability(0.5);
     double logProb3 = beta.getLogProbability(0.5);
 
-    assert(prob2 != prob3);       // Should be different after parameter change
-    assert(logProb2 != logProb3); // Should be different after parameter change
+    EXPECT_NE(prob2, prob3);       // Should be different after parameter change
+    EXPECT_NE(logProb2, logProb3); // Should be different after parameter change
 
     // Test that copy constructor preserves cache state
     BetaDistribution copied(beta);
-    assert(copied.getProbability(0.5) == beta.getProbability(0.5));
-    assert(copied.getLogProbability(0.5) == beta.getLogProbability(0.5));
+    EXPECT_EQ(copied.getProbability(0.5), beta.getProbability(0.5));
+    EXPECT_EQ(copied.getLogProbability(0.5), beta.getLogProbability(0.5));
 
     // Test that cached values are consistent
     double prob4 = beta.getProbability(0.5);
@@ -630,48 +559,13 @@ void testCaching() {
     double logProb4 = beta.getLogProbability(0.5);
 
     // Multiple calls should return identical results (using cache)
-    assert(beta.getProbability(0.5) == prob4);
-    assert(beta.getCumulativeProbability(0.5) == cdf4);
-    assert(beta.getLogProbability(0.5) == logProb4);
+    EXPECT_EQ(beta.getProbability(0.5), prob4);
+    EXPECT_EQ(beta.getCumulativeProbability(0.5), cdf4);
+    EXPECT_EQ(beta.getLogProbability(0.5), logProb4);
 
-    std::cout << "✓ Caching tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running Beta distribution tests..." << std::endl;
-    std::cout << "==================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testLogProbability();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testInvalidInputHandling();
-        testResetFunctionality();
-        testBetaProperties();
-        testFittingValidation();
-        testStatisticalMoments();
-        testPerformance();
-
-        // Gold Standard Tests
-        testCDFCalculations();
-        testEqualityAndIO();
-        testNumericalStability();
-        testCaching();
-
-        std::cout << "==================================" << std::endl;
-        std::cout << "✅ All Beta distribution tests passed (including Gold Standard)!"
-                  << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_beta_distribution.cpp
+++ b/tests/distributions/test_beta_distribution.cpp
@@ -25,7 +25,6 @@ TEST(BetaDistributionTest, BasicFunctionality) {
     BetaDistribution beta2(2.5, 1.5);
     EXPECT_EQ(beta2.getAlpha(), 2.5);
     EXPECT_EQ(beta2.getBeta(), 1.5);
-
 }
 
 /**
@@ -59,7 +58,6 @@ TEST(BetaDistributionTest, Probabilities) {
     double probAt1 = beta.getProbability(1.0);
     EXPECT_TRUE(probAt0 >= 0.0); // Should be 0 for Beta(2,3) since α > 1
     EXPECT_TRUE(probAt1 >= 0.0); // Should be 0 for Beta(2,3) since β > 1
-
 }
 
 /**
@@ -86,7 +84,6 @@ TEST(BetaDistributionTest, Fitting) {
     beta.fit(singlePoint);
     EXPECT_EQ(beta.getAlpha(), 1.0);
     EXPECT_EQ(beta.getBeta(), 1.0);
-
 }
 
 /**
@@ -137,7 +134,6 @@ TEST(BetaDistributionTest, ParameterValidation) {
     EXPECT_THROW(beta.setAlpha(0.0), std::invalid_argument);
 
     EXPECT_THROW(beta.setBeta(-1.0), std::invalid_argument);
-
 }
 
 /**
@@ -189,7 +185,6 @@ TEST(BetaDistributionTest, CopyMoveSemantics) {
     moveAssigned = std::move(temp);
     EXPECT_EQ(moveAssigned.getAlpha(), 1.41);
     EXPECT_EQ(moveAssigned.getBeta(), 1.73);
-
 }
 
 /**
@@ -213,7 +208,6 @@ TEST(BetaDistributionTest, InvalidInputHandling) {
     EXPECT_EQ(beta.getProbability(1.1), 0.0);
     EXPECT_EQ(beta.getProbability(-5.0), 0.0);
     EXPECT_EQ(beta.getProbability(10.0), 0.0);
-
 }
 
 /**
@@ -226,7 +220,6 @@ TEST(BetaDistributionTest, ResetFunctionality) {
 
     EXPECT_EQ(beta.getAlpha(), 1.0);
     EXPECT_EQ(beta.getBeta(), 1.0);
-
 }
 
 /**
@@ -277,7 +270,8 @@ TEST(BetaDistributionTest, LogProbability) {
     // Test invalid inputs return -infinity
     EXPECT_EQ(beta.getLogProbability(-0.1), -std::numeric_limits<double>::infinity());
     EXPECT_EQ(beta.getLogProbability(1.1), -std::numeric_limits<double>::infinity());
-    EXPECT_EQ(beta.getLogProbability(std::numeric_limits<double>::quiet_NaN()), -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(beta.getLogProbability(std::numeric_limits<double>::quiet_NaN()),
+              -std::numeric_limits<double>::infinity());
 
     // Test boundary cases
     BetaDistribution uniform(1.0, 1.0); // Uniform on [0,1]
@@ -287,7 +281,6 @@ TEST(BetaDistributionTest, LogProbability) {
     // For uniform distribution, log(f(x)) = -log(B(1,1)) = -log(1) = 0
     EXPECT_NEAR(logP0, 0.0, 1e-10);
     EXPECT_NEAR(logP1_boundary, 0.0, 1e-10);
-
 }
 
 /**
@@ -314,7 +307,6 @@ TEST(BetaDistributionTest, BetaProperties) {
     EXPECT_EQ(uniform.getProbability(-0.1), 0.0);
     EXPECT_EQ(uniform.getProbability(1.1), 0.0);
     EXPECT_GT(uniform.getProbability(0.5), 0.0);
-
 }
 
 /**
@@ -343,7 +335,6 @@ TEST(BetaDistributionTest, FittingValidation) {
     } catch (const std::exception &) {
         // Also acceptable if implementation rejects boundary values
     }
-
 }
 
 /**
@@ -364,7 +355,6 @@ TEST(BetaDistributionTest, StatisticalMoments) {
     // Test standard deviation
     double expectedStd = std::sqrt(expectedVar);
     EXPECT_NEAR(beta.getStandardDeviation(), expectedStd, 1e-10);
-
 }
 
 /**
@@ -429,7 +419,8 @@ TEST(BetaDistributionTest, Performance) {
     // Basic performance assertions (adjust thresholds based on typical performance)
     // These should be conservative to avoid false failures on different hardware
     EXPECT_LT(pdf_per_call, 2.0); // Should be well under 2 microseconds per PDF call
-    EXPECT_LT(log_pdf_per_call, 1.0); // Should be well under 1 microsecond per log PDF call (faster due to no exp)
+    EXPECT_LT(log_pdf_per_call,
+              1.0); // Should be well under 1 microsecond per log PDF call (faster due to no exp)
     EXPECT_LT(fit_per_point, 5.0); // Should be well under 5 microseconds per fit datapoint
 
     // Verify correctness (prevent compiler optimization removal)
@@ -469,7 +460,6 @@ TEST(BetaDistributionTest, CDFCalculations) {
     EXPECT_TRUE(cdf1 >= 0.0 && cdf1 <= 1.0);
     EXPECT_TRUE(cdf2 >= 0.0 && cdf2 <= 1.0);
     EXPECT_TRUE(cdf3 >= 0.0 && cdf3 <= 1.0);
-
 }
 
 /**
@@ -492,7 +482,6 @@ TEST(BetaDistributionTest, EqualityAndIO) {
     EXPECT_NE(output.find("Beta Distribution"), std::string::npos);
     EXPECT_NE(output.find("2.0"), std::string::npos);
     EXPECT_NE(output.find("1.5"), std::string::npos);
-
 }
 
 /**
@@ -518,7 +507,6 @@ TEST(BetaDistributionTest, NumericalStability) {
     double logProbLarge = largeAlpha.getLogProbability(0.1);
     EXPECT_TRUE(std::isfinite(logProbSmall));
     EXPECT_TRUE(std::isfinite(logProbLarge));
-
 }
 
 /**
@@ -562,7 +550,6 @@ TEST(BetaDistributionTest, Caching) {
     EXPECT_EQ(beta.getProbability(0.5), prob4);
     EXPECT_EQ(beta.getCumulativeProbability(0.5), cdf4);
     EXPECT_EQ(beta.getLogProbability(0.5), logProb4);
-
 }
 
 int main(int argc, char **argv) {

--- a/tests/distributions/test_binomial_distribution.cpp
+++ b/tests/distributions/test_binomial_distribution.cpp
@@ -1,19 +1,13 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <limits>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 #include "libhmm/distributions/binomial_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::BinomialDistribution;
 using libhmm::Observation;
@@ -21,27 +15,24 @@ using libhmm::Observation;
 /**
  * Test basic Binomial distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Binomial distribution functionality..." << std::endl;
+TEST(BinomialDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     BinomialDistribution binomial;
-    assert(binomial.getN() == 10);
-    assert(binomial.getP() == 0.5);
+    EXPECT_EQ(binomial.getN(), 10);
+    EXPECT_EQ(binomial.getP(), 0.5);
 
     // Test parameterized constructor
     BinomialDistribution binomial2(20, 0.3);
-    assert(binomial2.getN() == 20);
-    assert(binomial2.getP() == 0.3);
+    EXPECT_EQ(binomial2.getN(), 20);
+    EXPECT_EQ(binomial2.getP(), 0.3);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(BinomialDistributionTest, Probabilities) {
 
     BinomialDistribution binomial(10, 0.5);
 
@@ -50,35 +41,33 @@ void testProbabilities() {
     double prob5 = binomial.getProbability(5.0);
     double prob10 = binomial.getProbability(10.0);
 
-    assert(prob0 > 0.0);
-    assert(prob5 > 0.0);
-    assert(prob10 > 0.0);
+    EXPECT_GT(prob0, 0.0);
+    EXPECT_GT(prob5, 0.0);
+    EXPECT_GT(prob10, 0.0);
 
     // For symmetric binomial (p=0.5), P(5) should be the maximum
-    assert(prob5 >= prob0);
-    assert(prob5 >= prob10);
+    EXPECT_TRUE(prob5 >= prob0);
+    EXPECT_TRUE(prob5 >= prob10);
 
     // Test out of range values
-    assert(binomial.getProbability(-1.0) == 0.0);
-    assert(binomial.getProbability(11.0) == 0.0);
+    EXPECT_EQ(binomial.getProbability(-1.0), 0.0);
+    EXPECT_EQ(binomial.getProbability(11.0), 0.0);
 
     // Test edge cases
     BinomialDistribution binomial_p0(10, 0.0);
-    assert(binomial_p0.getProbability(0.0) == 1.0);
-    assert(binomial_p0.getProbability(1.0) == 0.0);
+    EXPECT_EQ(binomial_p0.getProbability(0.0), 1.0);
+    EXPECT_EQ(binomial_p0.getProbability(1.0), 0.0);
 
     BinomialDistribution binomial_p1(10, 1.0);
-    assert(binomial_p1.getProbability(10.0) == 1.0);
-    assert(binomial_p1.getProbability(9.0) == 0.0);
+    EXPECT_EQ(binomial_p1.getProbability(10.0), 1.0);
+    EXPECT_EQ(binomial_p1.getProbability(9.0), 0.0);
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(BinomialDistributionTest, Fitting) {
 
     BinomialDistribution binomial;
 
@@ -87,55 +76,53 @@ void testFitting() {
     binomial.fit(data);
 
     // After fitting, parameters should be positive and valid
-    assert(binomial.getN() > 0);
-    assert(binomial.getP() > 0.0 && binomial.getP() <= 1.0);
+    EXPECT_GT(binomial.getN(), 0);
+    EXPECT_GT(binomial.getP(), 0.0 && binomial.getP() <= 1.0);
 
     // Test with empty data (should reset to default)
     std::vector<Observation> emptyData;
     binomial.fit(emptyData);
-    assert(binomial.getN() == 10);
-    assert(binomial.getP() == 0.5);
+    EXPECT_EQ(binomial.getN(), 10);
+    EXPECT_EQ(binomial.getP(), 0.5);
 
     // Test with single point
     std::vector<Observation> singlePoint = {5};
     binomial.fit(singlePoint);
-    assert(binomial.getN() >= 1);
-    assert(binomial.getP() >= 0.0 && binomial.getP() <= 1.0);
+    EXPECT_TRUE(binomial.getN() >= 1);
+    EXPECT_TRUE(binomial.getP() >= 0.0 && binomial.getP() <= 1.0);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(BinomialDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
     try {
         BinomialDistribution binomial(0, 0.5); // Zero n
-        assert(false);                         // Should not reach here
+        ADD_FAILURE();                         // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         BinomialDistribution binomial(-1, 0.5); // Negative n
-        assert(false);                          // Should not reach here
+        ADD_FAILURE();                          // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         BinomialDistribution binomial(10, -0.1); // Negative p
-        assert(false);                           // Should not reach here
+        ADD_FAILURE();                           // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         BinomialDistribution binomial(10, 1.5); // p > 1
-        assert(false);                          // Should not reach here
+        ADD_FAILURE();                          // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
@@ -144,103 +131,77 @@ void testParameterValidation() {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        BinomialDistribution binomial(10, nan_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(BinomialDistribution binomial(10, nan_val), std::invalid_argument);
 
-    try {
-        BinomialDistribution binomial(10, inf_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(BinomialDistribution binomial(10, inf_val), std::invalid_argument);
 
     // Test setters validation
     BinomialDistribution binomial(10, 0.5);
 
-    try {
-        binomial.setN(0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(binomial.setN(0), std::invalid_argument);
 
-    try {
-        binomial.setP(-0.1);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(binomial.setP(-0.1), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(BinomialDistributionTest, StringRepresentation) {
 
     BinomialDistribution binomial(15, 0.3);
     std::string str = binomial.toString();
 
     // Should contain key information based on standardized format:
     // "Binomial Distribution:\n      n (trials) = 15\n      p (success probability) = 0.3\n      Mean = 4.5\n      Variance = 3.15\n"
-    assert(str.find("Binomial") != std::string::npos);
-    assert(str.find("Distribution") != std::string::npos);
-    assert(str.find("15") != std::string::npos);
-    assert(str.find("0.3") != std::string::npos);
-    assert(str.find("trials") != std::string::npos);
-    assert(str.find("success probability") != std::string::npos);
-    assert(str.find("Mean") != std::string::npos);
-    assert(str.find("Variance") != std::string::npos);
+    EXPECT_NE(str.find("Binomial"), std::string::npos);
+    EXPECT_NE(str.find("Distribution"), std::string::npos);
+    EXPECT_NE(str.find("15"), std::string::npos);
+    EXPECT_NE(str.find("0.3"), std::string::npos);
+    EXPECT_NE(str.find("trials"), std::string::npos);
+    EXPECT_NE(str.find("success probability"), std::string::npos);
+    EXPECT_NE(str.find("Mean"), std::string::npos);
+    EXPECT_NE(str.find("Variance"), std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(BinomialDistributionTest, CopyMoveSemantics) {
 
     BinomialDistribution original(12, 0.7);
 
     // Test copy constructor
     BinomialDistribution copied(original);
-    assert(copied.getN() == original.getN());
-    assert(copied.getP() == original.getP());
+    EXPECT_EQ(copied.getN(), original.getN());
+    EXPECT_EQ(copied.getP(), original.getP());
 
     // Test copy assignment
     BinomialDistribution assigned;
     assigned = original;
-    assert(assigned.getN() == original.getN());
-    assert(assigned.getP() == original.getP());
+    EXPECT_EQ(assigned.getN(), original.getN());
+    EXPECT_EQ(assigned.getP(), original.getP());
 
     // Test move constructor
     BinomialDistribution moved(std::move(original));
-    assert(moved.getN() == 12);
-    assert(moved.getP() == 0.7);
+    EXPECT_EQ(moved.getN(), 12);
+    EXPECT_EQ(moved.getP(), 0.7);
 
     // Test move assignment
     BinomialDistribution moveAssigned;
     BinomialDistribution temp(8, 0.4);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getN() == 8);
-    assert(moveAssigned.getP() == 0.4);
+    EXPECT_EQ(moveAssigned.getN(), 8);
+    EXPECT_EQ(moveAssigned.getP(), 0.4);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test invalid input handling
  */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(BinomialDistributionTest, InvalidInputHandling) {
 
     BinomialDistribution binomial(10, 0.5);
 
@@ -249,37 +210,33 @@ void testInvalidInputHandling() {
     double inf_val = std::numeric_limits<double>::infinity();
     double neg_inf_val = -std::numeric_limits<double>::infinity();
 
-    assert(binomial.getProbability(nan_val) == 0.0);
-    assert(binomial.getProbability(inf_val) == 0.0);
-    assert(binomial.getProbability(neg_inf_val) == 0.0);
+    EXPECT_EQ(binomial.getProbability(nan_val), 0.0);
+    EXPECT_EQ(binomial.getProbability(inf_val), 0.0);
+    EXPECT_EQ(binomial.getProbability(neg_inf_val), 0.0);
 
     // Out of range values should return 0
-    assert(binomial.getProbability(-1.0) == 0.0);
-    assert(binomial.getProbability(11.0) == 0.0);
+    EXPECT_EQ(binomial.getProbability(-1.0), 0.0);
+    EXPECT_EQ(binomial.getProbability(11.0), 0.0);
 
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
 }
 
 /**
  * Test reset functionality
  */
-void testResetFunctionality() {
-    std::cout << "Testing reset functionality..." << std::endl;
+TEST(BinomialDistributionTest, ResetFunctionality) {
 
     BinomialDistribution binomial(25, 0.8);
     binomial.reset();
 
-    assert(binomial.getN() == 10);
-    assert(binomial.getP() == 0.5);
+    EXPECT_EQ(binomial.getN(), 10);
+    EXPECT_EQ(binomial.getP(), 0.5);
 
-    std::cout << "✓ Reset functionality tests passed" << std::endl;
 }
 
 /**
  * Test binomial distribution properties
  */
-void testBinomialProperties() {
-    std::cout << "Testing Binomial distribution properties..." << std::endl;
+TEST(BinomialDistributionTest, BinomialProperties) {
 
     BinomialDistribution binomial(20, 0.3);
 
@@ -289,25 +246,23 @@ void testBinomialProperties() {
     double stddev = binomial.getStandardDeviation();
 
     // For Binomial(n,p): mean = n*p, variance = n*p*(1-p)
-    assert(std::abs(mean - 20 * 0.3) < 1e-10);
-    assert(std::abs(variance - 20 * 0.3 * 0.7) < 1e-10);
-    assert(std::abs(stddev - std::sqrt(variance)) < 1e-10);
+    EXPECT_NEAR(mean, 20 * 0.3, 1e-10);
+    EXPECT_NEAR(variance, 20 * 0.3 * 0.7, 1e-10);
+    EXPECT_NEAR(stddev, std::sqrt(variance), 1e-10);
 
     // Test that probabilities sum to 1 (approximately)
     double total_prob = 0.0;
     for (int k = 0; k <= 20; ++k) {
         total_prob += binomial.getProbability(k);
     }
-    assert(std::abs(total_prob - 1.0) < 1e-6); // Should sum to 1
+    EXPECT_NEAR(total_prob, 1.0, 1e-6); // Should sum to 1
 
-    std::cout << "✓ Binomial property tests passed" << std::endl;
 }
 
 /**
  * Test fitting validation
  */
-void testFittingValidation() {
-    std::cout << "Testing fitting validation..." << std::endl;
+TEST(BinomialDistributionTest, FittingValidation) {
 
     BinomialDistribution binomial;
 
@@ -316,8 +271,8 @@ void testFittingValidation() {
     try {
         binomial.fit(invalidData);
         // If it doesn't throw, the parameters should still be valid
-        assert(binomial.getN() > 0);
-        assert(binomial.getP() >= 0.0 && binomial.getP() <= 1.0);
+        EXPECT_GT(binomial.getN(), 0);
+        EXPECT_TRUE(binomial.getP() >= 0.0 && binomial.getP() <= 1.0);
     } catch (const std::exception &) {
         // It's also acceptable to throw for invalid data
     }
@@ -325,17 +280,15 @@ void testFittingValidation() {
     // Test with all zeros
     std::vector<Observation> zeroData = {0.0, 0.0, 0.0};
     binomial.fit(zeroData);
-    assert(binomial.getN() >= 1);
-    assert(binomial.getP() >= 0.0 && binomial.getP() <= 1.0);
+    EXPECT_TRUE(binomial.getN() >= 1);
+    EXPECT_TRUE(binomial.getP() >= 0.0 && binomial.getP() <= 1.0);
 
-    std::cout << "✓ Fitting validation tests passed" << std::endl;
 }
 
 /**
  * Test statistical moments
  */
-void testStatisticalMoments() {
-    std::cout << "Testing statistical moments..." << std::endl;
+TEST(BinomialDistributionTest, StatisticalMoments) {
 
     BinomialDistribution binomial(50, 0.4);
 
@@ -344,18 +297,16 @@ void testStatisticalMoments() {
     double stddev = binomial.getStandardDeviation();
 
     // Verify theoretical relationships
-    assert(std::abs(mean - 50 * 0.4) < 1e-10);
-    assert(std::abs(variance - 50 * 0.4 * 0.6) < 1e-10);
-    assert(std::abs(stddev * stddev - variance) < 1e-10);
+    EXPECT_NEAR(mean, 50 * 0.4, 1e-10);
+    EXPECT_NEAR(variance, 50 * 0.4 * 0.6, 1e-10);
+    EXPECT_NEAR(stddev * stddev, variance, 1e-10);
 
-    std::cout << "✓ Statistical moments tests passed" << std::endl;
 }
 
 /**
  * Test log probability calculations
  */
-void testLogProbability() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(BinomialDistributionTest, LogProbability) {
 
     BinomialDistribution binomial(10, 0.5);
 
@@ -364,30 +315,28 @@ void testLogProbability() {
     double prob5 = binomial.getProbability(5.0);
 
     // log(prob) should equal logProb (within numerical precision)
-    assert(std::abs(std::log(prob5) - logProb5) < 1e-10);
+    EXPECT_NEAR(std::log(prob5), logProb5, 1e-10);
 
     // Test out of range (should return -infinity)
     double logProbNeg = binomial.getLogProbability(-1.0);
     double logProbHigh = binomial.getLogProbability(11.0);
-    assert(std::isinf(logProbNeg) && logProbNeg < 0);
-    assert(std::isinf(logProbHigh) && logProbHigh < 0);
+    EXPECT_TRUE(std::isinf(logProbNeg) && logProbNeg < 0);
+    EXPECT_TRUE(std::isinf(logProbHigh) && logProbHigh < 0);
 
     // Test with invalid inputs
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
-    assert(std::isinf(binomial.getLogProbability(nan_val)) &&
+    EXPECT_TRUE(std::isinf(binomial.getLogProbability(nan_val)) &&
            binomial.getLogProbability(nan_val) < 0);
-    assert(std::isinf(binomial.getLogProbability(inf_val)) &&
+    EXPECT_TRUE(std::isinf(binomial.getLogProbability(inf_val)) &&
            binomial.getLogProbability(inf_val) < 0);
 
-    std::cout << "✓ Log probability tests passed" << std::endl;
 }
 
 /**
  * Test CDF calculations
  */
-void testCDF() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(BinomialDistributionTest, CDF) {
 
     BinomialDistribution binomial(10, 0.5);
 
@@ -396,35 +345,33 @@ void testCDF() {
     double cdf5 = binomial.getCumulativeProbability(5.0);
     double cdf10 = binomial.getCumulativeProbability(10.0);
 
-    assert(cdf0 >= 0.0 && cdf0 <= 1.0);
-    assert(cdf5 >= 0.0 && cdf5 <= 1.0);
-    assert(cdf10 >= 0.0 && cdf10 <= 1.0);
+    EXPECT_TRUE(cdf0 >= 0.0 && cdf0 <= 1.0);
+    EXPECT_TRUE(cdf5 >= 0.0 && cdf5 <= 1.0);
+    EXPECT_TRUE(cdf10 >= 0.0 && cdf10 <= 1.0);
 
     // CDF should be monotonic
-    assert(cdf0 <= cdf5);
-    assert(cdf5 <= cdf10);
+    EXPECT_LE(cdf0, cdf5);
+    EXPECT_LE(cdf5, cdf10);
 
     // CDF at maximum should be 1.0
-    assert(std::abs(cdf10 - 1.0) < 1e-10);
+    EXPECT_NEAR(cdf10, 1.0, 1e-10);
 
     // Test boundary cases
-    assert(binomial.getCumulativeProbability(-1.0) == 0.0);
-    assert(binomial.getCumulativeProbability(15.0) == 1.0);
+    EXPECT_EQ(binomial.getCumulativeProbability(-1.0), 0.0);
+    EXPECT_EQ(binomial.getCumulativeProbability(15.0), 1.0);
 
     // Test invalid inputs
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
-    assert(binomial.getCumulativeProbability(nan_val) == 0.0);
-    assert(binomial.getCumulativeProbability(inf_val) == 0.0);
+    EXPECT_EQ(binomial.getCumulativeProbability(nan_val), 0.0);
+    EXPECT_EQ(binomial.getCumulativeProbability(inf_val), 0.0);
 
-    std::cout << "✓ CDF tests passed" << std::endl;
 }
 
 /**
  * Test equality and I/O operators
  */
-void testEqualityAndIO() {
-    std::cout << "Testing equality and I/O operators..." << std::endl;
+TEST(BinomialDistributionTest, EqualityAndIO) {
 
     BinomialDistribution binomial1(10, 0.5);
     BinomialDistribution binomial2(10, 0.5);
@@ -432,21 +379,21 @@ void testEqualityAndIO() {
     BinomialDistribution binomial4(15, 0.5);
 
     // Test equality
-    assert(binomial1 == binomial2);
-    assert(!(binomial1 == binomial3));
-    assert(!(binomial1 == binomial4));
+    EXPECT_EQ(binomial1, binomial2);
+    EXPECT_FALSE(binomial1 == binomial3);
+    EXPECT_FALSE(binomial1 == binomial4);
 
     // Test inequality
-    assert(!(binomial1 != binomial2));
-    assert(binomial1 != binomial3);
-    assert(binomial1 != binomial4);
+    EXPECT_FALSE(binomial1 != binomial2);
+    EXPECT_NE(binomial1, binomial3);
+    EXPECT_NE(binomial1, binomial4);
 
     // Test stream output
     std::ostringstream oss;
     oss << binomial1;
     std::string output = oss.str();
-    assert(!output.empty());
-    assert(output.find("Binomial") != std::string::npos);
+    EXPECT_FALSE(output.empty());
+    EXPECT_NE(output.find("Binomial"), std::string::npos);
 
     // Test stream input via roundtrip
     BinomialDistribution source(20, 0.7);
@@ -455,17 +402,15 @@ void testEqualityAndIO() {
     std::istringstream iss(rss.str());
     BinomialDistribution inputBinomial;
     iss >> inputBinomial;
-    assert(inputBinomial.getN() == 20);
-    assert(std::abs(inputBinomial.getP() - 0.7) < 1e-10);
+    EXPECT_EQ(inputBinomial.getN(), 20);
+    EXPECT_NEAR(inputBinomial.getP(), 0.7, 1e-10);
 
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics
  */
-void testPerformance() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(BinomialDistributionTest, Performance) {
 
     BinomialDistribution binomial(100, 0.3);
 
@@ -514,18 +459,16 @@ void testPerformance() {
               << " μs/point (" << fitData.size() << " points)" << std::endl;
 
     // Performance requirements (should be reasonable)
-    assert(pdfTimePerCall < 10.0);   // Less than 10 μs per PDF call
-    assert(logPdfTimePerCall < 5.0); // Less than 5 μs per log PDF call
-    assert(fitTimePerPoint < 10.0);  // Less than 10 μs per data point for fitting
+    EXPECT_LT(pdfTimePerCall, 10.0);   // Less than 10 μs per PDF call
+    EXPECT_LT(logPdfTimePerCall, 5.0); // Less than 5 μs per log PDF call
+    EXPECT_LT(fitTimePerPoint, 10.0);  // Less than 10 μs per data point for fitting
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
 /**
  * Test caching mechanism
  */
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
+TEST(BinomialDistributionTest, Caching) {
 
     BinomialDistribution binomial(10, 0.3);
 
@@ -534,7 +477,7 @@ void testCaching() {
 
     // Second calculation should use cache (should be identical)
     double prob2 = binomial.getProbability(3.0);
-    assert(prob1 == prob2);
+    EXPECT_EQ(prob1, prob2);
 
     // Changing parameters should invalidate cache - use value closer to expected mean
     binomial.setP(0.7);                          // Changes mean from 3.0 to 7.0
@@ -543,49 +486,16 @@ void testCaching() {
     // The probabilities should be different (0.3 vs 0.7 is a significant change)
     // For Binomial(10, 0.3): P(X=3) ≈ 0.267, mean = 3
     // For Binomial(10, 0.7): P(X=3) ≈ 0.009, mean = 7
-    assert(std::abs(prob3 - prob1) > 1e-6); // Should be significantly different
+    EXPECT_GT(std::abs(prob3 - prob1), 1e-6); // Should be significantly different
 
     // Test that log probability also works with caching
     double logProb1 = binomial.getLogProbability(3.0);
     double logProb2 = binomial.getLogProbability(3.0);
-    assert(logProb1 == logProb2);
+    EXPECT_EQ(logProb1, logProb2);
 
-    std::cout << "✓ Caching tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running Binomial distribution tests..." << std::endl;
-    std::cout << "=====================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testInvalidInputHandling();
-        testResetFunctionality();
-        testBinomialProperties();
-        testFittingValidation();
-        testStatisticalMoments();
-
-        // Gold Standard Tests
-        testLogProbability();
-        testCDF();
-        testEqualityAndIO();
-        testPerformance();
-        testCaching();
-
-        std::cout << "=====================================" << std::endl;
-        std::cout << "✅ All Binomial distribution tests passed!" << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_binomial_distribution.cpp
+++ b/tests/distributions/test_binomial_distribution.cpp
@@ -26,7 +26,6 @@ TEST(BinomialDistributionTest, BasicFunctionality) {
     BinomialDistribution binomial2(20, 0.3);
     EXPECT_EQ(binomial2.getN(), 20);
     EXPECT_EQ(binomial2.getP(), 0.3);
-
 }
 
 /**
@@ -61,7 +60,6 @@ TEST(BinomialDistributionTest, Probabilities) {
     BinomialDistribution binomial_p1(10, 1.0);
     EXPECT_EQ(binomial_p1.getProbability(10.0), 1.0);
     EXPECT_EQ(binomial_p1.getProbability(9.0), 0.0);
-
 }
 
 /**
@@ -90,7 +88,6 @@ TEST(BinomialDistributionTest, Fitting) {
     binomial.fit(singlePoint);
     EXPECT_TRUE(binomial.getN() >= 1);
     EXPECT_TRUE(binomial.getP() >= 0.0 && binomial.getP() <= 1.0);
-
 }
 
 /**
@@ -141,7 +138,6 @@ TEST(BinomialDistributionTest, ParameterValidation) {
     EXPECT_THROW(binomial.setN(0), std::invalid_argument);
 
     EXPECT_THROW(binomial.setP(-0.1), std::invalid_argument);
-
 }
 
 /**
@@ -195,7 +191,6 @@ TEST(BinomialDistributionTest, CopyMoveSemantics) {
     moveAssigned = std::move(temp);
     EXPECT_EQ(moveAssigned.getN(), 8);
     EXPECT_EQ(moveAssigned.getP(), 0.4);
-
 }
 
 /**
@@ -217,7 +212,6 @@ TEST(BinomialDistributionTest, InvalidInputHandling) {
     // Out of range values should return 0
     EXPECT_EQ(binomial.getProbability(-1.0), 0.0);
     EXPECT_EQ(binomial.getProbability(11.0), 0.0);
-
 }
 
 /**
@@ -230,7 +224,6 @@ TEST(BinomialDistributionTest, ResetFunctionality) {
 
     EXPECT_EQ(binomial.getN(), 10);
     EXPECT_EQ(binomial.getP(), 0.5);
-
 }
 
 /**
@@ -256,7 +249,6 @@ TEST(BinomialDistributionTest, BinomialProperties) {
         total_prob += binomial.getProbability(k);
     }
     EXPECT_NEAR(total_prob, 1.0, 1e-6); // Should sum to 1
-
 }
 
 /**
@@ -282,7 +274,6 @@ TEST(BinomialDistributionTest, FittingValidation) {
     binomial.fit(zeroData);
     EXPECT_TRUE(binomial.getN() >= 1);
     EXPECT_TRUE(binomial.getP() >= 0.0 && binomial.getP() <= 1.0);
-
 }
 
 /**
@@ -300,7 +291,6 @@ TEST(BinomialDistributionTest, StatisticalMoments) {
     EXPECT_NEAR(mean, 50 * 0.4, 1e-10);
     EXPECT_NEAR(variance, 50 * 0.4 * 0.6, 1e-10);
     EXPECT_NEAR(stddev * stddev, variance, 1e-10);
-
 }
 
 /**
@@ -327,10 +317,9 @@ TEST(BinomialDistributionTest, LogProbability) {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
     EXPECT_TRUE(std::isinf(binomial.getLogProbability(nan_val)) &&
-           binomial.getLogProbability(nan_val) < 0);
+                binomial.getLogProbability(nan_val) < 0);
     EXPECT_TRUE(std::isinf(binomial.getLogProbability(inf_val)) &&
-           binomial.getLogProbability(inf_val) < 0);
-
+                binomial.getLogProbability(inf_val) < 0);
 }
 
 /**
@@ -365,7 +354,6 @@ TEST(BinomialDistributionTest, CDF) {
     double inf_val = std::numeric_limits<double>::infinity();
     EXPECT_EQ(binomial.getCumulativeProbability(nan_val), 0.0);
     EXPECT_EQ(binomial.getCumulativeProbability(inf_val), 0.0);
-
 }
 
 /**
@@ -404,7 +392,6 @@ TEST(BinomialDistributionTest, EqualityAndIO) {
     iss >> inputBinomial;
     EXPECT_EQ(inputBinomial.getN(), 20);
     EXPECT_NEAR(inputBinomial.getP(), 0.7, 1e-10);
-
 }
 
 /**
@@ -462,7 +449,6 @@ TEST(BinomialDistributionTest, Performance) {
     EXPECT_LT(pdfTimePerCall, 10.0);   // Less than 10 μs per PDF call
     EXPECT_LT(logPdfTimePerCall, 5.0); // Less than 5 μs per log PDF call
     EXPECT_LT(fitTimePerPoint, 10.0);  // Less than 10 μs per data point for fitting
-
 }
 
 /**
@@ -492,7 +478,6 @@ TEST(BinomialDistributionTest, Caching) {
     double logProb1 = binomial.getLogProbability(3.0);
     double logProb2 = binomial.getLogProbability(3.0);
     EXPECT_EQ(logProb1, logProb2);
-
 }
 
 int main(int argc, char **argv) {

--- a/tests/distributions/test_chi_squared_distribution.cpp
+++ b/tests/distributions/test_chi_squared_distribution.cpp
@@ -27,7 +27,6 @@ TEST(ChiSquaredDistributionTest, BasicFunctionality) {
     // Test parameter setter
     chi_dist.setDegreesOfFreedom(3.0);
     EXPECT_EQ(chi_dist.getDegreesOfFreedom(), 3.0);
-
 }
 
 /**
@@ -78,7 +77,6 @@ TEST(ChiSquaredDistributionTest, Probabilities) {
     // Probability at mode should be higher than nearby points
     EXPECT_TRUE(prob_at_mode >= prob_before_mode);
     EXPECT_TRUE(prob_at_mode >= prob_after_mode);
-
 }
 
 /**
@@ -105,7 +103,6 @@ TEST(ChiSquaredDistributionTest, StatisticalProperties) {
     EXPECT_EQ(chi_dist_1.getMode(), 0.0); // max(0, 1-2) = 0
     EXPECT_EQ(chi_dist_2.getMode(), 0.0); // max(0, 2-2) = 0
     EXPECT_EQ(chi_dist_5.getMode(), 3.0); // max(0, 5-2) = 3
-
 }
 
 /**
@@ -134,7 +131,6 @@ TEST(ChiSquaredDistributionTest, Fitting) {
     // Test with negative values - should throw exception
     std::vector<Observation> negative_data = {1.0, -2.0, 3.0};
     EXPECT_THROW(chi_dist.fit(negative_data), std::invalid_argument);
-
 }
 
 /**
@@ -171,7 +167,6 @@ TEST(ChiSquaredDistributionTest, ParameterValidation) {
     EXPECT_THROW(chi_dist.setDegreesOfFreedom(0.0), std::invalid_argument);
 
     EXPECT_THROW(chi_dist.setDegreesOfFreedom(-5.0), std::invalid_argument);
-
 }
 
 /**
@@ -212,7 +207,6 @@ TEST(ChiSquaredDistributionTest, CopyMoveSemantics) {
     double original_df = original.getDegreesOfFreedom();
     ChiSquaredDistribution moved(std::move(original));
     EXPECT_EQ(moved.getDegreesOfFreedom(), original_df);
-
 }
 
 /**
@@ -228,7 +222,6 @@ TEST(ChiSquaredDistributionTest, EqualityOperators) {
     EXPECT_FALSE(chi1 == chi3);
     EXPECT_NE(chi1, chi3);
     EXPECT_FALSE(chi1 != chi2);
-
 }
 
 /**
@@ -259,7 +252,6 @@ TEST(ChiSquaredDistributionTest, EdgeCases) {
     ChiSquaredDistribution chi_exactly_2(2.0); // df = 2
     double prob_2_at_zero = chi_exactly_2.getProbability(0.0);
     EXPECT_TRUE(std::isfinite(prob_2_at_zero) && prob_2_at_zero > 0.0); // Should be finite
-
 }
 
 /**
@@ -281,7 +273,6 @@ TEST(ChiSquaredDistributionTest, GammaRelationship) {
     EXPECT_EQ(chi_4.getMean(), 4.0);
     EXPECT_EQ(chi_4.getVariance(), 8.0);
     EXPECT_EQ(chi_4.getMode(), 2.0);
-
 }
 
 /**
@@ -292,8 +283,10 @@ TEST(ChiSquaredDistributionTest, LogProbabilities) {
     ChiSquaredDistribution chi_dist(3.0);
 
     // Test that log probability is -infinity for negative values
-    EXPECT_TRUE(std::isinf(chi_dist.getLogProbability(-0.1)) && chi_dist.getLogProbability(-0.1) < 0);
-    EXPECT_TRUE(std::isinf(chi_dist.getLogProbability(-1.0)) && chi_dist.getLogProbability(-1.0) < 0);
+    EXPECT_TRUE(std::isinf(chi_dist.getLogProbability(-0.1)) &&
+                chi_dist.getLogProbability(-0.1) < 0);
+    EXPECT_TRUE(std::isinf(chi_dist.getLogProbability(-1.0)) &&
+                chi_dist.getLogProbability(-1.0) < 0);
 
     // Test that log probability is finite for positive values
     EXPECT_TRUE(std::isfinite(chi_dist.getLogProbability(0.5)));
@@ -313,7 +306,6 @@ TEST(ChiSquaredDistributionTest, LogProbabilities) {
     // Test special case for df = 2 at x = 0
     ChiSquaredDistribution chi_2(2.0);
     EXPECT_TRUE(std::isfinite(chi_2.getLogProbability(0.0)));
-
 }
 
 /**
@@ -336,7 +328,8 @@ TEST(ChiSquaredDistributionTest, CDF) {
     EXPECT_GT(chi_dist.getCumulativeProbability(100.0), 0.99);
 
     // Test with NaN
-    EXPECT_TRUE(std::isnan(chi_dist.getCumulativeProbability(std::numeric_limits<double>::quiet_NaN())));
+    EXPECT_TRUE(
+        std::isnan(chi_dist.getCumulativeProbability(std::numeric_limits<double>::quiet_NaN())));
 
     // Test known values for Chi-squared(2) which is exponential-like
     ChiSquaredDistribution chi_2(2.0);
@@ -351,7 +344,6 @@ TEST(ChiSquaredDistributionTest, CDF) {
     // CDF calculations involving gamma functions need slightly more tolerance
     using namespace libhmm::constants;
     EXPECT_NEAR(cdf_at_2, expected_cdf, precision::LIMIT_TOLERANCE);
-
 }
 
 /**
@@ -384,7 +376,6 @@ TEST(ChiSquaredDistributionTest, EqualityAndIO) {
     if (iss.good()) {
         EXPECT_NEAR(inputDist.getDegreesOfFreedom(), 6.75, 1e-10);
     }
-
 }
 
 /**
@@ -417,7 +408,6 @@ TEST(ChiSquaredDistributionTest, Caching) {
     chi_dist.reset();
     double prob4 = chi_dist.getProbability(2.0);
     EXPECT_NE(prob4, prob3); // Should be different after reset
-
 }
 
 /**
@@ -477,7 +467,6 @@ TEST(ChiSquaredDistributionTest, Performance) {
     EXPECT_LT(pdfTimePerCall, 5.0);    // Less than 5 μs per PDF call
     EXPECT_LT(logPdfTimePerCall, 3.0); // Less than 3 μs per log PDF call
     EXPECT_LT(fitTimePerPoint, 10.0);  // Less than 10 μs per data point for fitting
-
 }
 
 /**

--- a/tests/distributions/test_chi_squared_distribution.cpp
+++ b/tests/distributions/test_chi_squared_distribution.cpp
@@ -1,18 +1,12 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <limits>
 #include <chrono>
 #include <sstream>
 #include "libhmm/distributions/chi_squared_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::ChiSquaredDistribution;
 using libhmm::Observation;
@@ -20,36 +14,33 @@ using libhmm::Observation;
 /**
  * Test basic Chi-squared distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Chi-squared distribution functionality..." << std::endl;
+TEST(ChiSquaredDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     ChiSquaredDistribution chi_dist;
-    assert(chi_dist.getDegreesOfFreedom() == 1.0);
+    EXPECT_EQ(chi_dist.getDegreesOfFreedom(), 1.0);
 
     // Test parameterized constructor
     ChiSquaredDistribution chi_dist2(5.0);
-    assert(chi_dist2.getDegreesOfFreedom() == 5.0);
+    EXPECT_EQ(chi_dist2.getDegreesOfFreedom(), 5.0);
 
     // Test parameter setter
     chi_dist.setDegreesOfFreedom(3.0);
-    assert(chi_dist.getDegreesOfFreedom() == 3.0);
+    EXPECT_EQ(chi_dist.getDegreesOfFreedom(), 3.0);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(ChiSquaredDistributionTest, Probabilities) {
 
     ChiSquaredDistribution chi_dist(2.0); // df = 2
 
     // Test that probability is zero for negative values
-    assert(chi_dist.getProbability(-0.1) == 0.0);
-    assert(chi_dist.getProbability(-1.0) == 0.0);
-    assert(chi_dist.getProbability(-10.0) == 0.0);
+    EXPECT_EQ(chi_dist.getProbability(-0.1), 0.0);
+    EXPECT_EQ(chi_dist.getProbability(-1.0), 0.0);
+    EXPECT_EQ(chi_dist.getProbability(-10.0), 0.0);
 
     // Test that probability is positive for non-negative values
     double prob_at_zero = chi_dist.getProbability(0.0);
@@ -57,16 +48,16 @@ void testProbabilities() {
     double prob_at_two = chi_dist.getProbability(2.0);
     double prob_at_five = chi_dist.getProbability(5.0);
 
-    assert(prob_at_zero > 0.0);
-    assert(prob_at_one > 0.0);
-    assert(prob_at_two > 0.0);
-    assert(prob_at_five > 0.0);
+    EXPECT_GT(prob_at_zero, 0.0);
+    EXPECT_GT(prob_at_one, 0.0);
+    EXPECT_GT(prob_at_two, 0.0);
+    EXPECT_GT(prob_at_five, 0.0);
 
     // For Chi-squared(2), the distribution is exponential-like
     // Probability should decrease as x increases
-    assert(prob_at_zero > prob_at_one);
-    assert(prob_at_one > prob_at_two);
-    assert(prob_at_two > prob_at_five);
+    EXPECT_GT(prob_at_zero, prob_at_one);
+    EXPECT_GT(prob_at_one, prob_at_two);
+    EXPECT_GT(prob_at_two, prob_at_five);
 
     // Test with df = 1
     ChiSquaredDistribution chi_dist_1(1.0);
@@ -74,8 +65,8 @@ void testProbabilities() {
     double prob_1_at_small = chi_dist_1.getProbability(0.1);
 
     // For df=1, density at x=0 should be infinite
-    assert(std::isinf(prob_1_at_zero));
-    assert(prob_1_at_small > 0.0 && std::isfinite(prob_1_at_small));
+    EXPECT_TRUE(std::isinf(prob_1_at_zero));
+    EXPECT_TRUE(prob_1_at_small > 0.0 && std::isfinite(prob_1_at_small));
 
     // Test with df > 2 (should have mode at df-2)
     ChiSquaredDistribution chi_dist_5(5.0);
@@ -85,46 +76,42 @@ void testProbabilities() {
     double prob_after_mode = chi_dist_5.getProbability(mode + 1.0);
 
     // Probability at mode should be higher than nearby points
-    assert(prob_at_mode >= prob_before_mode);
-    assert(prob_at_mode >= prob_after_mode);
+    EXPECT_TRUE(prob_at_mode >= prob_before_mode);
+    EXPECT_TRUE(prob_at_mode >= prob_after_mode);
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test statistical properties
  */
-void testStatisticalProperties() {
-    std::cout << "Testing statistical properties..." << std::endl;
+TEST(ChiSquaredDistributionTest, StatisticalProperties) {
 
     // Test mean and variance formulas
     ChiSquaredDistribution chi_dist_3(3.0);
-    assert(chi_dist_3.getMean() == 3.0);     // Mean = k
-    assert(chi_dist_3.getVariance() == 6.0); // Variance = 2k
-    assert(std::abs(chi_dist_3.getStandardDeviation() - std::sqrt(6.0)) < 1e-10);
+    EXPECT_EQ(chi_dist_3.getMean(), 3.0);     // Mean = k
+    EXPECT_EQ(chi_dist_3.getVariance(), 6.0); // Variance = 2k
+    EXPECT_NEAR(chi_dist_3.getStandardDeviation(), std::sqrt(6.0), 1e-10);
 
     ChiSquaredDistribution chi_dist_10(10.0);
-    assert(chi_dist_10.getMean() == 10.0);
-    assert(chi_dist_10.getVariance() == 20.0);
-    assert(std::abs(chi_dist_10.getStandardDeviation() - std::sqrt(20.0)) < 1e-10);
+    EXPECT_EQ(chi_dist_10.getMean(), 10.0);
+    EXPECT_EQ(chi_dist_10.getVariance(), 20.0);
+    EXPECT_NEAR(chi_dist_10.getStandardDeviation(), std::sqrt(20.0), 1e-10);
 
     // Test mode calculation
     ChiSquaredDistribution chi_dist_1(1.0);
     ChiSquaredDistribution chi_dist_2(2.0);
     ChiSquaredDistribution chi_dist_5(5.0);
 
-    assert(chi_dist_1.getMode() == 0.0); // max(0, 1-2) = 0
-    assert(chi_dist_2.getMode() == 0.0); // max(0, 2-2) = 0
-    assert(chi_dist_5.getMode() == 3.0); // max(0, 5-2) = 3
+    EXPECT_EQ(chi_dist_1.getMode(), 0.0); // max(0, 1-2) = 0
+    EXPECT_EQ(chi_dist_2.getMode(), 0.0); // max(0, 2-2) = 0
+    EXPECT_EQ(chi_dist_5.getMode(), 3.0); // max(0, 5-2) = 3
 
-    std::cout << "✓ Statistical properties tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(ChiSquaredDistributionTest, Fitting) {
 
     ChiSquaredDistribution chi_dist;
 
@@ -133,51 +120,39 @@ void testFitting() {
     chi_dist.fit(data);
 
     // For Chi-squared, MLE estimate of k is the sample mean
-    assert(std::abs(chi_dist.getDegreesOfFreedom() - 3.0) < 1e-10);
+    EXPECT_NEAR(chi_dist.getDegreesOfFreedom(), 3.0, 1e-10);
 
     // Test with another dataset
     std::vector<Observation> data2 = {0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5}; // Mean = 4.0
     chi_dist.fit(data2);
-    assert(std::abs(chi_dist.getDegreesOfFreedom() - 4.0) < 1e-10);
+    EXPECT_NEAR(chi_dist.getDegreesOfFreedom(), 4.0, 1e-10);
 
     // Test with empty data - should throw exception
     std::vector<Observation> empty_data;
-    try {
-        chi_dist.fit(empty_data);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(chi_dist.fit(empty_data), std::invalid_argument);
 
     // Test with negative values - should throw exception
     std::vector<Observation> negative_data = {1.0, -2.0, 3.0};
-    try {
-        chi_dist.fit(negative_data);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(chi_dist.fit(negative_data), std::invalid_argument);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(ChiSquaredDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
     try {
         ChiSquaredDistribution chi_dist(0.0); // Zero degrees of freedom
-        assert(false);                        // Should not reach here
+        ADD_FAILURE();                        // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         ChiSquaredDistribution chi_dist(-1.0); // Negative degrees of freedom
-        assert(false);                         // Should not reach here
+        ADD_FAILURE();                         // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
@@ -186,141 +161,111 @@ void testParameterValidation() {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        ChiSquaredDistribution chi_dist(nan_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(ChiSquaredDistribution chi_dist(nan_val), std::invalid_argument);
 
-    try {
-        ChiSquaredDistribution chi_dist(inf_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(ChiSquaredDistribution chi_dist(inf_val), std::invalid_argument);
 
     // Test setter validation
     ChiSquaredDistribution chi_dist(1.0);
 
-    try {
-        chi_dist.setDegreesOfFreedom(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(chi_dist.setDegreesOfFreedom(0.0), std::invalid_argument);
 
-    try {
-        chi_dist.setDegreesOfFreedom(-5.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(chi_dist.setDegreesOfFreedom(-5.0), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation and serialization
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(ChiSquaredDistributionTest, StringRepresentation) {
 
     ChiSquaredDistribution chi_dist(3.5);
     std::string str = chi_dist.toString();
 
     // Should contain key information
-    assert(str.find("ChiSquared Distribution") != std::string::npos);
-    assert(str.find("3.5") != std::string::npos);
-    assert(str.find("k") != std::string::npos);
+    EXPECT_NE(str.find("ChiSquared Distribution"), std::string::npos);
+    EXPECT_NE(str.find("3.5"), std::string::npos);
+    EXPECT_NE(str.find("k"), std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(ChiSquaredDistributionTest, CopyMoveSemantics) {
 
     ChiSquaredDistribution original(4.2);
 
     // Test copy constructor
     ChiSquaredDistribution copied(original);
-    assert(copied.getDegreesOfFreedom() == original.getDegreesOfFreedom());
-    assert(copied.getProbability(1.0) == original.getProbability(1.0));
+    EXPECT_EQ(copied.getDegreesOfFreedom(), original.getDegreesOfFreedom());
+    EXPECT_EQ(copied.getProbability(1.0), original.getProbability(1.0));
 
     // Test copy assignment
     ChiSquaredDistribution assigned(1.0);
     assigned = original;
-    assert(assigned.getDegreesOfFreedom() == original.getDegreesOfFreedom());
-    assert(assigned.getProbability(1.0) == original.getProbability(1.0));
+    EXPECT_EQ(assigned.getDegreesOfFreedom(), original.getDegreesOfFreedom());
+    EXPECT_EQ(assigned.getProbability(1.0), original.getProbability(1.0));
 
     // Test move constructor
     double original_df = original.getDegreesOfFreedom();
     ChiSquaredDistribution moved(std::move(original));
-    assert(moved.getDegreesOfFreedom() == original_df);
+    EXPECT_EQ(moved.getDegreesOfFreedom(), original_df);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test equality operators
  */
-void testEqualityOperators() {
-    std::cout << "Testing equality operators..." << std::endl;
+TEST(ChiSquaredDistributionTest, EqualityOperators) {
 
     ChiSquaredDistribution chi1(3.0);
     ChiSquaredDistribution chi2(3.0);
     ChiSquaredDistribution chi3(4.0);
 
-    assert(chi1 == chi2);
-    assert(!(chi1 == chi3));
-    assert(chi1 != chi3);
-    assert(!(chi1 != chi2));
+    EXPECT_EQ(chi1, chi2);
+    EXPECT_FALSE(chi1 == chi3);
+    EXPECT_NE(chi1, chi3);
+    EXPECT_FALSE(chi1 != chi2);
 
-    std::cout << "✓ Equality operator tests passed" << std::endl;
 }
 
 /**
  * Test edge cases and numerical stability
  */
-void testEdgeCases() {
-    std::cout << "Testing edge cases..." << std::endl;
+TEST(ChiSquaredDistributionTest, EdgeCases) {
 
     // Test very small degrees of freedom
     ChiSquaredDistribution chi_small(1e-5);
     double prob_small = chi_small.getProbability(0.01);
-    assert(std::isfinite(prob_small) && prob_small > 0.0);
+    EXPECT_TRUE(std::isfinite(prob_small) && prob_small > 0.0);
 
     // Test very large degrees of freedom
     ChiSquaredDistribution chi_large(1e5);
     double prob_large = chi_large.getProbability(1e5); // Around the mean
-    assert(std::isfinite(prob_large) && prob_large > 0.0);
+    EXPECT_TRUE(std::isfinite(prob_large) && prob_large > 0.0);
 
     // Test reset functionality
     ChiSquaredDistribution chi_test(10.0);
     chi_test.reset();
-    assert(chi_test.getDegreesOfFreedom() == 1.0);
+    EXPECT_EQ(chi_test.getDegreesOfFreedom(), 1.0);
 
     // Test boundary behavior for different df values
     ChiSquaredDistribution chi_half(0.5); // df < 1
     double prob_half_at_zero = chi_half.getProbability(0.0);
-    assert(std::isinf(prob_half_at_zero)); // Should be infinite
+    EXPECT_TRUE(std::isinf(prob_half_at_zero)); // Should be infinite
 
     ChiSquaredDistribution chi_exactly_2(2.0); // df = 2
     double prob_2_at_zero = chi_exactly_2.getProbability(0.0);
-    assert(std::isfinite(prob_2_at_zero) && prob_2_at_zero > 0.0); // Should be finite
+    EXPECT_TRUE(std::isfinite(prob_2_at_zero) && prob_2_at_zero > 0.0); // Should be finite
 
-    std::cout << "✓ Edge cases tests passed" << std::endl;
 }
 
 /**
  * Test relationship to Gamma distribution
  */
-void testGammaRelationship() {
-    std::cout << "Testing relationship to Gamma distribution..." << std::endl;
+TEST(ChiSquaredDistributionTest, GammaRelationship) {
 
     // Chi-squared(k) is equivalent to Gamma(k/2, 2)
     // We can't directly test this without the Gamma distribution,
@@ -333,69 +278,65 @@ void testGammaRelationship() {
     // Variance = 2k = 8
     // Mode = k - 2 = 2 (for k >= 2)
 
-    assert(chi_4.getMean() == 4.0);
-    assert(chi_4.getVariance() == 8.0);
-    assert(chi_4.getMode() == 2.0);
+    EXPECT_EQ(chi_4.getMean(), 4.0);
+    EXPECT_EQ(chi_4.getVariance(), 8.0);
+    EXPECT_EQ(chi_4.getMode(), 2.0);
 
-    std::cout << "✓ Gamma relationship tests passed" << std::endl;
 }
 
 /**
  * Test log probability calculations
  */
-void testLogProbabilities() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(ChiSquaredDistributionTest, LogProbabilities) {
 
     ChiSquaredDistribution chi_dist(3.0);
 
     // Test that log probability is -infinity for negative values
-    assert(std::isinf(chi_dist.getLogProbability(-0.1)) && chi_dist.getLogProbability(-0.1) < 0);
-    assert(std::isinf(chi_dist.getLogProbability(-1.0)) && chi_dist.getLogProbability(-1.0) < 0);
+    EXPECT_TRUE(std::isinf(chi_dist.getLogProbability(-0.1)) && chi_dist.getLogProbability(-0.1) < 0);
+    EXPECT_TRUE(std::isinf(chi_dist.getLogProbability(-1.0)) && chi_dist.getLogProbability(-1.0) < 0);
 
     // Test that log probability is finite for positive values
-    assert(std::isfinite(chi_dist.getLogProbability(0.5)));
-    assert(std::isfinite(chi_dist.getLogProbability(1.0)));
-    assert(std::isfinite(chi_dist.getLogProbability(2.0)));
+    EXPECT_TRUE(std::isfinite(chi_dist.getLogProbability(0.5)));
+    EXPECT_TRUE(std::isfinite(chi_dist.getLogProbability(1.0)));
+    EXPECT_TRUE(std::isfinite(chi_dist.getLogProbability(2.0)));
 
     // Test consistency between log and regular probability
     double x = 1.5;
     double prob = chi_dist.getProbability(x);
     double log_prob = chi_dist.getLogProbability(x);
-    assert(std::abs(std::log(prob) - log_prob) < 1e-10);
+    EXPECT_NEAR(std::log(prob), log_prob, 1e-10);
 
     // Test special case for df < 2 at x = 0
     ChiSquaredDistribution chi_1(1.0);
-    assert(std::isinf(chi_1.getLogProbability(0.0)) && chi_1.getLogProbability(0.0) > 0);
+    EXPECT_TRUE(std::isinf(chi_1.getLogProbability(0.0)) && chi_1.getLogProbability(0.0) > 0);
 
     // Test special case for df = 2 at x = 0
     ChiSquaredDistribution chi_2(2.0);
-    assert(std::isfinite(chi_2.getLogProbability(0.0)));
+    EXPECT_TRUE(std::isfinite(chi_2.getLogProbability(0.0)));
 
-    std::cout << "✓ Log probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test CDF calculations
  */
-void testCDF() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(ChiSquaredDistributionTest, CDF) {
 
     ChiSquaredDistribution chi_dist(4.0);
 
     // Test CDF values at boundaries
-    assert(chi_dist.getCumulativeProbability(-1.0) == 0.0); // Below support
-    assert(chi_dist.getCumulativeProbability(0.0) == 0.0);  // At lower bound
+    EXPECT_EQ(chi_dist.getCumulativeProbability(-1.0), 0.0); // Below support
+    EXPECT_EQ(chi_dist.getCumulativeProbability(0.0), 0.0);  // At lower bound
 
     // Test CDF is monotonically increasing
-    assert(chi_dist.getCumulativeProbability(1.0) < chi_dist.getCumulativeProbability(2.0));
-    assert(chi_dist.getCumulativeProbability(2.0) < chi_dist.getCumulativeProbability(4.0));
-    assert(chi_dist.getCumulativeProbability(4.0) < chi_dist.getCumulativeProbability(8.0));
+    EXPECT_LT(chi_dist.getCumulativeProbability(1.0), chi_dist.getCumulativeProbability(2.0));
+    EXPECT_LT(chi_dist.getCumulativeProbability(2.0), chi_dist.getCumulativeProbability(4.0));
+    EXPECT_LT(chi_dist.getCumulativeProbability(4.0), chi_dist.getCumulativeProbability(8.0));
 
     // Test CDF approaches 1 for large values
-    assert(chi_dist.getCumulativeProbability(100.0) > 0.99);
+    EXPECT_GT(chi_dist.getCumulativeProbability(100.0), 0.99);
 
     // Test with NaN
-    assert(std::isnan(chi_dist.getCumulativeProbability(std::numeric_limits<double>::quiet_NaN())));
+    EXPECT_TRUE(std::isnan(chi_dist.getCumulativeProbability(std::numeric_limits<double>::quiet_NaN())));
 
     // Test known values for Chi-squared(2) which is exponential-like
     ChiSquaredDistribution chi_2(2.0);
@@ -409,31 +350,29 @@ void testCDF() {
     // Use precision constant for numerical tolerance
     // CDF calculations involving gamma functions need slightly more tolerance
     using namespace libhmm::constants;
-    assert(std::abs(cdf_at_2 - expected_cdf) < precision::LIMIT_TOLERANCE);
+    EXPECT_NEAR(cdf_at_2, expected_cdf, precision::LIMIT_TOLERANCE);
 
-    std::cout << "✓ CDF calculation tests passed" << std::endl;
 }
 
 /**
  * Test equality operators and I/O
  */
-void testEqualityAndIO() {
-    std::cout << "Testing equality operators and I/O..." << std::endl;
+TEST(ChiSquaredDistributionTest, EqualityAndIO) {
 
     ChiSquaredDistribution chi1(3.5);
     ChiSquaredDistribution chi2(3.5);
     ChiSquaredDistribution chi3(4.0);
 
     // Test equality operator
-    assert(chi1 == chi2);
-    assert(!(chi1 == chi3));
+    EXPECT_EQ(chi1, chi2);
+    EXPECT_FALSE(chi1 == chi3);
 
     // Test stream output
     std::ostringstream oss;
     oss << chi1;
     std::string output = oss.str();
-    assert(output.find("ChiSquared Distribution") != std::string::npos);
-    assert(output.find("3.5") != std::string::npos);
+    EXPECT_NE(output.find("ChiSquared Distribution"), std::string::npos);
+    EXPECT_NE(output.find("3.5"), std::string::npos);
 
     std::cout << "Stream output: " << output << std::endl;
 
@@ -443,17 +382,15 @@ void testEqualityAndIO() {
     iss >> inputDist;
 
     if (iss.good()) {
-        assert(std::abs(inputDist.getDegreesOfFreedom() - 6.75) < 1e-10);
+        EXPECT_NEAR(inputDist.getDegreesOfFreedom(), 6.75, 1e-10);
     }
 
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
 }
 
 /**
  * Test caching mechanism
  */
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
+TEST(ChiSquaredDistributionTest, Caching) {
 
     ChiSquaredDistribution chi_dist(3.0);
 
@@ -466,29 +403,27 @@ void testCaching() {
     double logProb2 = chi_dist.getLogProbability(2.5);
 
     // Both should be valid
-    assert(std::isfinite(prob1) && prob1 > 0.0);
-    assert(std::isfinite(prob2) && prob2 > 0.0);
-    assert(std::isfinite(logProb1));
-    assert(std::isfinite(logProb2));
+    EXPECT_TRUE(std::isfinite(prob1) && prob1 > 0.0);
+    EXPECT_TRUE(std::isfinite(prob2) && prob2 > 0.0);
+    EXPECT_TRUE(std::isfinite(logProb1));
+    EXPECT_TRUE(std::isfinite(logProb2));
 
     // Changing parameters should invalidate cache
     chi_dist.setDegreesOfFreedom(5.0);
     double prob3 = chi_dist.getProbability(2.0);
-    assert(prob3 != prob1); // Should be different now
+    EXPECT_NE(prob3, prob1); // Should be different now
 
     // Reset should also invalidate cache
     chi_dist.reset();
     double prob4 = chi_dist.getProbability(2.0);
-    assert(prob4 != prob3); // Should be different after reset
+    EXPECT_NE(prob4, prob3); // Should be different after reset
 
-    std::cout << "✓ Caching mechanism tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics
  */
-void testPerformance() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(ChiSquaredDistributionTest, Performance) {
 
     ChiSquaredDistribution chi_dist(4.0);
 
@@ -539,46 +474,16 @@ void testPerformance() {
               << " μs/point (" << fitData.size() << " points)" << std::endl;
 
     // Performance requirements (should be reasonable)
-    assert(pdfTimePerCall < 5.0);    // Less than 5 μs per PDF call
-    assert(logPdfTimePerCall < 3.0); // Less than 3 μs per log PDF call
-    assert(fitTimePerPoint < 10.0);  // Less than 10 μs per data point for fitting
+    EXPECT_LT(pdfTimePerCall, 5.0);    // Less than 5 μs per PDF call
+    EXPECT_LT(logPdfTimePerCall, 3.0); // Less than 3 μs per log PDF call
+    EXPECT_LT(fitTimePerPoint, 10.0);  // Less than 10 μs per data point for fitting
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
 /**
  * Main test function
  */
-int main() {
-    std::cout << "=== Chi-squared Distribution Unit Tests ===" << std::endl;
-    std::cout << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testStatisticalProperties();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testEqualityOperators();
-        testEdgeCases();
-        testGammaRelationship();
-        testLogProbabilities();
-        testCDF();
-        testEqualityAndIO();
-        testCaching();
-        testPerformance();
-
-        std::cout << std::endl;
-        std::cout << "🎉 All Chi-squared distribution tests passed!" << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_discrete_distribution.cpp
+++ b/tests/distributions/test_discrete_distribution.cpp
@@ -1,19 +1,13 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <limits>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 #include "libhmm/distributions/discrete_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::DiscreteDistribution;
 using libhmm::Observation;
@@ -21,33 +15,30 @@ using libhmm::Observation;
 /**
  * Test basic Discrete distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Discrete distribution functionality..." << std::endl;
+TEST(DiscreteDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     DiscreteDistribution discrete;
-    assert(discrete.getNumSymbols() == 10); // Default is 10 symbols
+    EXPECT_EQ(discrete.getNumSymbols(), 10); // Default is 10 symbols
 
     // Test parameterized constructor
     DiscreteDistribution discrete2(5);
-    assert(discrete2.getNumSymbols() == 5);
+    EXPECT_EQ(discrete2.getNumSymbols(), 5);
 
     // Test invalid constructor parameter
     try {
         DiscreteDistribution discrete3(0); // Zero symbols
-        assert(false);                     // Should not reach here
+        ADD_FAILURE();                     // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(DiscreteDistributionTest, Probabilities) {
 
     DiscreteDistribution discrete(5); // 5 symbols: 0,1,2,3,4
 
@@ -55,27 +46,25 @@ void testProbabilities() {
     double expectedProb = 1.0 / 5.0; // 0.2
     for (int i = 0; i < 5; i++) {
         double prob = discrete.getProbability(i);
-        assert(std::abs(prob - expectedProb) < 1e-10);
+        EXPECT_NEAR(prob, expectedProb, 1e-10);
     }
 
     // Test invalid symbol indices
-    assert(discrete.getProbability(-1) == 0.0);
-    assert(discrete.getProbability(5) == 0.0);
-    assert(discrete.getProbability(10) == 0.0);
+    EXPECT_EQ(discrete.getProbability(-1), 0.0);
+    EXPECT_EQ(discrete.getProbability(5), 0.0);
+    EXPECT_EQ(discrete.getProbability(10), 0.0);
 
     // Test non-integer values (should treat as floor)
     double prob2_5 = discrete.getProbability(2.5);
     double prob2 = discrete.getProbability(2);
-    assert(prob2_5 == prob2); // Should be same as symbol 2
+    EXPECT_EQ(prob2_5, prob2); // Should be same as symbol 2
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(DiscreteDistributionTest, Fitting) {
 
     DiscreteDistribution discrete(5);
 
@@ -84,37 +73,35 @@ void testFitting() {
     discrete.fit(data);
 
     // Check fitted probabilities
-    assert(std::abs(discrete.getProbability(0) - 0.2) < 1e-10); // 1/5
-    assert(std::abs(discrete.getProbability(1) - 0.4) < 1e-10); // 2/5
-    assert(std::abs(discrete.getProbability(2) - 0.2) < 1e-10); // 1/5
-    assert(std::abs(discrete.getProbability(3) - 0.2) < 1e-10); // 1/5
-    assert(std::abs(discrete.getProbability(4) - 0.0) < 1e-10); // 0/5
+    EXPECT_NEAR(discrete.getProbability(0), 0.2, 1e-10); // 1/5
+    EXPECT_NEAR(discrete.getProbability(1), 0.4, 1e-10); // 2/5
+    EXPECT_NEAR(discrete.getProbability(2), 0.2, 1e-10); // 1/5
+    EXPECT_NEAR(discrete.getProbability(3), 0.2, 1e-10); // 1/5
+    EXPECT_NEAR(discrete.getProbability(4), 0.0, 1e-10); // 0/5
 
     // Test with empty data (should reset to uniform)
     std::vector<Observation> emptyData;
     discrete.fit(emptyData);
     double expectedUniform = 1.0 / 5.0;
     for (int i = 0; i < 5; i++) {
-        assert(std::abs(discrete.getProbability(i) - expectedUniform) < 1e-10);
+        EXPECT_NEAR(discrete.getProbability(i), expectedUniform, 1e-10);
     }
 
     // Test with single point
     std::vector<Observation> singlePoint = {2};
     discrete.fit(singlePoint);
-    assert(discrete.getProbability(0) == 0.0);
-    assert(discrete.getProbability(1) == 0.0);
-    assert(discrete.getProbability(2) == 1.0); // All probability on symbol 2
-    assert(discrete.getProbability(3) == 0.0);
-    assert(discrete.getProbability(4) == 0.0);
+    EXPECT_EQ(discrete.getProbability(0), 0.0);
+    EXPECT_EQ(discrete.getProbability(1), 0.0);
+    EXPECT_EQ(discrete.getProbability(2), 1.0); // All probability on symbol 2
+    EXPECT_EQ(discrete.getProbability(3), 0.0);
+    EXPECT_EQ(discrete.getProbability(4), 0.0);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test setProbability functionality
  */
-void testSetProbability() {
-    std::cout << "Testing setProbability functionality..." << std::endl;
+TEST(DiscreteDistributionTest, SetProbability) {
 
     DiscreteDistribution discrete(3);
 
@@ -123,14 +110,14 @@ void testSetProbability() {
     discrete.setProbability(1, 0.3);
     discrete.setProbability(2, 0.2);
 
-    assert(std::abs(discrete.getProbability(0) - 0.5) < 1e-10);
-    assert(std::abs(discrete.getProbability(1) - 0.3) < 1e-10);
-    assert(std::abs(discrete.getProbability(2) - 0.2) < 1e-10);
+    EXPECT_NEAR(discrete.getProbability(0), 0.5, 1e-10);
+    EXPECT_NEAR(discrete.getProbability(1), 0.3, 1e-10);
+    EXPECT_NEAR(discrete.getProbability(2), 0.2, 1e-10);
 
     // Test invalid probability values
     try {
         discrete.setProbability(0, -0.1); // Negative probability
-        assert(false);                    // Should not reach here
+        ADD_FAILURE();                    // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior (if implemented)
     } catch (...) {
@@ -139,40 +126,36 @@ void testSetProbability() {
 
     try {
         discrete.setProbability(0, 1.1); // Probability > 1
-        assert(false);                   // Should not reach here
+        ADD_FAILURE();                   // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior (if implemented)
     } catch (...) {
         // Some implementations might not validate, which is also acceptable
     }
 
-    std::cout << "✓ setProbability tests passed" << std::endl;
 }
 
 /**
  * Test string representation
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(DiscreteDistributionTest, StringRepresentation) {
 
     DiscreteDistribution discrete(5);
     std::string str = discrete.toString();
 
     // Should contain key information (modern format focuses on content, not specific formatting)
-    assert(str.find("Discrete") != std::string::npos);
-    assert(str.find("Distribution") != std::string::npos);
-    assert(str.find("0.2") != std::string::npos); // Should contain the probabilities
+    EXPECT_NE(str.find("Discrete"), std::string::npos);
+    EXPECT_NE(str.find("Distribution"), std::string::npos);
+    EXPECT_NE(str.find("0.2"), std::string::npos); // Should contain the probabilities
     // Modern format is more readable - focus on content rather than specific separators
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(DiscreteDistributionTest, CopyMoveSemantics) {
 
     DiscreteDistribution original(3);
     original.setProbability(0, 0.6);
@@ -181,25 +164,25 @@ void testCopyMoveSemantics() {
 
     // Test copy constructor
     DiscreteDistribution copied(original);
-    assert(copied.getNumSymbols() == original.getNumSymbols());
-    assert(std::abs(copied.getProbability(0) - 0.6) < 1e-10);
-    assert(std::abs(copied.getProbability(1) - 0.3) < 1e-10);
-    assert(std::abs(copied.getProbability(2) - 0.1) < 1e-10);
+    EXPECT_EQ(copied.getNumSymbols(), original.getNumSymbols());
+    EXPECT_NEAR(copied.getProbability(0), 0.6, 1e-10);
+    EXPECT_NEAR(copied.getProbability(1), 0.3, 1e-10);
+    EXPECT_NEAR(copied.getProbability(2), 0.1, 1e-10);
 
     // Test copy assignment
     DiscreteDistribution assigned(5); // Different size initially
     assigned = original;
-    assert(assigned.getNumSymbols() == original.getNumSymbols());
-    assert(std::abs(assigned.getProbability(0) - 0.6) < 1e-10);
-    assert(std::abs(assigned.getProbability(1) - 0.3) < 1e-10);
-    assert(std::abs(assigned.getProbability(2) - 0.1) < 1e-10);
+    EXPECT_EQ(assigned.getNumSymbols(), original.getNumSymbols());
+    EXPECT_NEAR(assigned.getProbability(0), 0.6, 1e-10);
+    EXPECT_NEAR(assigned.getProbability(1), 0.3, 1e-10);
+    EXPECT_NEAR(assigned.getProbability(2), 0.1, 1e-10);
 
     // Test move constructor
     DiscreteDistribution moved(std::move(original));
-    assert(moved.getNumSymbols() == 3);
-    assert(std::abs(moved.getProbability(0) - 0.6) < 1e-10);
-    assert(std::abs(moved.getProbability(1) - 0.3) < 1e-10);
-    assert(std::abs(moved.getProbability(2) - 0.1) < 1e-10);
+    EXPECT_EQ(moved.getNumSymbols(), 3);
+    EXPECT_NEAR(moved.getProbability(0), 0.6, 1e-10);
+    EXPECT_NEAR(moved.getProbability(1), 0.3, 1e-10);
+    EXPECT_NEAR(moved.getProbability(2), 0.1, 1e-10);
 
     // Test move assignment
     DiscreteDistribution moveAssigned(2);
@@ -207,18 +190,16 @@ void testCopyMoveSemantics() {
     temp.setProbability(1, 0.8);
     temp.setProbability(3, 0.2);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getNumSymbols() == 4);
-    assert(std::abs(moveAssigned.getProbability(1) - 0.8) < 1e-10);
-    assert(std::abs(moveAssigned.getProbability(3) - 0.2) < 1e-10);
+    EXPECT_EQ(moveAssigned.getNumSymbols(), 4);
+    EXPECT_NEAR(moveAssigned.getProbability(1), 0.8, 1e-10);
+    EXPECT_NEAR(moveAssigned.getProbability(3), 0.2, 1e-10);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test invalid input handling
  */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(DiscreteDistributionTest, InvalidInputHandling) {
 
     DiscreteDistribution discrete(5);
 
@@ -227,23 +208,21 @@ void testInvalidInputHandling() {
     double inf_val = std::numeric_limits<double>::infinity();
     double neg_inf_val = -std::numeric_limits<double>::infinity();
 
-    assert(discrete.getProbability(nan_val) == 0.0);
-    assert(discrete.getProbability(inf_val) == 0.0);
-    assert(discrete.getProbability(neg_inf_val) == 0.0);
+    EXPECT_EQ(discrete.getProbability(nan_val), 0.0);
+    EXPECT_EQ(discrete.getProbability(inf_val), 0.0);
+    EXPECT_EQ(discrete.getProbability(neg_inf_val), 0.0);
 
     // Test with out-of-range indices
-    assert(discrete.getProbability(-1) == 0.0);
-    assert(discrete.getProbability(5) == 0.0);
-    assert(discrete.getProbability(100) == 0.0);
+    EXPECT_EQ(discrete.getProbability(-1), 0.0);
+    EXPECT_EQ(discrete.getProbability(5), 0.0);
+    EXPECT_EQ(discrete.getProbability(100), 0.0);
 
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
 }
 
 /**
  * Test reset functionality
  */
-void testResetFunctionality() {
-    std::cout << "Testing reset functionality..." << std::endl;
+TEST(DiscreteDistributionTest, ResetFunctionality) {
 
     DiscreteDistribution discrete(4);
 
@@ -257,17 +236,15 @@ void testResetFunctionality() {
     discrete.reset();
     double expectedUniform = 1.0 / 4.0;
     for (int i = 0; i < 4; i++) {
-        assert(std::abs(discrete.getProbability(i) - expectedUniform) < 1e-10);
+        EXPECT_NEAR(discrete.getProbability(i), expectedUniform, 1e-10);
     }
 
-    std::cout << "✓ Reset functionality tests passed" << std::endl;
 }
 
 /**
  * Test discrete distribution properties
  */
-void testDiscreteProperties() {
-    std::cout << "Testing discrete distribution properties..." << std::endl;
+TEST(DiscreteDistributionTest, DiscreteProperties) {
 
     DiscreteDistribution discrete(3);
 
@@ -276,7 +253,7 @@ void testDiscreteProperties() {
     for (int i = 0; i < 3; i++) {
         totalProb += discrete.getProbability(i);
     }
-    assert(std::abs(totalProb - 1.0) < 1e-10);
+    EXPECT_NEAR(totalProb, 1.0, 1e-10);
 
     // Test with fitted data
     std::vector<Observation> data = {0, 0, 1, 2};
@@ -286,21 +263,19 @@ void testDiscreteProperties() {
     for (int i = 0; i < 3; i++) {
         totalProb += discrete.getProbability(i);
     }
-    assert(std::abs(totalProb - 1.0) < 1e-10);
+    EXPECT_NEAR(totalProb, 1.0, 1e-10);
 
     // Expected probabilities: 0->2/4=0.5, 1->1/4=0.25, 2->1/4=0.25
-    assert(std::abs(discrete.getProbability(0) - 0.5) < 1e-10);
-    assert(std::abs(discrete.getProbability(1) - 0.25) < 1e-10);
-    assert(std::abs(discrete.getProbability(2) - 0.25) < 1e-10);
+    EXPECT_NEAR(discrete.getProbability(0), 0.5, 1e-10);
+    EXPECT_NEAR(discrete.getProbability(1), 0.25, 1e-10);
+    EXPECT_NEAR(discrete.getProbability(2), 0.25, 1e-10);
 
-    std::cout << "✓ Discrete property tests passed" << std::endl;
 }
 
 /**
  * Test fitting validation
  */
-void testFittingValidation() {
-    std::cout << "Testing fitting validation..." << std::endl;
+TEST(DiscreteDistributionTest, FittingValidation) {
 
     DiscreteDistribution discrete(5);
 
@@ -316,7 +291,7 @@ void testFittingValidation() {
             totalValidProb += discrete.getProbability(i);
         }
         // Should still sum close to 1 (might ignore invalid values)
-        assert(totalValidProb > 0.5); // At least some probability assigned
+        EXPECT_GT(totalValidProb, 0.5); // At least some probability assigned
     } catch (const std::exception &) {
         // It's also acceptable to throw for invalid data
     }
@@ -326,21 +301,19 @@ void testFittingValidation() {
     try {
         discrete.fit(negativeData);
         // Check that non-negative symbols still get reasonable probabilities
-        assert(discrete.getProbability(0) >= 0.0);
-        assert(discrete.getProbability(1) >= 0.0);
-        assert(discrete.getProbability(2) >= 0.0);
+        EXPECT_TRUE(discrete.getProbability(0) >= 0.0);
+        EXPECT_TRUE(discrete.getProbability(1) >= 0.0);
+        EXPECT_TRUE(discrete.getProbability(2) >= 0.0);
     } catch (const std::exception &) {
         // Acceptable to reject negative values
     }
 
-    std::cout << "✓ Fitting validation tests passed" << std::endl;
 }
 
 /**
  * Test log probability calculations
  */
-void testLogProbability() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(DiscreteDistributionTest, LogProbability) {
 
     DiscreteDistribution discrete(3);
     discrete.setProbability(0, 0.5);
@@ -352,27 +325,25 @@ void testLogProbability() {
     double prob0 = discrete.getProbability(0.0);
 
     // log(prob) should equal logProb (within numerical precision)
-    assert(std::abs(std::log(prob0) - logProb0) < 1e-10);
+    EXPECT_NEAR(std::log(prob0), logProb0, 1e-10);
 
     // Test out of range (should return -infinity)
     double logProbNeg = discrete.getLogProbability(-1.0);
     double logProbHigh = discrete.getLogProbability(3.0);
-    assert(std::isinf(logProbNeg) && logProbNeg < 0);
-    assert(std::isinf(logProbHigh) && logProbHigh < 0);
+    EXPECT_TRUE(std::isinf(logProbNeg) && logProbNeg < 0);
+    EXPECT_TRUE(std::isinf(logProbHigh) && logProbHigh < 0);
 
     // Test with zero probability
     discrete.setProbability(2, 0.0);
     double logProbZero = discrete.getLogProbability(2.0);
-    assert(std::isinf(logProbZero) && logProbZero < 0);
+    EXPECT_TRUE(std::isinf(logProbZero) && logProbZero < 0);
 
-    std::cout << "✓ Log probability tests passed" << std::endl;
 }
 
 /**
  * Test CDF calculations
  */
-void testCDF() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(DiscreteDistributionTest, CDF) {
 
     DiscreteDistribution discrete(4);
     discrete.setProbability(0, 0.1);
@@ -386,28 +357,26 @@ void testCDF() {
     double cdf2 = discrete.getCumulativeProbability(2.0);
     double cdf3 = discrete.getCumulativeProbability(3.0);
 
-    assert(std::abs(cdf0 - 0.1) < 1e-10);
-    assert(std::abs(cdf1 - 0.3) < 1e-10); // 0.1 + 0.2
-    assert(std::abs(cdf2 - 0.6) < 1e-10); // 0.1 + 0.2 + 0.3
-    assert(std::abs(cdf3 - 1.0) < 1e-10); // 0.1 + 0.2 + 0.3 + 0.4
+    EXPECT_NEAR(cdf0, 0.1, 1e-10);
+    EXPECT_NEAR(cdf1, 0.3, 1e-10); // 0.1 + 0.2
+    EXPECT_NEAR(cdf2, 0.6, 1e-10); // 0.1 + 0.2 + 0.3
+    EXPECT_NEAR(cdf3, 1.0, 1e-10); // 0.1 + 0.2 + 0.3 + 0.4
 
     // CDF should be monotonic
-    assert(cdf0 <= cdf1);
-    assert(cdf1 <= cdf2);
-    assert(cdf2 <= cdf3);
+    EXPECT_LE(cdf0, cdf1);
+    EXPECT_LE(cdf1, cdf2);
+    EXPECT_LE(cdf2, cdf3);
 
     // Test boundary cases
-    assert(discrete.getCumulativeProbability(-1.0) == 0.0);
-    assert(discrete.getCumulativeProbability(10.0) == 1.0);
+    EXPECT_EQ(discrete.getCumulativeProbability(-1.0), 0.0);
+    EXPECT_EQ(discrete.getCumulativeProbability(10.0), 1.0);
 
-    std::cout << "✓ CDF tests passed" << std::endl;
 }
 
 /**
  * Test equality and I/O operators
  */
-void testEqualityAndIO() {
-    std::cout << "Testing equality and I/O operators..." << std::endl;
+TEST(DiscreteDistributionTest, EqualityAndIO) {
 
     DiscreteDistribution discrete1(3);
     discrete1.setProbability(0, 0.5);
@@ -427,21 +396,21 @@ void testEqualityAndIO() {
     DiscreteDistribution discrete4(4); // Different size
 
     // Test equality
-    assert(discrete1 == discrete2);
-    assert(!(discrete1 == discrete3));
-    assert(!(discrete1 == discrete4));
+    EXPECT_EQ(discrete1, discrete2);
+    EXPECT_FALSE(discrete1 == discrete3);
+    EXPECT_FALSE(discrete1 == discrete4);
 
     // Test inequality
-    assert(!(discrete1 != discrete2));
-    assert(discrete1 != discrete3);
-    assert(discrete1 != discrete4);
+    EXPECT_FALSE(discrete1 != discrete2);
+    EXPECT_NE(discrete1, discrete3);
+    EXPECT_NE(discrete1, discrete4);
 
     // Test stream output
     std::ostringstream oss;
     oss << discrete1;
     std::string output = oss.str();
-    assert(!output.empty());
-    assert(output.find("Discrete") != std::string::npos);
+    EXPECT_FALSE(output.empty());
+    EXPECT_NE(output.find("Discrete"), std::string::npos);
 
     // Test stream input via roundtrip
     DiscreteDistribution source(2);
@@ -452,18 +421,16 @@ void testEqualityAndIO() {
     std::istringstream iss(rss.str());
     DiscreteDistribution inputDiscrete;
     iss >> inputDiscrete;
-    assert(inputDiscrete.getNumSymbols() == 2);
-    assert(std::abs(inputDiscrete.getProbability(0) - 0.7) < 1e-10);
-    assert(std::abs(inputDiscrete.getProbability(1) - 0.3) < 1e-10);
+    EXPECT_EQ(inputDiscrete.getNumSymbols(), 2);
+    EXPECT_NEAR(inputDiscrete.getProbability(0), 0.7, 1e-10);
+    EXPECT_NEAR(inputDiscrete.getProbability(1), 0.3, 1e-10);
 
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics
  */
-void testPerformance() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(DiscreteDistributionTest, Performance) {
 
     DiscreteDistribution discrete(100); // Larger distribution
 
@@ -512,19 +479,16 @@ void testPerformance() {
               << " μs/point (" << fitData.size() << " points)" << std::endl;
 
     // Performance requirements (should be reasonable)
-    assert(pdfTimePerCall < 2.0);    // Less than 2 μs per PDF call (discrete should be very fast)
-    assert(logPdfTimePerCall < 2.0); // Less than 2 μs per log PDF call
-    assert(fitTimePerPoint <
-           2.0); // Less than 2 μs per data point for fitting (discrete fitting is simple)
+    EXPECT_LT(pdfTimePerCall, 2.0);    // Less than 2 μs per PDF call (discrete should be very fast)
+    EXPECT_LT(logPdfTimePerCall, 2.0); // Less than 2 μs per log PDF call
+    EXPECT_LT(fitTimePerPoint, 2.0); // Less than 2 μs per data point for fitting (discrete fitting is simple)
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
 /**
  * Test caching mechanism
  */
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
+TEST(DiscreteDistributionTest, Caching) {
 
     DiscreteDistribution discrete(3);
     discrete.setProbability(0, 0.4);
@@ -534,54 +498,22 @@ void testCaching() {
     // Test entropy calculation (uses caching)
     double entropy1 = discrete.getEntropy();
     double entropy2 = discrete.getEntropy();
-    assert(entropy1 == entropy2); // Should be identical due to caching
+    EXPECT_EQ(entropy1, entropy2); // Should be identical due to caching
 
     // Test probability sum calculation (uses caching)
     double sum1 = discrete.getProbabilitySum();
     double sum2 = discrete.getProbabilitySum();
-    assert(sum1 == sum2);                 // Should be identical due to caching
-    assert(std::abs(sum1 - 1.0) < 1e-10); // Should sum to 1
+    EXPECT_EQ(sum1, sum2);                 // Should be identical due to caching
+    EXPECT_NEAR(sum1, 1.0, 1e-10); // Should sum to 1
 
     // Changing probabilities should invalidate cache
     discrete.setProbability(0, 0.5);
     double newEntropy = discrete.getEntropy();
-    assert(newEntropy != entropy1); // Should be different after change
+    EXPECT_NE(newEntropy, entropy1); // Should be different after change
 
-    std::cout << "✓ Caching tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running Discrete distribution tests..." << std::endl;
-    std::cout << "=====================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testFitting();
-        testSetProbability();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testInvalidInputHandling();
-        testResetFunctionality();
-        testDiscreteProperties();
-        testFittingValidation();
-
-        // Gold Standard Tests
-        testLogProbability();
-        testCDF();
-        testEqualityAndIO();
-        testPerformance();
-        testCaching();
-
-        std::cout << "=====================================" << std::endl;
-        std::cout << "✅ All Discrete distribution tests passed!" << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_discrete_distribution.cpp
+++ b/tests/distributions/test_discrete_distribution.cpp
@@ -32,7 +32,6 @@ TEST(DiscreteDistributionTest, BasicFunctionality) {
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
-
 }
 
 /**
@@ -58,7 +57,6 @@ TEST(DiscreteDistributionTest, Probabilities) {
     double prob2_5 = discrete.getProbability(2.5);
     double prob2 = discrete.getProbability(2);
     EXPECT_EQ(prob2_5, prob2); // Should be same as symbol 2
-
 }
 
 /**
@@ -95,7 +93,6 @@ TEST(DiscreteDistributionTest, Fitting) {
     EXPECT_EQ(discrete.getProbability(2), 1.0); // All probability on symbol 2
     EXPECT_EQ(discrete.getProbability(3), 0.0);
     EXPECT_EQ(discrete.getProbability(4), 0.0);
-
 }
 
 /**
@@ -132,7 +129,6 @@ TEST(DiscreteDistributionTest, SetProbability) {
     } catch (...) {
         // Some implementations might not validate, which is also acceptable
     }
-
 }
 
 /**
@@ -193,7 +189,6 @@ TEST(DiscreteDistributionTest, CopyMoveSemantics) {
     EXPECT_EQ(moveAssigned.getNumSymbols(), 4);
     EXPECT_NEAR(moveAssigned.getProbability(1), 0.8, 1e-10);
     EXPECT_NEAR(moveAssigned.getProbability(3), 0.2, 1e-10);
-
 }
 
 /**
@@ -216,7 +211,6 @@ TEST(DiscreteDistributionTest, InvalidInputHandling) {
     EXPECT_EQ(discrete.getProbability(-1), 0.0);
     EXPECT_EQ(discrete.getProbability(5), 0.0);
     EXPECT_EQ(discrete.getProbability(100), 0.0);
-
 }
 
 /**
@@ -238,7 +232,6 @@ TEST(DiscreteDistributionTest, ResetFunctionality) {
     for (int i = 0; i < 4; i++) {
         EXPECT_NEAR(discrete.getProbability(i), expectedUniform, 1e-10);
     }
-
 }
 
 /**
@@ -269,7 +262,6 @@ TEST(DiscreteDistributionTest, DiscreteProperties) {
     EXPECT_NEAR(discrete.getProbability(0), 0.5, 1e-10);
     EXPECT_NEAR(discrete.getProbability(1), 0.25, 1e-10);
     EXPECT_NEAR(discrete.getProbability(2), 0.25, 1e-10);
-
 }
 
 /**
@@ -307,7 +299,6 @@ TEST(DiscreteDistributionTest, FittingValidation) {
     } catch (const std::exception &) {
         // Acceptable to reject negative values
     }
-
 }
 
 /**
@@ -337,7 +328,6 @@ TEST(DiscreteDistributionTest, LogProbability) {
     discrete.setProbability(2, 0.0);
     double logProbZero = discrete.getLogProbability(2.0);
     EXPECT_TRUE(std::isinf(logProbZero) && logProbZero < 0);
-
 }
 
 /**
@@ -370,7 +360,6 @@ TEST(DiscreteDistributionTest, CDF) {
     // Test boundary cases
     EXPECT_EQ(discrete.getCumulativeProbability(-1.0), 0.0);
     EXPECT_EQ(discrete.getCumulativeProbability(10.0), 1.0);
-
 }
 
 /**
@@ -424,7 +413,6 @@ TEST(DiscreteDistributionTest, EqualityAndIO) {
     EXPECT_EQ(inputDiscrete.getNumSymbols(), 2);
     EXPECT_NEAR(inputDiscrete.getProbability(0), 0.7, 1e-10);
     EXPECT_NEAR(inputDiscrete.getProbability(1), 0.3, 1e-10);
-
 }
 
 /**
@@ -481,8 +469,8 @@ TEST(DiscreteDistributionTest, Performance) {
     // Performance requirements (should be reasonable)
     EXPECT_LT(pdfTimePerCall, 2.0);    // Less than 2 μs per PDF call (discrete should be very fast)
     EXPECT_LT(logPdfTimePerCall, 2.0); // Less than 2 μs per log PDF call
-    EXPECT_LT(fitTimePerPoint, 2.0); // Less than 2 μs per data point for fitting (discrete fitting is simple)
-
+    EXPECT_LT(fitTimePerPoint,
+              2.0); // Less than 2 μs per data point for fitting (discrete fitting is simple)
 }
 
 /**
@@ -503,14 +491,13 @@ TEST(DiscreteDistributionTest, Caching) {
     // Test probability sum calculation (uses caching)
     double sum1 = discrete.getProbabilitySum();
     double sum2 = discrete.getProbabilitySum();
-    EXPECT_EQ(sum1, sum2);                 // Should be identical due to caching
+    EXPECT_EQ(sum1, sum2);         // Should be identical due to caching
     EXPECT_NEAR(sum1, 1.0, 1e-10); // Should sum to 1
 
     // Changing probabilities should invalidate cache
     discrete.setProbability(0, 0.5);
     double newEntropy = discrete.getEntropy();
     EXPECT_NE(newEntropy, entropy1); // Should be different after change
-
 }
 
 int main(int argc, char **argv) {

--- a/tests/distributions/test_exponential_distribution.cpp
+++ b/tests/distributions/test_exponential_distribution.cpp
@@ -1,19 +1,13 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <limits>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 #include "libhmm/distributions/exponential_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::ExponentialDistribution;
 using libhmm::Observation;
@@ -22,60 +16,55 @@ using namespace libhmm::constants;
 /**
  * Test basic Exponential distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Exponential distribution functionality..." << std::endl;
+TEST(ExponentialDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     ExponentialDistribution exponential;
-    assert(exponential.getLambda() == 1.0);
+    EXPECT_EQ(exponential.getLambda(), 1.0);
 
     // Test parameterized constructor
     ExponentialDistribution exponential2(2.5);
-    assert(exponential2.getLambda() == 2.5);
+    EXPECT_EQ(exponential2.getLambda(), 2.5);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(ExponentialDistributionTest, Probabilities) {
 
     ExponentialDistribution exponential(1.0); // lambda=1
 
     // For continuous Exponential PDF, at x=0 the value is λ (the rate parameter)
-    assert(exponential.getProbability(0.0) == 1.0); // lambda = 1.0
+    EXPECT_EQ(exponential.getProbability(0.0), 1.0); // lambda = 1.0
 
     // Should be positive for positive values
     double prob1 = exponential.getProbability(1.0);
     double prob2 = exponential.getProbability(2.0);
     double prob3 = exponential.getProbability(3.0);
 
-    assert(prob1 > 0.0);
-    assert(prob2 > 0.0);
-    assert(prob3 > 0.0);
+    EXPECT_GT(prob1, 0.0);
+    EXPECT_GT(prob2, 0.0);
+    EXPECT_GT(prob3, 0.0);
 
     // Should decrease with increasing x (memoryless property)
-    assert(prob1 > prob2);
-    assert(prob2 > prob3);
+    EXPECT_GT(prob1, prob2);
+    EXPECT_GT(prob2, prob3);
 
     // Should be zero for negative values
-    assert(exponential.getProbability(-1.0) == 0.0);
-    assert(exponential.getProbability(-0.5) == 0.0);
+    EXPECT_EQ(exponential.getProbability(-1.0), 0.0);
+    EXPECT_EQ(exponential.getProbability(-0.5), 0.0);
 
     // Test that probability is reasonable (our implementation returns small values for continuous distributions)
-    assert(prob1 > 1e-10); // Should be positive
-    assert(prob1 < 1.0);   // Should be less than 1
+    EXPECT_GT(prob1, 1e-10); // Should be positive
+    EXPECT_LT(prob1, 1.0);   // Should be less than 1
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(ExponentialDistributionTest, Fitting) {
 
     ExponentialDistribution exponential;
 
@@ -85,38 +74,36 @@ void testFitting() {
     double expectedLambda = 1.0 / expectedMean;
 
     exponential.fit(data);
-    assert(std::abs(exponential.getLambda() - expectedLambda) < 1e-10);
+    EXPECT_NEAR(exponential.getLambda(), expectedLambda, 1e-10);
 
     // Test with empty data (should reset to default)
     std::vector<Observation> emptyData;
     exponential.fit(emptyData);
-    assert(exponential.getLambda() == 1.0);
+    EXPECT_EQ(exponential.getLambda(), 1.0);
 
     // Test with single positive point (implementation resets to default for insufficient data)
     std::vector<Observation> singlePoint = {2.5};
     exponential.fit(singlePoint);
-    assert(exponential.getLambda() == 1.0); // Implementation resets to default
+    EXPECT_EQ(exponential.getLambda(), 1.0); // Implementation resets to default
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(ExponentialDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
     try {
         ExponentialDistribution exponential(0.0); // Zero lambda
-        assert(false);                            // Should not reach here
+        ADD_FAILURE();                            // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         ExponentialDistribution exponential(-1.0); // Negative lambda
-        assert(false);                             // Should not reach here
+        ADD_FAILURE();                             // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
@@ -125,102 +112,71 @@ void testParameterValidation() {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        ExponentialDistribution exponential(nan_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(ExponentialDistribution exponential(nan_val), std::invalid_argument);
 
-    try {
-        ExponentialDistribution exponential(inf_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(ExponentialDistribution exponential(inf_val), std::invalid_argument);
 
     // Test setters validation
     ExponentialDistribution exponential(1.0);
 
-    try {
-        exponential.setLambda(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(exponential.setLambda(0.0), std::invalid_argument);
 
-    try {
-        exponential.setLambda(-1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(exponential.setLambda(-1.0), std::invalid_argument);
 
-    try {
-        exponential.setLambda(nan_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(exponential.setLambda(nan_val), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(ExponentialDistributionTest, StringRepresentation) {
 
     ExponentialDistribution exponential(2.5);
     std::string str = exponential.toString();
 
     // Should contain key information based on new format:
     // "Exponential Distribution:\n      λ (rate parameter) = 2.5\n      Mean = 0.4\n"
-    assert(str.find("Exponential") != std::string::npos);
-    assert(str.find("Distribution") != std::string::npos);
-    assert(str.find("2.5") != std::string::npos);
-    assert(str.find("rate parameter") != std::string::npos);
+    EXPECT_NE(str.find("Exponential"), std::string::npos);
+    EXPECT_NE(str.find("Distribution"), std::string::npos);
+    EXPECT_NE(str.find("2.5"), std::string::npos);
+    EXPECT_NE(str.find("rate parameter"), std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(ExponentialDistributionTest, CopyMoveSemantics) {
 
     ExponentialDistribution original(3.14);
 
     // Test copy constructor
     ExponentialDistribution copied(original);
-    assert(copied.getLambda() == original.getLambda());
+    EXPECT_EQ(copied.getLambda(), original.getLambda());
 
     // Test copy assignment
     ExponentialDistribution assigned;
     assigned = original;
-    assert(assigned.getLambda() == original.getLambda());
+    EXPECT_EQ(assigned.getLambda(), original.getLambda());
 
     // Test move constructor
     ExponentialDistribution moved(std::move(original));
-    assert(moved.getLambda() == 3.14);
+    EXPECT_EQ(moved.getLambda(), 3.14);
 
     // Test move assignment
     ExponentialDistribution moveAssigned;
     ExponentialDistribution temp(2.71);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getLambda() == 2.71);
+    EXPECT_EQ(moveAssigned.getLambda(), 2.71);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test invalid input handling
  */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(ExponentialDistributionTest, InvalidInputHandling) {
 
     ExponentialDistribution exponential(1.0);
 
@@ -229,36 +185,32 @@ void testInvalidInputHandling() {
     double inf_val = std::numeric_limits<double>::infinity();
     double neg_inf_val = -std::numeric_limits<double>::infinity();
 
-    assert(exponential.getProbability(nan_val) == 0.0);
-    assert(exponential.getProbability(inf_val) == 0.0);
-    assert(exponential.getProbability(neg_inf_val) == 0.0);
+    EXPECT_EQ(exponential.getProbability(nan_val), 0.0);
+    EXPECT_EQ(exponential.getProbability(inf_val), 0.0);
+    EXPECT_EQ(exponential.getProbability(neg_inf_val), 0.0);
 
     // Negative values should return 0
-    assert(exponential.getProbability(-1.0) == 0.0);
-    assert(exponential.getProbability(-0.1) == 0.0);
+    EXPECT_EQ(exponential.getProbability(-1.0), 0.0);
+    EXPECT_EQ(exponential.getProbability(-0.1), 0.0);
 
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
 }
 
 /**
  * Test reset functionality
  */
-void testResetFunctionality() {
-    std::cout << "Testing reset functionality..." << std::endl;
+TEST(ExponentialDistributionTest, ResetFunctionality) {
 
     ExponentialDistribution exponential(10.0);
     exponential.reset();
 
-    assert(exponential.getLambda() == 1.0);
+    EXPECT_EQ(exponential.getLambda(), 1.0);
 
-    std::cout << "✓ Reset functionality tests passed" << std::endl;
 }
 
 /**
  * Test fitting validation
  */
-void testFittingValidation() {
-    std::cout << "Testing fitting validation..." << std::endl;
+TEST(ExponentialDistributionTest, FittingValidation) {
 
     ExponentialDistribution exponential;
 
@@ -270,7 +222,7 @@ void testFittingValidation() {
     try {
         exponential.fit(invalidData);
         // If it doesn't throw, the parameter should still be valid
-        assert(exponential.getLambda() > 0.0);
+        EXPECT_GT(exponential.getLambda(), 0.0);
     } catch (const std::exception &) {
         // It's also acceptable to throw for invalid data
     }
@@ -279,19 +231,17 @@ void testFittingValidation() {
     std::vector<Observation> zeroData = {0.0, 1.0, 2.0};
     try {
         exponential.fit(zeroData);
-        assert(exponential.getLambda() > 0.0);
+        EXPECT_GT(exponential.getLambda(), 0.0);
     } catch (const std::exception &) {
         // Acceptable to reject zero values
     }
 
-    std::cout << "✓ Fitting validation tests passed" << std::endl;
 }
 
 /**
  * Test log probability function for numerical stability
  */
-void testLogProbability() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(ExponentialDistributionTest, LogProbability) {
 
     ExponentialDistribution exponential(2.0); // lambda=2
 
@@ -305,18 +255,18 @@ void testLogProbability() {
     double logP3 = exponential.getLogProbability(x3);
 
     // Verify log probabilities are negative (since probabilities < 1)
-    assert(logP1 < 0.0);
-    assert(logP2 < 0.0);
-    assert(logP3 < 0.0);
+    EXPECT_LT(logP1, 0.0);
+    EXPECT_LT(logP2, 0.0);
+    EXPECT_LT(logP3, 0.0);
 
     // For exponential with λ=2: log(f(x)) = log(2) - 2x
     double expectedLogP1 = std::log(2.0) - 2.0 * x1; // log(2) - 1
     double expectedLogP2 = std::log(2.0) - 2.0 * x2; // log(2) - 2
     double expectedLogP3 = std::log(2.0) - 2.0 * x3; // log(2) - 4
 
-    assert(std::abs(logP1 - expectedLogP1) < 1e-10);
-    assert(std::abs(logP2 - expectedLogP2) < 1e-10);
-    assert(std::abs(logP3 - expectedLogP3) < 1e-10);
+    EXPECT_NEAR(logP1, expectedLogP1, 1e-10);
+    EXPECT_NEAR(logP2, expectedLogP2, 1e-10);
+    EXPECT_NEAR(logP3, expectedLogP3, 1e-10);
 
     // Verify consistency with getProbability
     double p1 = exponential.getProbability(x1);
@@ -324,22 +274,19 @@ void testLogProbability() {
 
     // Note: For small tolerance values, getProbability might not exactly match
     // the log of getProbability due to discrete approximation, so we test reasonableness
-    assert(p1 > 0.0);
-    assert(p2 > 0.0);
+    EXPECT_GT(p1, 0.0);
+    EXPECT_GT(p2, 0.0);
 
     // Test invalid inputs return -infinity
-    assert(exponential.getLogProbability(-1.0) == -std::numeric_limits<double>::infinity());
-    assert(exponential.getLogProbability(std::numeric_limits<double>::quiet_NaN()) ==
-           -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(exponential.getLogProbability(-1.0), -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(exponential.getLogProbability(std::numeric_limits<double>::quiet_NaN()), -std::numeric_limits<double>::infinity());
 
-    std::cout << "✓ Log probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test memoryless property
  */
-void testMemorylessProperty() {
-    std::cout << "Testing memoryless property..." << std::endl;
+TEST(ExponentialDistributionTest, MemorylessProperty) {
 
     ExponentialDistribution exponential(1.0);
 
@@ -358,16 +305,14 @@ void testMemorylessProperty() {
     double ratio2 = p3 / p2;
 
     // Ratios should be approximately equal due to memoryless property
-    assert(std::abs(ratio1 - ratio2) < 1e-9); // Slightly looser tolerance for numerical precision
+    EXPECT_NEAR(ratio1, ratio2, 1e-9); // Slightly looser tolerance for numerical precision
 
-    std::cout << "✓ Memoryless property tests passed" << std::endl;
 }
 
 /**
  * Test statistical moments and properties
  */
-void testStatisticalMoments() {
-    std::cout << "Testing statistical moments..." << std::endl;
+TEST(ExponentialDistributionTest, StatisticalMoments) {
 
     ExponentialDistribution exponential(2.5);
 
@@ -376,24 +321,22 @@ void testStatisticalMoments() {
     double expectedVar = 1.0 / (2.5 * 2.5);
     double expectedStdDev = 1.0 / 2.5;
 
-    assert(std::abs(exponential.getMean() - expectedMean) < 1e-10);
-    assert(std::abs(exponential.getVariance() - expectedVar) < 1e-10);
-    assert(std::abs(exponential.getStandardDeviation() - expectedStdDev) < 1e-10);
+    EXPECT_NEAR(exponential.getMean(), expectedMean, 1e-10);
+    EXPECT_NEAR(exponential.getVariance(), expectedVar, 1e-10);
+    EXPECT_NEAR(exponential.getStandardDeviation(), expectedStdDev, 1e-10);
 
     // Test scale parameter (should equal mean)
-    assert(std::abs(exponential.getScale() - expectedMean) < 1e-10);
+    EXPECT_NEAR(exponential.getScale(), expectedMean, 1e-10);
 
     // For exponential distribution, mean = standard deviation
-    assert(std::abs(exponential.getMean() - exponential.getStandardDeviation()) < 1e-10);
+    EXPECT_NEAR(exponential.getMean(), exponential.getStandardDeviation(), 1e-10);
 
-    std::cout << "✓ Statistical moments tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics and optimizations
  */
-void testPerformanceCharacteristics() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(ExponentialDistributionTest, PerformanceCharacteristics) {
 
     ExponentialDistribution exponential(1.5);
 
@@ -444,18 +387,16 @@ void testPerformanceCharacteristics() {
               << " μs/point (" << fitData.size() << " points)" << std::endl;
 
     // Performance requirements (should be fast)
-    assert(pdfTimePerCall < 1.0);    // Less than 1 μs per PDF call
-    assert(logPdfTimePerCall < 1.0); // Less than 1 μs per log PDF call
-    assert(fitTimePerPoint < 0.1);   // Less than 0.1 μs per data point for fitting
+    EXPECT_LT(pdfTimePerCall, 1.0);    // Less than 1 μs per PDF call
+    EXPECT_LT(logPdfTimePerCall, 1.0); // Less than 1 μs per log PDF call
+    EXPECT_LT(fitTimePerPoint, 0.1);   // Less than 0.1 μs per data point for fitting
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
 /**
  * Test enhanced fitting with robust validation
  */
-void testEnhancedFitting() {
-    std::cout << "Testing enhanced fitting with validation..." << std::endl;
+TEST(ExponentialDistributionTest, EnhancedFitting) {
 
     ExponentialDistribution exponential;
 
@@ -465,144 +406,137 @@ void testEnhancedFitting() {
     double expectedLambda = 1.0 / expectedMean;
 
     exponential.fit(testData);
-    assert(std::abs(exponential.getLambda() - expectedLambda) < 1e-10);
+    EXPECT_NEAR(exponential.getLambda(), expectedLambda, 1e-10);
 
     // Test with negative data (should reset to default)
     std::vector<Observation> negativeData = {1.0, -0.5, 2.0};
     exponential.fit(negativeData);
-    assert(exponential.getLambda() == 1.0); // Should reset to default
+    EXPECT_EQ(exponential.getLambda(), 1.0); // Should reset to default
 
     // Test with zero values (should reset to default)
     std::vector<Observation> zeroData = {0.0, 1.0, 2.0};
     exponential.fit(zeroData);
-    assert(exponential.getLambda() == 1.0); // Should reset to default
+    EXPECT_EQ(exponential.getLambda(), 1.0); // Should reset to default
 
     // Test with all zero values
     std::vector<Observation> allZeros = {0.0, 0.0, 0.0};
     exponential.fit(allZeros);
-    assert(exponential.getLambda() == 1.0); // Should reset to default
+    EXPECT_EQ(exponential.getLambda(), 1.0); // Should reset to default
 
-    std::cout << "✓ Enhanced fitting tests passed" << std::endl;
 }
 
 /**
  * Test numerical edge cases and stability
  */
-void testNumericalStability() {
-    std::cout << "Testing numerical stability..." << std::endl;
+TEST(ExponentialDistributionTest, NumericalStability) {
 
     // Test with very small lambda
     ExponentialDistribution smallExp(1e-6);
     double probSmall = smallExp.getProbability(1.0);
-    assert(probSmall > 0.0);
-    assert(std::isfinite(probSmall));
+    EXPECT_GT(probSmall, 0.0);
+    EXPECT_TRUE(std::isfinite(probSmall));
 
     // Test with very large lambda
     ExponentialDistribution largeExp(1e6);
     double probLarge = largeExp.getProbability(0.000001);
-    assert(probLarge > 0.0);
-    assert(std::isfinite(probLarge));
+    EXPECT_GT(probLarge, 0.0);
+    EXPECT_TRUE(std::isfinite(probLarge));
 
     // Test log probability with extreme values
     double logProbSmall = smallExp.getLogProbability(1000.0);
     double logProbLarge = largeExp.getLogProbability(0.000001);
-    assert(std::isfinite(logProbSmall));
-    assert(std::isfinite(logProbLarge));
+    EXPECT_TRUE(std::isfinite(logProbSmall));
+    EXPECT_TRUE(std::isfinite(logProbLarge));
 
     // Test mathematical correctness at special points
     ExponentialDistribution unit(1.0);
 
     // At x=0, PDF should equal lambda
-    assert(std::abs(unit.getProbability(0.0) - 1.0) < 1e-10);
+    EXPECT_NEAR(unit.getProbability(0.0), 1.0, 1e-10);
 
     // Log PDF at x=0 should equal log(lambda)
-    assert(std::abs(unit.getLogProbability(0.0) - std::log(1.0)) < 1e-10);
+    EXPECT_NEAR(unit.getLogProbability(0.0), std::log(1.0), 1e-10);
 
-    std::cout << "✓ Numerical stability tests passed" << std::endl;
 }
 
 /**
  * Test CDF calculations
  */
-void testCDF() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(ExponentialDistributionTest, CDF) {
 
     ExponentialDistribution exponential(1.0); // lambda=1
 
     // For exponential distribution: F(x) = 1 - exp(-λx)
     // Test at various points
     double cdfAt0 = exponential.getCumulativeProbability(0.0);
-    assert(std::abs(cdfAt0 - 0.0) < 1e-10); // F(0) = 0
+    EXPECT_NEAR(cdfAt0, 0.0, 1e-10); // F(0) = 0
 
     double cdfAt1 = exponential.getCumulativeProbability(1.0);
     double expectedCdf1 = 1.0 - std::exp(-1.0); // 1 - e^(-1)
-    assert(std::abs(cdfAt1 - expectedCdf1) < 1e-10);
+    EXPECT_NEAR(cdfAt1, expectedCdf1, 1e-10);
 
     double cdfAt2 = exponential.getCumulativeProbability(2.0);
     double expectedCdf2 = 1.0 - std::exp(-2.0); // 1 - e^(-2)
-    assert(std::abs(cdfAt2 - expectedCdf2) < 1e-10);
+    EXPECT_NEAR(cdfAt2, expectedCdf2, 1e-10);
 
     // Test CDF is monotonically increasing
-    assert(exponential.getCumulativeProbability(1.0) < exponential.getCumulativeProbability(2.0));
-    assert(exponential.getCumulativeProbability(2.0) < exponential.getCumulativeProbability(3.0));
+    EXPECT_LT(exponential.getCumulativeProbability(1.0), exponential.getCumulativeProbability(2.0));
+    EXPECT_LT(exponential.getCumulativeProbability(2.0), exponential.getCumulativeProbability(3.0));
 
     // Test CDF bounds
-    assert(exponential.getCumulativeProbability(0.0) >= 0.0 &&
-           exponential.getCumulativeProbability(0.0) <= 1.0);
-    assert(exponential.getCumulativeProbability(10.0) >= 0.0 &&
-           exponential.getCumulativeProbability(10.0) <= 1.0);
+    EXPECT_GE(exponential.getCumulativeProbability(0.0), 0.0);
+    EXPECT_LE(exponential.getCumulativeProbability(0.0), 1.0);
+    EXPECT_GE(exponential.getCumulativeProbability(10.0), 0.0);
+    EXPECT_LE(exponential.getCumulativeProbability(10.0), 1.0);
 
     // Test that CDF approaches 1 for large values
-    assert(exponential.getCumulativeProbability(10.0) >
-           0.99995); // Should be very close to 1 (for λ=1, F(10) ≈ 0.99995)
+    EXPECT_GT(exponential.getCumulativeProbability(10.0), 0.99995); // Should be very close to 1 (for λ=1, F(10) ≈ 0.99995)
 
     // Test with different parameters
     ExponentialDistribution exponential2(2.0);
     double cdf2At1 = exponential2.getCumulativeProbability(1.0);
     double expectedCdf2At1 = 1.0 - std::exp(-2.0); // 1 - e^(-2)
-    assert(std::abs(cdf2At1 - expectedCdf2At1) < 1e-10);
+    EXPECT_NEAR(cdf2At1, expectedCdf2At1, 1e-10);
 
     // CDF for λ=2 should be higher than for λ=1 at same x
-    assert(exponential2.getCumulativeProbability(1.0) > exponential.getCumulativeProbability(1.0));
+    EXPECT_GT(exponential2.getCumulativeProbability(1.0), exponential.getCumulativeProbability(1.0));
 
-    std::cout << "✓ CDF calculation tests passed" << std::endl;
 }
 
 /**
  * Test equality operators and I/O
  */
-void testEqualityAndIO() {
-    std::cout << "Testing equality operators and I/O..." << std::endl;
+TEST(ExponentialDistributionTest, EqualityAndIO) {
 
     ExponentialDistribution e1(2.5);
     ExponentialDistribution e2(2.5);
     ExponentialDistribution e3(2.6); // Different lambda
 
     // Test equality operator
-    assert(e1 == e2);
-    assert(e2 == e1); // Symmetric
+    EXPECT_EQ(e1, e2);
+    EXPECT_EQ(e2, e1); // Symmetric
 
     // Test inequality
-    assert(!(e1 == e3));
-    assert(e1 != e3);
+    EXPECT_FALSE(e1 == e3);
+    EXPECT_NE(e1, e3);
 
     // Test self-equality
-    assert(e1 == e1);
+    EXPECT_EQ(e1, e1);
 
     // Test with very small differences (within tolerance)
     ExponentialDistribution e4(2.5 + 1e-15); // Very small difference
-    assert(e1 == e4);                        // Should be equal within tolerance
+    EXPECT_EQ(e1, e4);                        // Should be equal within tolerance
 
     // Test with differences larger than tolerance
     ExponentialDistribution e5(2.5 + 1e-5); // Larger difference
-    assert(!(e1 == e5));                    // Should not be equal
+    EXPECT_FALSE(e1 == e5);                    // Should not be equal
 
     // Test stream output
     std::ostringstream oss;
     oss << e1;
     std::string output = oss.str();
-    assert(output.find("Exponential Distribution") != std::string::npos);
-    assert(output.find("2.5") != std::string::npos);
+    EXPECT_NE(output.find("Exponential Distribution"), std::string::npos);
+    EXPECT_NE(output.find("2.5"), std::string::npos);
 
     std::cout << "Stream output: " << output << std::endl;
 
@@ -612,23 +546,21 @@ void testEqualityAndIO() {
     iss >> inputDist;
 
     if (!iss.fail()) {
-        assert(std::abs(inputDist.getLambda() - 3.14) < 1e-10);
+        EXPECT_NEAR(inputDist.getLambda(), 3.14, 1e-10);
     }
 
     // Test input operator with invalid data
     std::istringstream invalid_iss("invalid data format");
     ExponentialDistribution invalid_test;
     invalid_iss >> invalid_test;
-    assert(invalid_iss.fail()); // Stream should be in failed state
+    EXPECT_TRUE(invalid_iss.fail()); // Stream should be in failed state
 
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
 }
 
 /**
  * Test caching mechanism
  */
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
+TEST(ExponentialDistributionTest, Caching) {
 
     ExponentialDistribution exponential(1.0);
 
@@ -637,7 +569,7 @@ void testCaching() {
     double logProb1 = exponential.getLogProbability(1.0);
 
     // Verify consistency between PDF and log PDF
-    assert(std::abs(prob1 - std::exp(logProb1)) < 1e-10);
+    EXPECT_NEAR(prob1, std::exp(logProb1), 1e-10);
 
     // Change parameters (this should invalidate cache)
     exponential.setLambda(2.0); // Significant change
@@ -647,11 +579,11 @@ void testCaching() {
     double logProb2 = exponential.getLogProbability(1.0);
 
     // Values should be different due to parameter change
-    assert(std::abs(prob1 - prob2) > 1e-6);
-    assert(std::abs(logProb1 - logProb2) > 1e-6);
+    EXPECT_GT(std::abs(prob1 - prob2), 1e-6);
+    EXPECT_GT(std::abs(logProb1 - logProb2), 1e-6);
 
     // Verify consistency with new parameters
-    assert(std::abs(prob2 - std::exp(logProb2)) < 1e-10);
+    EXPECT_NEAR(prob2, std::exp(logProb2), 1e-10);
 
     // Test that cached values are properly used for derived properties
     double mean1 = exponential.getMean();
@@ -660,53 +592,20 @@ void testCaching() {
     double scale1 = exponential.getScale();
 
     // These should all use cached values and be consistent
-    assert(std::abs(mean1 - (1.0 / 2.0)) < 1e-10);             // mean = 1/λ
-    assert(std::abs(variance1 - (1.0 / (2.0 * 2.0))) < 1e-10); // variance = 1/λ²
-    assert(std::abs(stdDev1 - mean1) < 1e-10);                 // std_dev = mean for exponential
-    assert(std::abs(scale1 - mean1) < 1e-10);                  // scale = mean for exponential
+    EXPECT_NEAR(mean1, (1.0 / 2.0), 1e-10);             // mean = 1/λ
+    EXPECT_NEAR(variance1, (1.0 / (2.0 * 2.0)), 1e-10); // variance = 1/λ²
+    EXPECT_NEAR(stdDev1, mean1, 1e-10);                 // std_dev = mean for exponential
+    EXPECT_NEAR(scale1, mean1, 1e-10);                  // scale = mean for exponential
 
     // Test cache invalidation with reset
     double prob3 = exponential.getProbability(1.0);
     exponential.reset();
     double prob4 = exponential.getProbability(1.0);
-    assert(std::abs(prob3 - prob4) > 1e-6); // Should be different after reset
+    EXPECT_GT(std::abs(prob3 - prob4), 1e-6); // Should be different after reset
 
-    std::cout << "✓ Caching mechanism tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running Exponential distribution tests..." << std::endl;
-    std::cout << "=========================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testLogProbability();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testInvalidInputHandling();
-        testResetFunctionality();
-        testFittingValidation();
-        testMemorylessProperty();
-        testStatisticalMoments();
-        testPerformanceCharacteristics();
-        testEnhancedFitting();
-        testNumericalStability();
-        testCDF();
-        testEqualityAndIO();
-        testCaching();
-
-        std::cout << "=========================================" << std::endl;
-        std::cout << "✅ All Exponential distribution tests passed!" << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_exponential_distribution.cpp
+++ b/tests/distributions/test_exponential_distribution.cpp
@@ -25,7 +25,6 @@ TEST(ExponentialDistributionTest, BasicFunctionality) {
     // Test parameterized constructor
     ExponentialDistribution exponential2(2.5);
     EXPECT_EQ(exponential2.getLambda(), 2.5);
-
 }
 
 /**
@@ -58,7 +57,6 @@ TEST(ExponentialDistributionTest, Probabilities) {
     // Test that probability is reasonable (our implementation returns small values for continuous distributions)
     EXPECT_GT(prob1, 1e-10); // Should be positive
     EXPECT_LT(prob1, 1.0);   // Should be less than 1
-
 }
 
 /**
@@ -85,7 +83,6 @@ TEST(ExponentialDistributionTest, Fitting) {
     std::vector<Observation> singlePoint = {2.5};
     exponential.fit(singlePoint);
     EXPECT_EQ(exponential.getLambda(), 1.0); // Implementation resets to default
-
 }
 
 /**
@@ -124,7 +121,6 @@ TEST(ExponentialDistributionTest, ParameterValidation) {
     EXPECT_THROW(exponential.setLambda(-1.0), std::invalid_argument);
 
     EXPECT_THROW(exponential.setLambda(nan_val), std::invalid_argument);
-
 }
 
 /**
@@ -170,7 +166,6 @@ TEST(ExponentialDistributionTest, CopyMoveSemantics) {
     ExponentialDistribution temp(2.71);
     moveAssigned = std::move(temp);
     EXPECT_EQ(moveAssigned.getLambda(), 2.71);
-
 }
 
 /**
@@ -192,7 +187,6 @@ TEST(ExponentialDistributionTest, InvalidInputHandling) {
     // Negative values should return 0
     EXPECT_EQ(exponential.getProbability(-1.0), 0.0);
     EXPECT_EQ(exponential.getProbability(-0.1), 0.0);
-
 }
 
 /**
@@ -204,7 +198,6 @@ TEST(ExponentialDistributionTest, ResetFunctionality) {
     exponential.reset();
 
     EXPECT_EQ(exponential.getLambda(), 1.0);
-
 }
 
 /**
@@ -235,7 +228,6 @@ TEST(ExponentialDistributionTest, FittingValidation) {
     } catch (const std::exception &) {
         // Acceptable to reject zero values
     }
-
 }
 
 /**
@@ -279,8 +271,8 @@ TEST(ExponentialDistributionTest, LogProbability) {
 
     // Test invalid inputs return -infinity
     EXPECT_EQ(exponential.getLogProbability(-1.0), -std::numeric_limits<double>::infinity());
-    EXPECT_EQ(exponential.getLogProbability(std::numeric_limits<double>::quiet_NaN()), -std::numeric_limits<double>::infinity());
-
+    EXPECT_EQ(exponential.getLogProbability(std::numeric_limits<double>::quiet_NaN()),
+              -std::numeric_limits<double>::infinity());
 }
 
 /**
@@ -306,7 +298,6 @@ TEST(ExponentialDistributionTest, MemorylessProperty) {
 
     // Ratios should be approximately equal due to memoryless property
     EXPECT_NEAR(ratio1, ratio2, 1e-9); // Slightly looser tolerance for numerical precision
-
 }
 
 /**
@@ -330,7 +321,6 @@ TEST(ExponentialDistributionTest, StatisticalMoments) {
 
     // For exponential distribution, mean = standard deviation
     EXPECT_NEAR(exponential.getMean(), exponential.getStandardDeviation(), 1e-10);
-
 }
 
 /**
@@ -390,7 +380,6 @@ TEST(ExponentialDistributionTest, PerformanceCharacteristics) {
     EXPECT_LT(pdfTimePerCall, 1.0);    // Less than 1 μs per PDF call
     EXPECT_LT(logPdfTimePerCall, 1.0); // Less than 1 μs per log PDF call
     EXPECT_LT(fitTimePerPoint, 0.1);   // Less than 0.1 μs per data point for fitting
-
 }
 
 /**
@@ -422,7 +411,6 @@ TEST(ExponentialDistributionTest, EnhancedFitting) {
     std::vector<Observation> allZeros = {0.0, 0.0, 0.0};
     exponential.fit(allZeros);
     EXPECT_EQ(exponential.getLambda(), 1.0); // Should reset to default
-
 }
 
 /**
@@ -456,7 +444,6 @@ TEST(ExponentialDistributionTest, NumericalStability) {
 
     // Log PDF at x=0 should equal log(lambda)
     EXPECT_NEAR(unit.getLogProbability(0.0), std::log(1.0), 1e-10);
-
 }
 
 /**
@@ -490,7 +477,8 @@ TEST(ExponentialDistributionTest, CDF) {
     EXPECT_LE(exponential.getCumulativeProbability(10.0), 1.0);
 
     // Test that CDF approaches 1 for large values
-    EXPECT_GT(exponential.getCumulativeProbability(10.0), 0.99995); // Should be very close to 1 (for λ=1, F(10) ≈ 0.99995)
+    EXPECT_GT(exponential.getCumulativeProbability(10.0),
+              0.99995); // Should be very close to 1 (for λ=1, F(10) ≈ 0.99995)
 
     // Test with different parameters
     ExponentialDistribution exponential2(2.0);
@@ -499,8 +487,8 @@ TEST(ExponentialDistributionTest, CDF) {
     EXPECT_NEAR(cdf2At1, expectedCdf2At1, 1e-10);
 
     // CDF for λ=2 should be higher than for λ=1 at same x
-    EXPECT_GT(exponential2.getCumulativeProbability(1.0), exponential.getCumulativeProbability(1.0));
-
+    EXPECT_GT(exponential2.getCumulativeProbability(1.0),
+              exponential.getCumulativeProbability(1.0));
 }
 
 /**
@@ -525,11 +513,11 @@ TEST(ExponentialDistributionTest, EqualityAndIO) {
 
     // Test with very small differences (within tolerance)
     ExponentialDistribution e4(2.5 + 1e-15); // Very small difference
-    EXPECT_EQ(e1, e4);                        // Should be equal within tolerance
+    EXPECT_EQ(e1, e4);                       // Should be equal within tolerance
 
     // Test with differences larger than tolerance
     ExponentialDistribution e5(2.5 + 1e-5); // Larger difference
-    EXPECT_FALSE(e1 == e5);                    // Should not be equal
+    EXPECT_FALSE(e1 == e5);                 // Should not be equal
 
     // Test stream output
     std::ostringstream oss;
@@ -554,7 +542,6 @@ TEST(ExponentialDistributionTest, EqualityAndIO) {
     ExponentialDistribution invalid_test;
     invalid_iss >> invalid_test;
     EXPECT_TRUE(invalid_iss.fail()); // Stream should be in failed state
-
 }
 
 /**
@@ -602,7 +589,6 @@ TEST(ExponentialDistributionTest, Caching) {
     exponential.reset();
     double prob4 = exponential.getProbability(1.0);
     EXPECT_GT(std::abs(prob3 - prob4), 1e-6); // Should be different after reset
-
 }
 
 int main(int argc, char **argv) {

--- a/tests/distributions/test_gamma_distribution.cpp
+++ b/tests/distributions/test_gamma_distribution.cpp
@@ -1,18 +1,12 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <climits>
 #include <chrono>
 #include <iomanip>
 #include "libhmm/distributions/gamma_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::GammaDistribution;
 using libhmm::Observation;
@@ -20,57 +14,52 @@ using libhmm::Observation;
 /**
  * Test basic Gamma distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Gamma distribution functionality..." << std::endl;
+TEST(GammaDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     GammaDistribution gamma;
-    assert(gamma.getK() == 1.0);
-    assert(gamma.getTheta() == 1.0);
+    EXPECT_EQ(gamma.getK(), 1.0);
+    EXPECT_EQ(gamma.getTheta(), 1.0);
 
     // Test parameterized constructor
     GammaDistribution gamma2(2.5, 1.5);
-    assert(gamma2.getK() == 2.5);
-    assert(gamma2.getTheta() == 1.5);
+    EXPECT_EQ(gamma2.getK(), 2.5);
+    EXPECT_EQ(gamma2.getTheta(), 1.5);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(GammaDistributionTest, Probabilities) {
 
     GammaDistribution gamma(2.0, 1.0); // k=2, theta=1
 
     // Gamma distribution should be zero at x=0
-    assert(gamma.getProbability(0.0) == 0.0);
+    EXPECT_EQ(gamma.getProbability(0.0), 0.0);
 
     // Should be positive for positive values
     double prob1 = gamma.getProbability(1.0);
     double prob2 = gamma.getProbability(2.0);
     double prob3 = gamma.getProbability(3.0);
 
-    assert(prob1 > 0.0);
-    assert(prob2 > 0.0);
-    assert(prob3 > 0.0);
+    EXPECT_GT(prob1, 0.0);
+    EXPECT_GT(prob2, 0.0);
+    EXPECT_GT(prob3, 0.0);
 
     // Should be zero for negative values
-    assert(gamma.getProbability(-1.0) == 0.0);
-    assert(gamma.getProbability(-0.5) == 0.0);
+    EXPECT_EQ(gamma.getProbability(-1.0), 0.0);
+    EXPECT_EQ(gamma.getProbability(-0.5), 0.0);
 
     // For Gamma(2,1), the mode is at k-1 = 1, so prob at 1 should be relatively high
-    assert(prob1 > prob3); // Probability should decrease away from mode
+    EXPECT_GT(prob1, prob3); // Probability should decrease away from mode
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(GammaDistributionTest, Fitting) {
 
     GammaDistribution gamma;
 
@@ -79,55 +68,53 @@ void testFitting() {
 
     gamma.fit(data);
     // After fitting, parameters should be positive
-    assert(gamma.getK() > 0.0);
-    assert(gamma.getTheta() > 0.0);
+    EXPECT_GT(gamma.getK(), 0.0);
+    EXPECT_GT(gamma.getTheta(), 0.0);
 
     // Test with empty data (should reset to default)
     std::vector<Observation> emptyData;
     gamma.fit(emptyData);
-    assert(gamma.getK() == 1.0); // New implementation resets to default
-    assert(gamma.getTheta() == 1.0);
+    EXPECT_EQ(gamma.getK(), 1.0); // New implementation resets to default
+    EXPECT_EQ(gamma.getTheta(), 1.0);
 
     // Test with single positive point (implementation resets to default for insufficient data)
     std::vector<Observation> singlePoint = {2.5};
     gamma.fit(singlePoint);
-    assert(gamma.getK() == 1.0); // Implementation resets to default
-    assert(gamma.getTheta() == 1.0);
+    EXPECT_EQ(gamma.getK(), 1.0); // Implementation resets to default
+    EXPECT_EQ(gamma.getTheta(), 1.0);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(GammaDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
     try {
         GammaDistribution gamma(0.0, 1.0); // Zero k
-        assert(false);                     // Should not reach here
+        ADD_FAILURE();                     // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         GammaDistribution gamma(-1.0, 1.0); // Negative k
-        assert(false);                      // Should not reach here
+        ADD_FAILURE();                      // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         GammaDistribution gamma(1.0, 0.0); // Zero theta
-        assert(false);                     // Should not reach here
+        ADD_FAILURE();                     // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         GammaDistribution gamma(1.0, -1.0); // Negative theta
-        assert(false);                      // Should not reach here
+        ADD_FAILURE();                      // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
@@ -136,83 +123,67 @@ void testParameterValidation() {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        GammaDistribution gamma(nan_val, 1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(GammaDistribution gamma(nan_val, 1.0), std::invalid_argument);
 
-    try {
-        GammaDistribution gamma(1.0, inf_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(GammaDistribution gamma(1.0, inf_val), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(GammaDistributionTest, StringRepresentation) {
 
     GammaDistribution gamma(2.5, 1.5);
     std::string str = gamma.toString();
 
     // Should contain key information based on new format:
     // "Gamma Distribution:\n      k (shape parameter) = 2.5\n      θ (scale parameter) = 1.5\n      Mean = 3.75\n      Variance = 5.625\n"
-    assert(str.find("Gamma") != std::string::npos);
-    assert(str.find("2.5") != std::string::npos);
-    assert(str.find("1.5") != std::string::npos);
-    assert(str.find("shape parameter") != std::string::npos);
-    assert(str.find("scale parameter") != std::string::npos);
+    EXPECT_NE(str.find("Gamma"), std::string::npos);
+    EXPECT_NE(str.find("2.5"), std::string::npos);
+    EXPECT_NE(str.find("1.5"), std::string::npos);
+    EXPECT_NE(str.find("shape parameter"), std::string::npos);
+    EXPECT_NE(str.find("scale parameter"), std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(GammaDistributionTest, CopyMoveSemantics) {
 
     GammaDistribution original(3.14, 2.71);
 
     // Test copy constructor
     GammaDistribution copied(original);
-    assert(copied.getK() == original.getK());
-    assert(copied.getTheta() == original.getTheta());
+    EXPECT_EQ(copied.getK(), original.getK());
+    EXPECT_EQ(copied.getTheta(), original.getTheta());
 
     // Test copy assignment
     GammaDistribution assigned;
     assigned = original;
-    assert(assigned.getK() == original.getK());
-    assert(assigned.getTheta() == original.getTheta());
+    EXPECT_EQ(assigned.getK(), original.getK());
+    EXPECT_EQ(assigned.getTheta(), original.getTheta());
 
     // Test move constructor
     GammaDistribution moved(std::move(original));
-    assert(moved.getK() == 3.14);
-    assert(moved.getTheta() == 2.71);
+    EXPECT_EQ(moved.getK(), 3.14);
+    EXPECT_EQ(moved.getTheta(), 2.71);
 
     // Test move assignment
     GammaDistribution moveAssigned;
     GammaDistribution temp(1.41, 1.73);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getK() == 1.41);
-    assert(moveAssigned.getTheta() == 1.73);
+    EXPECT_EQ(moveAssigned.getK(), 1.41);
+    EXPECT_EQ(moveAssigned.getTheta(), 1.73);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test invalid input handling
  */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(GammaDistributionTest, InvalidInputHandling) {
 
     GammaDistribution gamma(2.0, 1.0);
 
@@ -221,37 +192,33 @@ void testInvalidInputHandling() {
     double inf_val = std::numeric_limits<double>::infinity();
     double neg_inf_val = -std::numeric_limits<double>::infinity();
 
-    assert(gamma.getProbability(nan_val) == 0.0);
-    assert(gamma.getProbability(inf_val) == 0.0);
-    assert(gamma.getProbability(neg_inf_val) == 0.0);
+    EXPECT_EQ(gamma.getProbability(nan_val), 0.0);
+    EXPECT_EQ(gamma.getProbability(inf_val), 0.0);
+    EXPECT_EQ(gamma.getProbability(neg_inf_val), 0.0);
 
     // Negative values should return 0
-    assert(gamma.getProbability(-1.0) == 0.0);
-    assert(gamma.getProbability(-0.1) == 0.0);
+    EXPECT_EQ(gamma.getProbability(-1.0), 0.0);
+    EXPECT_EQ(gamma.getProbability(-0.1), 0.0);
 
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
 }
 
 /**
  * Test reset functionality
  */
-void testResetFunctionality() {
-    std::cout << "Testing reset functionality..." << std::endl;
+TEST(GammaDistributionTest, ResetFunctionality) {
 
     GammaDistribution gamma(10.0, 5.0);
     gamma.reset();
 
-    assert(gamma.getK() == 1.0);
-    assert(gamma.getTheta() == 1.0);
+    EXPECT_EQ(gamma.getK(), 1.0);
+    EXPECT_EQ(gamma.getTheta(), 1.0);
 
-    std::cout << "✓ Reset functionality tests passed" << std::endl;
 }
 
 /**
  * Test log probability function
  */
-void testLogProbability() {
-    std::cout << "Testing log probability function..." << std::endl;
+TEST(GammaDistributionTest, LogProbability) {
 
     GammaDistribution gamma(2.0, 1.0); // k=2, theta=1
 
@@ -269,24 +236,22 @@ void testLogProbability() {
     double p1 = gamma.getProbability(x1);
     double p2 = gamma.getProbability(x2);
 
-    assert(std::abs(p1 - std::exp(logP1)) < 1e-10);
-    assert(std::abs(p2 - std::exp(logP2)) < 1e-10);
+    EXPECT_NEAR(p1, std::exp(logP1), 1e-10);
+    EXPECT_NEAR(p2, std::exp(logP2), 1e-10);
 
     // Test with invalid inputs
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
-    assert(std::isinf(gamma.getLogProbability(nan_val)));
-    assert(std::isinf(gamma.getLogProbability(inf_val)));
-    assert(std::isinf(gamma.getLogProbability(-1.0)));
+    EXPECT_TRUE(std::isinf(gamma.getLogProbability(nan_val)));
+    EXPECT_TRUE(std::isinf(gamma.getLogProbability(inf_val)));
+    EXPECT_TRUE(std::isinf(gamma.getLogProbability(-1.0)));
 
-    std::cout << "✓ Log probability tests passed" << std::endl;
 }
 
 /**
  * Test additional getters and setters
  */
-void testAdditionalGettersSetters() {
-    std::cout << "Testing additional getters and setters..." << std::endl;
+TEST(GammaDistributionTest, AdditionalGettersSetters) {
 
     GammaDistribution gamma(2.0, 3.0);
 
@@ -298,40 +263,38 @@ void testAdditionalGettersSetters() {
     double rate = gamma.getRate();
 
     // For Gamma(k=2, theta=3): mean=6, variance=18, stddev=sqrt(18), mode=3, rate=1/3
-    assert(std::abs(mean - 6.0) < 1e-10);
-    assert(std::abs(variance - 18.0) < 1e-10);
-    assert(std::abs(stdDev - std::sqrt(18.0)) < 1e-10);
-    assert(std::abs(mode - 3.0) < 1e-10); // (k-1)*theta = (2-1)*3 = 3
-    assert(std::abs(rate - (1.0 / 3.0)) < 1e-10);
+    EXPECT_NEAR(mean, 6.0, 1e-10);
+    EXPECT_NEAR(variance, 18.0, 1e-10);
+    EXPECT_NEAR(stdDev, std::sqrt(18.0), 1e-10);
+    EXPECT_NEAR(mode, 3.0, 1e-10); // (k-1)*theta = (2-1)*3 = 3
+    EXPECT_NEAR(rate, (1.0 / 3.0), 1e-10);
 
     // Test setters
     gamma.setK(3.0);
-    assert(std::abs(gamma.getK() - 3.0) < 1e-10);
+    EXPECT_NEAR(gamma.getK(), 3.0, 1e-10);
 
     gamma.setTheta(2.0);
-    assert(std::abs(gamma.getTheta() - 2.0) < 1e-10);
+    EXPECT_NEAR(gamma.getTheta(), 2.0, 1e-10);
 
     // Test setParameters function
     gamma.setParameters(1.5, 0.5);
-    assert(std::abs(gamma.getK() - 1.5) < 1e-10);
-    assert(std::abs(gamma.getTheta() - 0.5) < 1e-10);
+    EXPECT_NEAR(gamma.getK(), 1.5, 1e-10);
+    EXPECT_NEAR(gamma.getTheta(), 0.5, 1e-10);
 
     // Test setParameters validation
     try {
         gamma.setParameters(-1.0, 1.0); // Invalid k
-        assert(false);                  // Should not reach here
+        ADD_FAILURE();                  // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior - setParameters should validate inputs
     }
 
-    std::cout << "✓ Additional getters/setters tests passed" << std::endl;
 }
 
 /**
  * Test mathematical correctness with known values
  */
-void testMathematicalCorrectness() {
-    std::cout << "Testing mathematical correctness..." << std::endl;
+TEST(GammaDistributionTest, MathematicalCorrectness) {
 
     // Test with Gamma(1,1) which should be equivalent to Exponential(1)
     GammaDistribution gamma1(1.0, 1.0);
@@ -339,7 +302,7 @@ void testMathematicalCorrectness() {
     // At x=1: PDF = 1 * exp(-1) ≈ 0.36787944
     double pdf1 = gamma1.getProbability(1.0);
     double expected1 = std::exp(-1.0);
-    assert(std::abs(pdf1 - expected1) < 1e-6);
+    EXPECT_NEAR(pdf1, expected1, 1e-6);
 
     // Test with Gamma(2,1)
     GammaDistribution gamma2(2.0, 1.0);
@@ -347,16 +310,14 @@ void testMathematicalCorrectness() {
     // At x=1: PDF = 1 * exp(-1) ≈ 0.36787944 (mode is at x=1)
     double pdf2 = gamma2.getProbability(1.0);
     double expected2 = std::exp(-1.0);
-    assert(std::abs(pdf2 - expected2) < 1e-6);
+    EXPECT_NEAR(pdf2, expected2, 1e-6);
 
-    std::cout << "✓ Mathematical correctness tests passed" << std::endl;
 }
 
 /**
  * Test fitting validation
  */
-void testFittingValidation() {
-    std::cout << "Testing fitting validation..." << std::endl;
+TEST(GammaDistributionTest, FittingValidation) {
 
     GammaDistribution gamma;
 
@@ -364,48 +325,46 @@ void testFittingValidation() {
     std::vector<Observation> mixedData = {1.0, 2.0, -1.0, 3.0};
     gamma.fit(mixedData);
     // Should fit to the positive values {1.0, 2.0, 3.0} and not reset
-    assert(gamma.getK() > 0.0); // Should have fitted to positive values
-    assert(gamma.getTheta() > 0.0);
+    EXPECT_GT(gamma.getK(), 0.0); // Should have fitted to positive values
+    EXPECT_GT(gamma.getTheta(), 0.0);
 
     // Test with data containing all negative values (should reset to default)
     std::vector<Observation> allNegativeData = {-1.0, -2.0, -3.0};
     gamma.fit(allNegativeData);
-    assert(gamma.getK() == 1.0); // Should reset to default
-    assert(gamma.getTheta() == 1.0);
+    EXPECT_EQ(gamma.getK(), 1.0); // Should reset to default
+    EXPECT_EQ(gamma.getTheta(), 1.0);
 
     // Test with zero values mixed with positives (should filter zeros and fit to positives)
     std::vector<Observation> zeroMixedData = {0.0, 1.0, 2.0};
     gamma.fit(zeroMixedData);
     // Should fit to the positive values {1.0, 2.0} and not reset
-    assert(gamma.getK() > 0.0); // Should have fitted to positive values
-    assert(gamma.getTheta() > 0.0);
+    EXPECT_GT(gamma.getK(), 0.0); // Should have fitted to positive values
+    EXPECT_GT(gamma.getTheta(), 0.0);
 
     // Test with mostly zero values (should reset to default)
     std::vector<Observation> mostlyZeroData = {0.0, 0.0, 1.0};
     gamma.fit(mostlyZeroData);
-    assert(gamma.getK() == 1.0); // Should reset to default (only 1 positive value)
-    assert(gamma.getTheta() == 1.0);
+    EXPECT_EQ(gamma.getK(), 1.0); // Should reset to default (only 1 positive value)
+    EXPECT_EQ(gamma.getTheta(), 1.0);
 
     // Test with all zero values
     std::vector<Observation> allZeros = {0.0, 0.0, 0.0};
     gamma.fit(allZeros);
-    assert(gamma.getK() == 1.0);
-    assert(gamma.getTheta() == 1.0);
+    EXPECT_EQ(gamma.getK(), 1.0);
+    EXPECT_EQ(gamma.getTheta(), 1.0);
 
-    std::cout << "✓ Fitting validation tests passed" << std::endl;
 }
 
 /**
  * Test CDF functionality
  */
-void testCDF() {
-    std::cout << "Testing CDF functionality..." << std::endl;
+TEST(GammaDistributionTest, CDF) {
 
     GammaDistribution gamma(2.0, 1.0); // k=2, theta=1
 
     // Test CDF properties
-    assert(gamma.getCumulativeProbability(-1.0) == 0.0); // CDF should be 0 for negative values
-    assert(gamma.getCumulativeProbability(0.0) == 0.0);  // CDF should be 0 at x=0
+    EXPECT_EQ(gamma.getCumulativeProbability(-1.0), 0.0); // CDF should be 0 for negative values
+    EXPECT_EQ(gamma.getCumulativeProbability(0.0), 0.0);  // CDF should be 0 at x=0
 
     // Test CDF values at specific points
     double cdf1 = gamma.getCumulativeProbability(1.0);
@@ -413,31 +372,29 @@ void testCDF() {
     double cdf3 = gamma.getCumulativeProbability(3.0);
 
     // CDF should be monotonically increasing
-    assert(cdf1 < cdf2);
-    assert(cdf2 < cdf3);
+    EXPECT_LT(cdf1, cdf2);
+    EXPECT_LT(cdf2, cdf3);
 
     // CDF should be between 0 and 1
-    assert(cdf1 > 0.0 && cdf1 < 1.0);
-    assert(cdf2 > 0.0 && cdf2 < 1.0);
-    assert(cdf3 > 0.0 && cdf3 < 1.0);
+    EXPECT_TRUE(cdf1 > 0.0 && cdf1 < 1.0);
+    EXPECT_TRUE(cdf2 > 0.0 && cdf2 < 1.0);
+    EXPECT_TRUE(cdf3 > 0.0 && cdf3 < 1.0);
 
     // Test that CDF approaches 1 for large values
     double cdf_large = gamma.getCumulativeProbability(10.0);
-    assert(cdf_large > 0.95); // Should be close to 1
+    EXPECT_GT(cdf_large, 0.95); // Should be close to 1
 
     // Test with invalid inputs
     double nan_val = std::numeric_limits<double>::quiet_NaN();
-    assert(gamma.getCumulativeProbability(nan_val) == 0.0 ||
-           std::isnan(gamma.getCumulativeProbability(nan_val)));
+    EXPECT_TRUE(gamma.getCumulativeProbability(nan_val) == 0.0 ||
+                std::isnan(gamma.getCumulativeProbability(nan_val)));
 
-    std::cout << "✓ CDF tests passed" << std::endl;
 }
 
 /**
  * Test equality operator
  */
-void testEqualityOperator() {
-    std::cout << "Testing equality operator..." << std::endl;
+TEST(GammaDistributionTest, EqualityOperator) {
 
     GammaDistribution gamma1(2.5, 1.5);
     GammaDistribution gamma2(2.5, 1.5);
@@ -445,34 +402,32 @@ void testEqualityOperator() {
     GammaDistribution gamma4(2.6, 1.5); // Different k
 
     // Test equality
-    assert(gamma1 == gamma2);
-    assert(gamma2 == gamma1); // Symmetric
+    EXPECT_EQ(gamma1, gamma2);
+    EXPECT_EQ(gamma2, gamma1); // Symmetric
 
     // Test inequality
-    assert(!(gamma1 == gamma3));
-    assert(!(gamma1 == gamma4));
-    assert(gamma1 != gamma3);
-    assert(gamma1 != gamma4);
+    EXPECT_FALSE(gamma1 == gamma3);
+    EXPECT_FALSE(gamma1 == gamma4);
+    EXPECT_NE(gamma1, gamma3);
+    EXPECT_NE(gamma1, gamma4);
 
     // Test self-equality
-    assert(gamma1 == gamma1);
+    EXPECT_EQ(gamma1, gamma1);
 
     // Test with very small differences (within tolerance)
     GammaDistribution gamma5(2.5, 1.5 + 1e-15); // Very small difference
-    assert(gamma1 == gamma5);                   // Should be equal within tolerance
+    EXPECT_EQ(gamma1, gamma5);                   // Should be equal within tolerance
 
     // Test with differences larger than tolerance
     GammaDistribution gamma6(2.5, 1.5 + 1e-5); // Larger difference (10x the tolerance)
-    assert(!(gamma1 == gamma6));               // Should not be equal
+    EXPECT_FALSE(gamma1 == gamma6);               // Should not be equal
 
-    std::cout << "✓ Equality operator tests passed" << std::endl;
 }
 
 /**
  * Test I/O operators
  */
-void testIOOperators() {
-    std::cout << "Testing I/O operators..." << std::endl;
+TEST(GammaDistributionTest, IOOperators) {
 
     GammaDistribution original(3.14, 2.71);
 
@@ -482,11 +437,11 @@ void testIOOperators() {
     std::string output = oss.str();
 
     // Check that output contains expected information
-    assert(output.find("Gamma Distribution") != std::string::npos);
-    assert(output.find("3.14") != std::string::npos);
-    assert(output.find("2.71") != std::string::npos);
-    assert(output.find("shape") != std::string::npos);
-    assert(output.find("scale") != std::string::npos);
+    EXPECT_NE(output.find("Gamma Distribution"), std::string::npos);
+    EXPECT_NE(output.find("3.14"), std::string::npos);
+    EXPECT_NE(output.find("2.71"), std::string::npos);
+    EXPECT_NE(output.find("shape"), std::string::npos);
+    EXPECT_NE(output.find("scale"), std::string::npos);
 
     // Test input operator via roundtrip
     GammaDistribution source(1.41, 1.73);
@@ -497,23 +452,21 @@ void testIOOperators() {
     iss >> reconstructed;
 
     // Check that parameters were correctly parsed
-    assert(std::abs(reconstructed.getK() - 1.41) < 1e-10);
-    assert(std::abs(reconstructed.getTheta() - 1.73) < 1e-10);
+    EXPECT_NEAR(reconstructed.getK(), 1.41, 1e-10);
+    EXPECT_NEAR(reconstructed.getTheta(), 1.73, 1e-10);
 
     // Test input operator with invalid data
     std::istringstream invalid_iss("invalid data format");
     GammaDistribution invalid_test;
     invalid_iss >> invalid_test;
-    assert(invalid_iss.fail()); // Stream should be in failed state
+    EXPECT_TRUE(invalid_iss.fail()); // Stream should be in failed state
 
-    std::cout << "✓ I/O operator tests passed" << std::endl;
 }
 
 /**
  * Test caching behavior
  */
-void testCaching() {
-    std::cout << "Testing caching behavior..." << std::endl;
+TEST(GammaDistributionTest, Caching) {
 
     GammaDistribution gamma(2.0, 1.0);
 
@@ -522,7 +475,7 @@ void testCaching() {
     double logProb1 = gamma.getLogProbability(1.0);
 
     // Verify consistency
-    assert(std::abs(prob1 - std::exp(logProb1)) < 1e-10);
+    EXPECT_NEAR(prob1, std::exp(logProb1), 1e-10);
 
     // Change parameters (this should invalidate cache)
     gamma.setK(3.0);
@@ -532,82 +485,78 @@ void testCaching() {
     double logProb2 = gamma.getLogProbability(1.0);
 
     // Values should be different due to parameter change
-    assert(std::abs(prob1 - prob2) > 1e-6);
-    assert(std::abs(logProb1 - logProb2) > 1e-6);
+    EXPECT_GT(std::abs(prob1 - prob2), 1e-6);
+    EXPECT_GT(std::abs(logProb1 - logProb2), 1e-6);
 
     // Verify consistency with new parameters
-    assert(std::abs(prob2 - std::exp(logProb2)) < 1e-10);
+    EXPECT_NEAR(prob2, std::exp(logProb2), 1e-10);
 
     // Test cache invalidation with setTheta
     double prob3 = gamma.getProbability(1.0);
     gamma.setTheta(2.0);
     double prob4 = gamma.getProbability(1.0);
-    assert(std::abs(prob3 - prob4) > 1e-6);
+    EXPECT_GT(std::abs(prob3 - prob4), 1e-6);
 
     // Test cache invalidation with setParameters
     double prob5 = gamma.getProbability(1.0);
     gamma.setParameters(1.5, 0.8);
     double prob6 = gamma.getProbability(1.0);
-    assert(std::abs(prob5 - prob6) > 1e-6);
+    EXPECT_GT(std::abs(prob5 - prob6), 1e-6);
 
-    std::cout << "✓ Caching tests passed" << std::endl;
 }
 
 /**
  * Test numerical stability
  */
-void testNumericalStability() {
-    std::cout << "Testing numerical stability..." << std::endl;
+TEST(GammaDistributionTest, NumericalStability) {
 
     // Test with very small shape parameter
     GammaDistribution gamma_small(0.1, 1.0);
     double prob_small = gamma_small.getProbability(0.01);
     double logProb_small = gamma_small.getLogProbability(0.01);
-    assert(std::isfinite(prob_small));
-    assert(std::isfinite(logProb_small));
+    EXPECT_TRUE(std::isfinite(prob_small));
+    EXPECT_TRUE(std::isfinite(logProb_small));
 
     // Test with very large shape parameter
     GammaDistribution gamma_large(100.0, 1.0);
     double prob_large = gamma_large.getProbability(100.0);
     double logProb_large = gamma_large.getLogProbability(100.0);
-    assert(std::isfinite(prob_large));
-    assert(std::isfinite(logProb_large));
+    EXPECT_TRUE(std::isfinite(prob_large));
+    EXPECT_TRUE(std::isfinite(logProb_large));
 
     // Test with very small scale parameter
     GammaDistribution gamma_small_scale(2.0, 0.001);
     double prob_small_scale = gamma_small_scale.getProbability(0.001);
-    assert(std::isfinite(prob_small_scale));
+    EXPECT_TRUE(std::isfinite(prob_small_scale));
 
     // Test with very large scale parameter
     GammaDistribution gamma_large_scale(2.0, 1000.0);
     double prob_large_scale = gamma_large_scale.getProbability(1000.0);
-    assert(std::isfinite(prob_large_scale));
+    EXPECT_TRUE(std::isfinite(prob_large_scale));
 
     // Test log probability doesn't overflow/underflow
     GammaDistribution gamma_extreme(0.01, 0.01);
     double logProb_extreme = gamma_extreme.getLogProbability(1e-10);
-    assert(std::isfinite(logProb_extreme) ||
+    EXPECT_TRUE(std::isfinite(logProb_extreme) ||
            logProb_extreme == -std::numeric_limits<double>::infinity());
 
     // Test CDF stability
     double cdf_small = gamma_small.getCumulativeProbability(1e-6);
     double cdf_large = gamma_large.getCumulativeProbability(1000.0);
-    assert(cdf_small >= 0.0 && cdf_small <= 1.0);
-    assert(cdf_large >= 0.0 && cdf_large <= 1.0);
+    EXPECT_TRUE(cdf_small >= 0.0 && cdf_small <= 1.0);
+    EXPECT_TRUE(cdf_large >= 0.0 && cdf_large <= 1.0);
 
     // Test with values very close to zero
     GammaDistribution gamma_test(1.5, 1.0);
     double prob_near_zero = gamma_test.getProbability(1e-100);
-    assert(prob_near_zero >= 0.0);
+    EXPECT_TRUE(prob_near_zero >= 0.0);
 
-    std::cout << "✓ Numerical stability tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics
  */
-void testPerformance() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(GammaDistributionTest, Performance) {
 
     using namespace std::chrono;
     GammaDistribution gamma(2.0, 1.0);
@@ -659,13 +608,13 @@ void testPerformance() {
     double fit_per_point = static_cast<double>(fit_duration.count()) / fit_datapoints;
 
     // Basic performance assertions
-    assert(pdf_per_call < 2.0);     // Should be well under 2 microseconds per PDF call
-    assert(log_pdf_per_call < 1.0); // Should be well under 1 microsecond per log PDF call
-    assert(fit_per_point < 10.0);   // Should be well under 10 microseconds per fit datapoint
+    EXPECT_LT(pdf_per_call, 2.0);     // Should be well under 2 microseconds per PDF call
+    EXPECT_LT(log_pdf_per_call, 1.0); // Should be well under 1 microsecond per log PDF call
+    EXPECT_LT(fit_per_point, 10.0);   // Should be well under 10 microseconds per fit datapoint
 
     // Verify correctness
-    assert(sum_pdf > 0.0);
-    assert(sum_log_pdf < 0.0); // Log probabilities should be negative
+    EXPECT_GT(sum_pdf, 0.0);
+    EXPECT_LT(sum_log_pdf, 0.0); // Log probabilities should be negative
 
     std::cout << std::fixed << std::setprecision(3);
     std::cout << "  PDF timing:       " << pdf_per_call << " μs/call (" << pdf_iterations
@@ -674,42 +623,9 @@ void testPerformance() {
               << " calls)" << std::endl;
     std::cout << "  Fit timing:       " << fit_per_point << " μs/point (" << fit_datapoints
               << " points)" << std::endl;
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running Gamma distribution tests..." << std::endl;
-    std::cout << "===================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testLogProbability();
-        testAdditionalGettersSetters();
-        testMathematicalCorrectness();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testInvalidInputHandling();
-        testResetFunctionality();
-        testFittingValidation();
-        testCDF();
-        testEqualityOperator();
-        testIOOperators();
-        testCaching();
-        testNumericalStability();
-        testPerformance();
-
-        std::cout << "===================================" << std::endl;
-        std::cout << "✅ All Gamma distribution tests passed!" << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_gamma_distribution.cpp
+++ b/tests/distributions/test_gamma_distribution.cpp
@@ -25,7 +25,6 @@ TEST(GammaDistributionTest, BasicFunctionality) {
     GammaDistribution gamma2(2.5, 1.5);
     EXPECT_EQ(gamma2.getK(), 2.5);
     EXPECT_EQ(gamma2.getTheta(), 1.5);
-
 }
 
 /**
@@ -53,7 +52,6 @@ TEST(GammaDistributionTest, Probabilities) {
 
     // For Gamma(2,1), the mode is at k-1 = 1, so prob at 1 should be relatively high
     EXPECT_GT(prob1, prob3); // Probability should decrease away from mode
-
 }
 
 /**
@@ -82,7 +80,6 @@ TEST(GammaDistributionTest, Fitting) {
     gamma.fit(singlePoint);
     EXPECT_EQ(gamma.getK(), 1.0); // Implementation resets to default
     EXPECT_EQ(gamma.getTheta(), 1.0);
-
 }
 
 /**
@@ -126,7 +123,6 @@ TEST(GammaDistributionTest, ParameterValidation) {
     EXPECT_THROW(GammaDistribution gamma(nan_val, 1.0), std::invalid_argument);
 
     EXPECT_THROW(GammaDistribution gamma(1.0, inf_val), std::invalid_argument);
-
 }
 
 /**
@@ -177,7 +173,6 @@ TEST(GammaDistributionTest, CopyMoveSemantics) {
     moveAssigned = std::move(temp);
     EXPECT_EQ(moveAssigned.getK(), 1.41);
     EXPECT_EQ(moveAssigned.getTheta(), 1.73);
-
 }
 
 /**
@@ -199,7 +194,6 @@ TEST(GammaDistributionTest, InvalidInputHandling) {
     // Negative values should return 0
     EXPECT_EQ(gamma.getProbability(-1.0), 0.0);
     EXPECT_EQ(gamma.getProbability(-0.1), 0.0);
-
 }
 
 /**
@@ -212,7 +206,6 @@ TEST(GammaDistributionTest, ResetFunctionality) {
 
     EXPECT_EQ(gamma.getK(), 1.0);
     EXPECT_EQ(gamma.getTheta(), 1.0);
-
 }
 
 /**
@@ -245,7 +238,6 @@ TEST(GammaDistributionTest, LogProbability) {
     EXPECT_TRUE(std::isinf(gamma.getLogProbability(nan_val)));
     EXPECT_TRUE(std::isinf(gamma.getLogProbability(inf_val)));
     EXPECT_TRUE(std::isinf(gamma.getLogProbability(-1.0)));
-
 }
 
 /**
@@ -288,7 +280,6 @@ TEST(GammaDistributionTest, AdditionalGettersSetters) {
     } catch (const std::invalid_argument &) {
         // Expected behavior - setParameters should validate inputs
     }
-
 }
 
 /**
@@ -311,7 +302,6 @@ TEST(GammaDistributionTest, MathematicalCorrectness) {
     double pdf2 = gamma2.getProbability(1.0);
     double expected2 = std::exp(-1.0);
     EXPECT_NEAR(pdf2, expected2, 1e-6);
-
 }
 
 /**
@@ -352,7 +342,6 @@ TEST(GammaDistributionTest, FittingValidation) {
     gamma.fit(allZeros);
     EXPECT_EQ(gamma.getK(), 1.0);
     EXPECT_EQ(gamma.getTheta(), 1.0);
-
 }
 
 /**
@@ -388,7 +377,6 @@ TEST(GammaDistributionTest, CDF) {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     EXPECT_TRUE(gamma.getCumulativeProbability(nan_val) == 0.0 ||
                 std::isnan(gamma.getCumulativeProbability(nan_val)));
-
 }
 
 /**
@@ -416,12 +404,11 @@ TEST(GammaDistributionTest, EqualityOperator) {
 
     // Test with very small differences (within tolerance)
     GammaDistribution gamma5(2.5, 1.5 + 1e-15); // Very small difference
-    EXPECT_EQ(gamma1, gamma5);                   // Should be equal within tolerance
+    EXPECT_EQ(gamma1, gamma5);                  // Should be equal within tolerance
 
     // Test with differences larger than tolerance
     GammaDistribution gamma6(2.5, 1.5 + 1e-5); // Larger difference (10x the tolerance)
-    EXPECT_FALSE(gamma1 == gamma6);               // Should not be equal
-
+    EXPECT_FALSE(gamma1 == gamma6);            // Should not be equal
 }
 
 /**
@@ -460,7 +447,6 @@ TEST(GammaDistributionTest, IOOperators) {
     GammaDistribution invalid_test;
     invalid_iss >> invalid_test;
     EXPECT_TRUE(invalid_iss.fail()); // Stream should be in failed state
-
 }
 
 /**
@@ -502,7 +488,6 @@ TEST(GammaDistributionTest, Caching) {
     gamma.setParameters(1.5, 0.8);
     double prob6 = gamma.getProbability(1.0);
     EXPECT_GT(std::abs(prob5 - prob6), 1e-6);
-
 }
 
 /**
@@ -538,7 +523,7 @@ TEST(GammaDistributionTest, NumericalStability) {
     GammaDistribution gamma_extreme(0.01, 0.01);
     double logProb_extreme = gamma_extreme.getLogProbability(1e-10);
     EXPECT_TRUE(std::isfinite(logProb_extreme) ||
-           logProb_extreme == -std::numeric_limits<double>::infinity());
+                logProb_extreme == -std::numeric_limits<double>::infinity());
 
     // Test CDF stability
     double cdf_small = gamma_small.getCumulativeProbability(1e-6);
@@ -550,7 +535,6 @@ TEST(GammaDistributionTest, NumericalStability) {
     GammaDistribution gamma_test(1.5, 1.0);
     double prob_near_zero = gamma_test.getProbability(1e-100);
     EXPECT_TRUE(prob_near_zero >= 0.0);
-
 }
 
 /**

--- a/tests/distributions/test_gaussian_distribution.cpp
+++ b/tests/distributions/test_gaussian_distribution.cpp
@@ -1,616 +1,275 @@
+#include <gtest/gtest.h>
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <limits>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 #include "libhmm/distributions/gaussian_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
 
 using libhmm::GaussianDistribution;
 using libhmm::Observation;
 using namespace libhmm::constants;
 
-/**
- * Test basic Gaussian distribution functionality
- */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Gaussian distribution functionality..." << std::endl;
-
-    // Test default constructor
+TEST(GaussianDistributionTest, BasicFunctionality) {
     GaussianDistribution gaussian;
-    assert(gaussian.getMean() == 0.0);
-    assert(gaussian.getStandardDeviation() == 1.0);
+    EXPECT_EQ(gaussian.getMean(), 0.0);
+    EXPECT_EQ(gaussian.getStandardDeviation(), 1.0);
 
-    // Test parameterized constructor
     GaussianDistribution gaussian2(5.0, 2.5);
-    assert(gaussian2.getMean() == 5.0);
-    assert(gaussian2.getStandardDeviation() == 2.5);
-
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
+    EXPECT_EQ(gaussian2.getMean(), 5.0);
+    EXPECT_EQ(gaussian2.getStandardDeviation(), 2.5);
 }
 
-/**
- * Test probability calculations
- */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
-
-    GaussianDistribution gaussian(0.0, 1.0); // Standard normal
-
-    // Test at mean (should be highest probability)
-    double probAtMean = gaussian.getProbability(0.0);
-    assert(probAtMean > 0.0);
-
-    // Test precise PDF value for standard normal at mean (should be 1/sqrt(2π))
-    double expectedPDF = 1.0 / math::SQRT_2PI;
-    assert(std::abs(probAtMean - expectedPDF) < 1e-10);
-
-    // Test symmetry around mean
-    double probAt1 = gaussian.getProbability(1.0);
-    double probAtNeg1 = gaussian.getProbability(-1.0);
-    assert(std::abs(probAt1 - probAtNeg1) < 1e-10);
-
-    // Probability at mean should be higher than at ±1
-    assert(probAtMean > probAt1);
-
-    // Test that probability density at mean is reasonable (should be small for continuous dist)
-    assert(probAtMean < 1.0);   // Should be less than 1 for probability density
-    assert(probAtMean > 1e-10); // Should be greater than zero
-
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
-}
-
-/**
- * Test parameter fitting
- */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
-
-    GaussianDistribution gaussian;
-
-    // Test with known data (should fit mean=3.0, approximate std dev)
-    std::vector<Observation> data = {1.0, 2.0, 3.0, 4.0, 5.0};
-    double expectedMean = 3.0;
-
-    gaussian.fit(data);
-    assert(std::abs(gaussian.getMean() - expectedMean) < 1e-10);
-    assert(gaussian.getStandardDeviation() > 0.0);
-
-    // Test with empty data (should reset to default)
-    std::vector<Observation> emptyData;
-    gaussian.fit(emptyData);
-    assert(gaussian.getMean() == 0.0);
-    assert(gaussian.getStandardDeviation() == 1.0);
-
-    // Test with single point (implementation resets to default for insufficient data)
-    std::vector<Observation> singlePoint = {7.5};
-    gaussian.fit(singlePoint);
-    assert(gaussian.getMean() == 0.0); // Implementation resets to default
-    assert(gaussian.getStandardDeviation() == 1.0);
-
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
-}
-
-/**
- * Test parameter validation
- */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
-
-    // Test invalid constructor parameters
-    try {
-        GaussianDistribution gaussian(0.0, 0.0); // Zero std dev
-        assert(false);                           // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior - validation should catch zero std dev
-    }
-
-    try {
-        GaussianDistribution gaussian(0.0, -1.0); // Negative std dev
-        assert(false);                            // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior - validation should catch negative std dev
-    }
-
-    // Test invalid mean
-    double nan_val = std::numeric_limits<double>::quiet_NaN();
-    double inf_val = std::numeric_limits<double>::infinity();
-
-    try {
-        GaussianDistribution gaussian(nan_val, 1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior - validation should catch NaN mean
-    }
-
-    try {
-        GaussianDistribution gaussian(inf_val, 1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior - validation should catch infinite mean
-    }
-
-    // Test setters validation
+TEST(GaussianDistributionTest, Probabilities) {
     GaussianDistribution gaussian(0.0, 1.0);
 
-    try {
-        gaussian.setMean(nan_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior - setMean should validate input
-    }
+    double probAtMean = gaussian.getProbability(0.0);
+    EXPECT_GT(probAtMean, 0.0);
+    EXPECT_NEAR(probAtMean, 1.0 / math::SQRT_2PI, 1e-10);
 
-    try {
-        gaussian.setStandardDeviation(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior - setStandardDeviation should validate zero
-    }
-
-    try {
-        gaussian.setStandardDeviation(-1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior - setStandardDeviation should validate negative values
-    }
-
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
+    double probAt1 = gaussian.getProbability(1.0);
+    EXPECT_NEAR(probAt1, gaussian.getProbability(-1.0), 1e-10);
+    EXPECT_GT(probAtMean, probAt1);
+    EXPECT_LT(probAtMean, 1.0);
+    EXPECT_GT(probAtMean, 1e-10);
 }
 
-/**
- * Test string representation
- */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(GaussianDistributionTest, Fitting) {
+    GaussianDistribution gaussian;
 
+    std::vector<Observation> data = {1.0, 2.0, 3.0, 4.0, 5.0};
+    gaussian.fit(data);
+    EXPECT_NEAR(gaussian.getMean(), 3.0, 1e-10);
+    EXPECT_GT(gaussian.getStandardDeviation(), 0.0);
+
+    gaussian.fit(std::vector<Observation>{});
+    EXPECT_EQ(gaussian.getMean(), 0.0);
+    EXPECT_EQ(gaussian.getStandardDeviation(), 1.0);
+
+    gaussian.fit(std::vector<Observation>{7.5});
+    EXPECT_EQ(gaussian.getMean(), 0.0);
+    EXPECT_EQ(gaussian.getStandardDeviation(), 1.0);
+}
+
+TEST(GaussianDistributionTest, ParameterValidation) {
+    EXPECT_THROW(GaussianDistribution(0.0, 0.0), std::invalid_argument);
+    EXPECT_THROW(GaussianDistribution(0.0, -1.0), std::invalid_argument);
+    EXPECT_THROW(GaussianDistribution(std::numeric_limits<double>::quiet_NaN(), 1.0), std::invalid_argument);
+    EXPECT_THROW(GaussianDistribution(std::numeric_limits<double>::infinity(), 1.0), std::invalid_argument);
+
+    GaussianDistribution gaussian(0.0, 1.0);
+    EXPECT_THROW(gaussian.setMean(std::numeric_limits<double>::quiet_NaN()), std::invalid_argument);
+    EXPECT_THROW(gaussian.setStandardDeviation(0.0), std::invalid_argument);
+    EXPECT_THROW(gaussian.setStandardDeviation(-1.0), std::invalid_argument);
+}
+
+TEST(GaussianDistributionTest, StringRepresentation) {
     GaussianDistribution gaussian(2.5, 1.5);
     std::string str = gaussian.toString();
-
-    // Should contain key information based on actual output format:
-    // "Gaussian Distribution:\n      μ (mean) = 2.5\n      σ (std. deviation) = 1.5\n      Mean = 2.5\n      Variance = 2.25\n"
-    assert(str.find("Gaussian") != std::string::npos);
-    assert(str.find("Distribution") != std::string::npos);
-    assert(str.find("2.5") != std::string::npos);
-    assert(str.find("1.5") != std::string::npos);
-    assert(str.find("Mean") != std::string::npos);
-    assert(str.find("std. deviation") != std::string::npos);
-
-    std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
+    EXPECT_NE(str.find("Gaussian"), std::string::npos);
+    EXPECT_NE(str.find("Distribution"), std::string::npos);
+    EXPECT_NE(str.find("2.5"), std::string::npos);
+    EXPECT_NE(str.find("1.5"), std::string::npos);
+    EXPECT_NE(str.find("Mean"), std::string::npos);
+    EXPECT_NE(str.find("std. deviation"), std::string::npos);
 }
 
-/**
- * Test copy/move semantics
- */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
-
+TEST(GaussianDistributionTest, CopyMoveSemantics) {
     GaussianDistribution original(3.14, 2.71);
 
-    // Test copy constructor
     GaussianDistribution copied(original);
-    assert(copied.getMean() == original.getMean());
-    assert(copied.getStandardDeviation() == original.getStandardDeviation());
+    EXPECT_EQ(copied.getMean(), original.getMean());
+    EXPECT_EQ(copied.getStandardDeviation(), original.getStandardDeviation());
 
-    // Test copy assignment
     GaussianDistribution assigned;
     assigned = original;
-    assert(assigned.getMean() == original.getMean());
-    assert(assigned.getStandardDeviation() == original.getStandardDeviation());
+    EXPECT_EQ(assigned.getMean(), original.getMean());
+    EXPECT_EQ(assigned.getStandardDeviation(), original.getStandardDeviation());
 
-    // Test move constructor
     GaussianDistribution moved(std::move(original));
-    assert(moved.getMean() == 3.14);
-    assert(moved.getStandardDeviation() == 2.71);
+    EXPECT_EQ(moved.getMean(), 3.14);
+    EXPECT_EQ(moved.getStandardDeviation(), 2.71);
 
-    // Test move assignment
     GaussianDistribution moveAssigned;
     GaussianDistribution temp(1.41, 1.73);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getMean() == 1.41);
-    assert(moveAssigned.getStandardDeviation() == 1.73);
-
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
+    EXPECT_EQ(moveAssigned.getMean(), 1.41);
+    EXPECT_EQ(moveAssigned.getStandardDeviation(), 1.73);
 }
 
-/**
- * Test invalid input handling
- */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(GaussianDistributionTest, InvalidInputHandling) {
+    GaussianDistribution gaussian(0.0, 1.0);
+    EXPECT_EQ(gaussian.getProbability(std::numeric_limits<double>::quiet_NaN()), 0.0);
+    EXPECT_EQ(gaussian.getProbability(std::numeric_limits<double>::infinity()), 0.0);
+    EXPECT_EQ(gaussian.getProbability(-std::numeric_limits<double>::infinity()), 0.0);
+}
 
+TEST(GaussianDistributionTest, LogProbability) {
     GaussianDistribution gaussian(0.0, 1.0);
 
-    // Test with invalid inputs
-    double nan_val = std::numeric_limits<double>::quiet_NaN();
-    double inf_val = std::numeric_limits<double>::infinity();
-    double neg_inf_val = -std::numeric_limits<double>::infinity();
+    EXPECT_NEAR(gaussian.getLogProbability(0.0), std::log(1.0 / math::SQRT_2PI), 1e-10);
+    EXPECT_NEAR(std::exp(gaussian.getLogProbability(0.0)), gaussian.getProbability(0.0), 1e-10);
+    EXPECT_NEAR(gaussian.getLogProbability(1.0), gaussian.getLogProbability(-1.0), 1e-10);
 
-    assert(gaussian.getProbability(nan_val) == 0.0);
-    assert(gaussian.getProbability(inf_val) == 0.0);
-    assert(gaussian.getProbability(neg_inf_val) == 0.0);
-
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
+    EXPECT_TRUE(std::isinf(gaussian.getLogProbability(std::numeric_limits<double>::quiet_NaN())));
+    EXPECT_TRUE(std::isinf(gaussian.getLogProbability(std::numeric_limits<double>::infinity())));
 }
 
-/**
- * Test log probability function
- */
-void testLogProbability() {
-    std::cout << "Testing log probability function..." << std::endl;
-
-    GaussianDistribution gaussian(0.0, 1.0); // Standard normal
-
-    // Test log PDF at mean
-    double logProbAtMean = gaussian.getLogProbability(0.0);
-    double expectedLogPDF = std::log(1.0 / math::SQRT_2PI);
-    assert(std::abs(logProbAtMean - expectedLogPDF) < 1e-10);
-
-    // Test consistency between PDF and log PDF
-    double prob = gaussian.getProbability(0.0);
-    double logProb = gaussian.getLogProbability(0.0);
-    assert(std::abs(prob - std::exp(logProb)) < 1e-10);
-
-    // Test symmetry in log space
-    double logProbAt1 = gaussian.getLogProbability(1.0);
-    double logProbAtNeg1 = gaussian.getLogProbability(-1.0);
-    assert(std::abs(logProbAt1 - logProbAtNeg1) < 1e-10);
-
-    // Test with invalid inputs
-    double nan_val = std::numeric_limits<double>::quiet_NaN();
-    double inf_val = std::numeric_limits<double>::infinity();
-    assert(std::isinf(gaussian.getLogProbability(nan_val)));
-    assert(std::isinf(gaussian.getLogProbability(inf_val)));
-
-    std::cout << "✓ Log probability tests passed" << std::endl;
-}
-
-/**
- * Test additional getters and setters
- */
-void testAdditionalGettersSetters() {
-    std::cout << "Testing additional getters and setters..." << std::endl;
-
+TEST(GaussianDistributionTest, AdditionalGettersSetters) {
     GaussianDistribution gaussian(3.0, 2.0);
+    EXPECT_NEAR(gaussian.getVariance(), 4.0, 1e-10);
 
-    // Test variance getter
-    double variance = gaussian.getVariance();
-    assert(std::abs(variance - 4.0) < 1e-10); // 2.0^2 = 4.0
-
-    // Test setParameters function
     gaussian.setParameters(1.5, 0.5);
-    assert(std::abs(gaussian.getMean() - 1.5) < 1e-10);
-    assert(std::abs(gaussian.getStandardDeviation() - 0.5) < 1e-10);
-    assert(std::abs(gaussian.getVariance() - 0.25) < 1e-10);
+    EXPECT_NEAR(gaussian.getMean(), 1.5, 1e-10);
+    EXPECT_NEAR(gaussian.getStandardDeviation(), 0.5, 1e-10);
+    EXPECT_NEAR(gaussian.getVariance(), 0.25, 1e-10);
 
-    // Test setParameters validation
-    try {
-        gaussian.setParameters(1.0, -1.0); // Invalid std dev
-        assert(false);                     // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior - setParameters should validate inputs
-    }
-
-    std::cout << "✓ Additional getters/setters tests passed" << std::endl;
+    EXPECT_THROW(gaussian.setParameters(1.0, -1.0), std::invalid_argument);
 }
 
-/**
- * Test mathematical correctness with known values
- */
-void testMathematicalCorrectness() {
-    std::cout << "Testing mathematical correctness..." << std::endl;
+TEST(GaussianDistributionTest, MathematicalCorrectness) {
+    GaussianDistribution gaussian1(0.0, 1.0);
+    GaussianDistribution gaussian2(5.0, 2.0);
 
-    // Test with different distributions
-    GaussianDistribution gaussian1(0.0, 1.0); // Standard normal
-    GaussianDistribution gaussian2(5.0, 2.0); // Non-standard
-
-    // Test known PDF values for standard normal
-    // At x=0: PDF = 1/sqrt(2π) ≈ 0.3989422804
-    double pdf0 = gaussian1.getProbability(0.0);
-    assert(std::abs(pdf0 - 0.3989422804) < 1e-8);
-
-    // At x=1: PDF ≈ 0.2419707245
-    double pdf1 = gaussian1.getProbability(1.0);
-    assert(std::abs(pdf1 - 0.2419707245) < 1e-8);
-
-    // Test different distribution
-    // At mean (x=5): PDF = 1/(2*sqrt(2π)) ≈ 0.1994711402
-    double pdf_mean = gaussian2.getProbability(5.0);
-    double expected = 1.0 / (2.0 * math::SQRT_2PI);
-    assert(std::abs(pdf_mean - expected) < 1e-8);
-
-    std::cout << "✓ Mathematical correctness tests passed" << std::endl;
+    EXPECT_NEAR(gaussian1.getProbability(0.0), 0.3989422804, 1e-8);
+    EXPECT_NEAR(gaussian1.getProbability(1.0), 0.2419707245, 1e-8);
+    EXPECT_NEAR(gaussian2.getProbability(5.0), 1.0 / (2.0 * math::SQRT_2PI), 1e-8);
 }
 
-/**
- * Test reset functionality
- */
-void testResetFunctionality() {
-    std::cout << "Testing reset functionality..." << std::endl;
-
+TEST(GaussianDistributionTest, ResetFunctionality) {
     GaussianDistribution gaussian(10.0, 5.0);
     gaussian.reset();
-
-    assert(gaussian.getMean() == 0.0);
-    assert(gaussian.getStandardDeviation() == 1.0);
-
-    std::cout << "✓ Reset functionality tests passed" << std::endl;
+    EXPECT_EQ(gaussian.getMean(), 0.0);
+    EXPECT_EQ(gaussian.getStandardDeviation(), 1.0);
 }
 
-/**
- * Test CDF calculations
- */
-void testCDF() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(GaussianDistributionTest, CDF) {
+    GaussianDistribution gaussian(0.0, 1.0);
 
-    GaussianDistribution gaussian(0.0, 1.0); // Standard normal
+    EXPECT_NEAR(gaussian.getCumulativeProbability(0.0), 0.5, 1e-6);
 
-    // Test CDF at mean (should be 0.5)
-    double cdfAtMean = gaussian.getCumulativeProbability(0.0);
-    assert(std::abs(cdfAtMean - 0.5) < 1e-6);
-
-    // Test CDF symmetry
     double cdfAt1 = gaussian.getCumulativeProbability(1.0);
     double cdfAtNeg1 = gaussian.getCumulativeProbability(-1.0);
-    assert(std::abs(cdfAt1 + cdfAtNeg1 - 1.0) < 1e-6); // Should sum to 1
+    EXPECT_NEAR(cdfAt1 + cdfAtNeg1, 1.0, 1e-6);
 
-    // Test CDF is monotonically increasing
-    assert(gaussian.getCumulativeProbability(-2.0) < gaussian.getCumulativeProbability(-1.0));
-    assert(gaussian.getCumulativeProbability(-1.0) < gaussian.getCumulativeProbability(0.0));
-    assert(gaussian.getCumulativeProbability(0.0) < gaussian.getCumulativeProbability(1.0));
-    assert(gaussian.getCumulativeProbability(1.0) < gaussian.getCumulativeProbability(2.0));
+    EXPECT_LT(gaussian.getCumulativeProbability(-2.0), gaussian.getCumulativeProbability(-1.0));
+    EXPECT_LT(gaussian.getCumulativeProbability(-1.0), gaussian.getCumulativeProbability(0.0));
+    EXPECT_LT(gaussian.getCumulativeProbability(0.0), gaussian.getCumulativeProbability(1.0));
+    EXPECT_LT(gaussian.getCumulativeProbability(1.0), gaussian.getCumulativeProbability(2.0));
 
-    // Test CDF bounds
-    assert(gaussian.getCumulativeProbability(-5.0) >= 0.0 &&
-           gaussian.getCumulativeProbability(-5.0) <= 1.0);
-    assert(gaussian.getCumulativeProbability(5.0) >= 0.0 &&
-           gaussian.getCumulativeProbability(5.0) <= 1.0);
+    EXPECT_GE(gaussian.getCumulativeProbability(-5.0), 0.0);
+    EXPECT_LE(gaussian.getCumulativeProbability(-5.0), 1.0);
+    EXPECT_LT(gaussian.getCumulativeProbability(-10.0), 0.001);
+    EXPECT_GT(gaussian.getCumulativeProbability(10.0), 0.999);
 
-    // Test that CDF approaches bounds
-    assert(gaussian.getCumulativeProbability(-10.0) < 0.001); // Should be very small
-    assert(gaussian.getCumulativeProbability(10.0) > 0.999);  // Should be very close to 1
-
-    // Test with different parameters
     GaussianDistribution gaussian2(2.0, 0.5);
-    double cdfAtMean2 = gaussian2.getCumulativeProbability(2.0);
-    assert(std::abs(cdfAtMean2 - 0.5) < 1e-6);
+    EXPECT_NEAR(gaussian2.getCumulativeProbability(2.0), 0.5, 1e-6);
 
-    // Test with invalid inputs
-    double nan_val = std::numeric_limits<double>::quiet_NaN();
-    assert(gaussian.getCumulativeProbability(nan_val) == 0.0); // CDF returns 0.0 for NaN input
-
-    std::cout << "✓ CDF calculation tests passed" << std::endl;
+    EXPECT_EQ(gaussian.getCumulativeProbability(std::numeric_limits<double>::quiet_NaN()), 0.0);
 }
 
-/**
- * Test equality operators and I/O
- */
-void testEqualityAndIO() {
-    std::cout << "Testing equality operators and I/O..." << std::endl;
-
+TEST(GaussianDistributionTest, EqualityAndIO) {
     GaussianDistribution g1(2.5, 1.5);
     GaussianDistribution g2(2.5, 1.5);
-    GaussianDistribution g3(2.5, 1.6); // Different std dev
-    GaussianDistribution g4(2.6, 1.5); // Different mean
+    GaussianDistribution g3(2.5, 1.6);
+    GaussianDistribution g4(2.6, 1.5);
 
-    // Test equality operator
-    assert(g1 == g2);
-    assert(g2 == g1); // Symmetric
+    EXPECT_TRUE(g1 == g2);
+    EXPECT_TRUE(g2 == g1);
+    EXPECT_FALSE(g1 == g3);
+    EXPECT_FALSE(g1 == g4);
+    EXPECT_TRUE(g1 != g3);
+    EXPECT_TRUE(g1 == g1);
+    EXPECT_TRUE(g1 == GaussianDistribution(2.5, 1.5 + 1e-15));
+    EXPECT_FALSE(g1 == GaussianDistribution(2.5, 1.5 + 1e-5));
 
-    // Test inequality
-    assert(!(g1 == g3));
-    assert(!(g1 == g4));
-    assert(g1 != g3);
-    assert(g1 != g4);
-
-    // Test self-equality
-    assert(g1 == g1);
-
-    // Test with very small differences (within tolerance)
-    GaussianDistribution g5(2.5, 1.5 + 1e-15); // Very small difference
-    assert(g1 == g5);                          // Should be equal within tolerance
-
-    // Test with differences larger than tolerance
-    GaussianDistribution g6(2.5, 1.5 + 1e-5); // Larger difference
-    assert(!(g1 == g6));                      // Should not be equal
-
-    // Test stream output
     std::ostringstream oss;
     oss << g1;
     std::string output = oss.str();
-    assert(output.find("Gaussian Distribution") != std::string::npos);
-    assert(output.find("2.5") != std::string::npos);
-    assert(output.find("1.5") != std::string::npos);
+    EXPECT_NE(output.find("Gaussian Distribution"), std::string::npos);
+    EXPECT_NE(output.find("2.5"), std::string::npos);
+    EXPECT_NE(output.find("1.5"), std::string::npos);
 
-    std::cout << "Stream output: " << output << std::endl;
-
-    // Test stream input
-    std::istringstream iss("Mean = 3.14 Standard deviation = 2.71");
-    GaussianDistribution inputDist;
-    iss >> inputDist;
-
-    if (iss.good()) {
-        assert(std::abs(inputDist.getMean() - 3.14) < 1e-10);
-        assert(std::abs(inputDist.getStandardDeviation() - 2.71) < 1e-10);
-    }
-
-    // Test input operator with invalid data
     std::istringstream invalid_iss("invalid data format");
     GaussianDistribution invalid_test;
     invalid_iss >> invalid_test;
-    assert(invalid_iss.fail()); // Stream should be in failed state
-
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
+    EXPECT_TRUE(invalid_iss.fail());
 }
 
-/**
- * Test caching mechanism
- */
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
-
+TEST(GaussianDistributionTest, Caching) {
     GaussianDistribution gaussian(1.0, 2.0);
 
-    // Get some probability values (this should populate cache)
-    // Use the mean value for maximum sensitivity
     double prob1 = gaussian.getProbability(1.0);
     double logProb1 = gaussian.getLogProbability(1.0);
+    EXPECT_NEAR(prob1, std::exp(logProb1), 1e-10);
 
-    // Verify consistency between PDF and log PDF
-    assert(std::abs(prob1 - std::exp(logProb1)) < 1e-10);
+    gaussian.setMean(3.0);
+    double prob2 = gaussian.getProbability(1.0);
+    EXPECT_GT(std::abs(prob1 - prob2), 1e-6);
+    EXPECT_NEAR(prob2, std::exp(gaussian.getLogProbability(1.0)), 1e-10);
 
-    // Change parameters (this should invalidate cache)
-    gaussian.setMean(3.0); // Bigger change for clearer difference
+    double prob3 = gaussian.getProbability(3.0);
+    gaussian.setStandardDeviation(1.0);
+    EXPECT_GT(std::abs(prob3 - gaussian.getProbability(3.0)), 1e-6);
 
-    // Get probability again (should use updated parameters)
-    double prob2 = gaussian.getProbability(1.0); // Same x value
-    double logProb2 = gaussian.getLogProbability(1.0);
-
-    // Values should be different due to parameter change
-    assert(std::abs(prob1 - prob2) > 1e-6);
-    assert(std::abs(logProb1 - logProb2) > 1e-6);
-
-    // Verify consistency with new parameters
-    assert(std::abs(prob2 - std::exp(logProb2)) < 1e-10);
-
-    // Test cache invalidation with setStandardDeviation
-    double prob3 = gaussian.getProbability(3.0); // Use current mean
-    gaussian.setStandardDeviation(1.0);          // Change std dev significantly
-    double prob4 = gaussian.getProbability(3.0);
-    assert(std::abs(prob3 - prob4) > 1e-6);
-
-    // Test cache invalidation with setParameters
     double prob5 = gaussian.getProbability(3.0);
-    gaussian.setParameters(0.0, 1.0); // Change to standard normal
-    double prob6 = gaussian.getProbability(3.0);
-    assert(std::abs(prob5 - prob6) > 1e-6);
+    gaussian.setParameters(0.0, 1.0);
+    EXPECT_GT(std::abs(prob5 - gaussian.getProbability(3.0)), 1e-6);
 
-    // Test cache invalidation with reset
-    // Change the parameters first then reset to see cache invalidation
     gaussian.setMean(5.0);
     double prob_before_reset = gaussian.getProbability(0.0);
     gaussian.reset();
-    double prob_after_reset = gaussian.getProbability(0.0);
-    assert(std::abs(prob_before_reset - prob_after_reset) > 1e-6);
-
-    std::cout << "✓ Caching mechanism tests passed" << std::endl;
+    EXPECT_GT(std::abs(prob_before_reset - gaussian.getProbability(0.0)), 1e-6);
 }
 
-/**
- * Test performance characteristics to verify optimizations
- * This serves as a benchmark and regression test for performance
- */
-void testPerformance() {
-    std::cout << "Testing performance characteristics..." << std::endl;
-
+TEST(GaussianDistributionTest, Performance) {
     using namespace std::chrono;
     GaussianDistribution gaussian(0.0, 1.0);
 
-    // Test parameters
     const int pdf_iterations = 100000;
     const int fit_datapoints = 5000;
 
-    // Generate test values for PDF calls
     std::vector<double> testValues;
     testValues.reserve(pdf_iterations);
     for (int i = 0; i < pdf_iterations; ++i) {
         testValues.push_back(-3.0 + (6.0 * i) / pdf_iterations);
     }
 
-    // Test getProbability() performance (should benefit from caching)
     auto start = high_resolution_clock::now();
     double sum_pdf = 0.0;
-    for (const auto &val : testValues) {
-        sum_pdf += gaussian.getProbability(val);
-    }
+    for (const auto &val : testValues) { sum_pdf += gaussian.getProbability(val); }
     auto end = high_resolution_clock::now();
-    auto pdf_duration = duration_cast<microseconds>(end - start);
+    double pdf_per_call = static_cast<double>(duration_cast<microseconds>(end - start).count()) / pdf_iterations;
 
-    // Test getLogProbability() performance (should benefit from cached 1/σ and log(σ))
     start = high_resolution_clock::now();
     double sum_log_pdf = 0.0;
-    for (const auto &val : testValues) {
-        sum_log_pdf += gaussian.getLogProbability(val);
-    }
+    for (const auto &val : testValues) { sum_log_pdf += gaussian.getLogProbability(val); }
     end = high_resolution_clock::now();
-    auto log_pdf_duration = duration_cast<microseconds>(end - start);
+    double log_pdf_per_call = static_cast<double>(duration_cast<microseconds>(end - start).count()) / pdf_iterations;
 
-    // Test fitting performance with Welford's algorithm
-    std::vector<double> fit_data;
-    fit_data.reserve(fit_datapoints);
-    for (int i = 0; i < fit_datapoints; ++i) {
-        fit_data.push_back(i * 0.001); // Linear data for consistent testing
-    }
-
+    std::vector<double> fit_data(fit_datapoints);
+    for (int i = 0; i < fit_datapoints; ++i) { fit_data[i] = i * 0.001; }
     start = high_resolution_clock::now();
     gaussian.fit(fit_data);
     end = high_resolution_clock::now();
-    auto fit_duration = duration_cast<microseconds>(end - start);
+    double fit_per_point = static_cast<double>(duration_cast<microseconds>(end - start).count()) / fit_datapoints;
 
-    // Performance expectations (reasonable thresholds for regression testing)
-    double pdf_per_call = static_cast<double>(pdf_duration.count()) / pdf_iterations;
-    double log_pdf_per_call = static_cast<double>(log_pdf_duration.count()) / pdf_iterations;
-    double fit_per_point = static_cast<double>(fit_duration.count()) / fit_datapoints;
+    std::cout << std::fixed << std::setprecision(3)
+              << "  PDF: " << pdf_per_call << " μs/call"
+              << "  LogPDF: " << log_pdf_per_call << " μs/call"
+              << "  Fit: " << fit_per_point << " μs/point\n";
 
-    // Basic performance assertions (adjust thresholds based on typical performance)
-    // These should be conservative to avoid false failures on different hardware
-    assert(pdf_per_call < 1.0);     // Should be well under 1 microsecond per PDF call
-    assert(log_pdf_per_call < 1.0); // Should be well under 1 microsecond per log PDF call
-    assert(fit_per_point < 10.0);   // Should be well under 10 microseconds per fit datapoint
-
-    // Verify correctness (prevent compiler optimization removal)
-    assert(sum_pdf > 0.0);
-    assert(sum_log_pdf < 0.0); // Log probabilities should be negative
-
-    std::cout << std::fixed << std::setprecision(3);
-    std::cout << "  PDF timing:       " << pdf_per_call << " μs/call (" << pdf_iterations
-              << " calls)" << std::endl;
-    std::cout << "  Log PDF timing:   " << log_pdf_per_call << " μs/call (" << pdf_iterations
-              << " calls)" << std::endl;
-    std::cout << "  Fit timing:       " << fit_per_point << " μs/point (" << fit_datapoints
-              << " points)" << std::endl;
-    std::cout << "✓ Performance tests passed" << std::endl;
+    EXPECT_LT(pdf_per_call, 1.0);
+    EXPECT_LT(log_pdf_per_call, 1.0);
+    EXPECT_LT(fit_per_point, 10.0);
+    EXPECT_GT(sum_pdf, 0.0);
+    EXPECT_LT(sum_log_pdf, 0.0);
 }
 
-int main() {
-    std::cout << "Running Gaussian distribution tests..." << std::endl;
-    std::cout << "======================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testLogProbability();
-        testAdditionalGettersSetters();
-        testMathematicalCorrectness();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testInvalidInputHandling();
-        testResetFunctionality();
-        testCDF();
-        testEqualityAndIO();
-        testCaching();
-        testPerformance();
-
-        std::cout << "======================================" << std::endl;
-        std::cout << "✅ All Gaussian distribution tests passed!" << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_gaussian_distribution.cpp
+++ b/tests/distributions/test_gaussian_distribution.cpp
@@ -57,8 +57,10 @@ TEST(GaussianDistributionTest, Fitting) {
 TEST(GaussianDistributionTest, ParameterValidation) {
     EXPECT_THROW(GaussianDistribution(0.0, 0.0), std::invalid_argument);
     EXPECT_THROW(GaussianDistribution(0.0, -1.0), std::invalid_argument);
-    EXPECT_THROW(GaussianDistribution(std::numeric_limits<double>::quiet_NaN(), 1.0), std::invalid_argument);
-    EXPECT_THROW(GaussianDistribution(std::numeric_limits<double>::infinity(), 1.0), std::invalid_argument);
+    EXPECT_THROW(GaussianDistribution(std::numeric_limits<double>::quiet_NaN(), 1.0),
+                 std::invalid_argument);
+    EXPECT_THROW(GaussianDistribution(std::numeric_limits<double>::infinity(), 1.0),
+                 std::invalid_argument);
 
     GaussianDistribution gaussian(0.0, 1.0);
     EXPECT_THROW(gaussian.setMean(std::numeric_limits<double>::quiet_NaN()), std::invalid_argument);
@@ -240,25 +242,33 @@ TEST(GaussianDistributionTest, Performance) {
 
     auto start = high_resolution_clock::now();
     double sum_pdf = 0.0;
-    for (const auto &val : testValues) { sum_pdf += gaussian.getProbability(val); }
+    for (const auto &val : testValues) {
+        sum_pdf += gaussian.getProbability(val);
+    }
     auto end = high_resolution_clock::now();
-    double pdf_per_call = static_cast<double>(duration_cast<microseconds>(end - start).count()) / pdf_iterations;
+    double pdf_per_call =
+        static_cast<double>(duration_cast<microseconds>(end - start).count()) / pdf_iterations;
 
     start = high_resolution_clock::now();
     double sum_log_pdf = 0.0;
-    for (const auto &val : testValues) { sum_log_pdf += gaussian.getLogProbability(val); }
+    for (const auto &val : testValues) {
+        sum_log_pdf += gaussian.getLogProbability(val);
+    }
     end = high_resolution_clock::now();
-    double log_pdf_per_call = static_cast<double>(duration_cast<microseconds>(end - start).count()) / pdf_iterations;
+    double log_pdf_per_call =
+        static_cast<double>(duration_cast<microseconds>(end - start).count()) / pdf_iterations;
 
     std::vector<double> fit_data(fit_datapoints);
-    for (int i = 0; i < fit_datapoints; ++i) { fit_data[i] = i * 0.001; }
+    for (int i = 0; i < fit_datapoints; ++i) {
+        fit_data[i] = i * 0.001;
+    }
     start = high_resolution_clock::now();
     gaussian.fit(fit_data);
     end = high_resolution_clock::now();
-    double fit_per_point = static_cast<double>(duration_cast<microseconds>(end - start).count()) / fit_datapoints;
+    double fit_per_point =
+        static_cast<double>(duration_cast<microseconds>(end - start).count()) / fit_datapoints;
 
-    std::cout << std::fixed << std::setprecision(3)
-              << "  PDF: " << pdf_per_call << " μs/call"
+    std::cout << std::fixed << std::setprecision(3) << "  PDF: " << pdf_per_call << " μs/call"
               << "  LogPDF: " << log_pdf_per_call << " μs/call"
               << "  Fit: " << fit_per_point << " μs/point\n";
 

--- a/tests/distributions/test_log_normal_distribution.cpp
+++ b/tests/distributions/test_log_normal_distribution.cpp
@@ -1,19 +1,13 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <limits>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 #include "libhmm/distributions/log_normal_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::LogNormalDistribution;
 using libhmm::Observation;
@@ -21,98 +15,91 @@ using libhmm::Observation;
 /**
  * Test basic LogNormal distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic LogNormal distribution functionality..." << std::endl;
+TEST(LogNormalDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     LogNormalDistribution lognormal;
-    assert(lognormal.getMean() == 0.0);
-    assert(lognormal.getStandardDeviation() == 1.0);
+    EXPECT_EQ(lognormal.getMean(), 0.0);
+    EXPECT_EQ(lognormal.getStandardDeviation(), 1.0);
 
     // Test parameterized constructor
     LogNormalDistribution lognormal2(5.0, 2.5);
-    assert(lognormal2.getMean() == 5.0);
-    assert(lognormal2.getStandardDeviation() == 2.5);
+    EXPECT_EQ(lognormal2.getMean(), 5.0);
+    EXPECT_EQ(lognormal2.getStandardDeviation(), 2.5);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(LogNormalDistributionTest, Probabilities) {
 
     LogNormalDistribution lognormal(0.0, 1.0);
 
     // Test that probability is zero for non-positive values
-    assert(lognormal.getProbability(0.0) == 0.0);
-    assert(lognormal.getProbability(-1.0) == 0.0);
-    assert(lognormal.getProbability(-0.5) == 0.0);
+    EXPECT_EQ(lognormal.getProbability(0.0), 0.0);
+    EXPECT_EQ(lognormal.getProbability(-1.0), 0.0);
+    EXPECT_EQ(lognormal.getProbability(-0.5), 0.0);
 
     // Test that probability is positive for positive values
     double prob1 = lognormal.getProbability(1.0);
     double prob2 = lognormal.getProbability(2.0);
     double prob3 = lognormal.getProbability(0.5);
 
-    assert(prob1 > 0.0);
-    assert(prob2 > 0.0);
-    assert(prob3 > 0.0);
+    EXPECT_GT(prob1, 0.0);
+    EXPECT_GT(prob2, 0.0);
+    EXPECT_GT(prob3, 0.0);
 
     // Test that probability density is reasonable (should be small for continuous dist)
-    assert(prob1 < 1.0);   // Should be less than 1 for probability density
-    assert(prob1 > 1e-10); // Should be greater than zero
+    EXPECT_LT(prob1, 1.0);   // Should be less than 1 for probability density
+    EXPECT_GT(prob1, 1e-10); // Should be greater than zero
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(LogNormalDistributionTest, Fitting) {
 
     LogNormalDistribution lognormal;
 
     // Test with known data
     std::vector<Observation> data = {1.0, 2.0, 3.0, 4.0, 5.0};
     lognormal.fit(data);
-    assert(lognormal.getMean() > 0.0); // Should have some reasonable value
-    assert(lognormal.getStandardDeviation() > 0.0);
+    EXPECT_GT(lognormal.getMean(), 0.0); // Should have some reasonable value
+    EXPECT_GT(lognormal.getStandardDeviation(), 0.0);
 
     // Test with empty data (should reset to default)
     std::vector<Observation> emptyData;
     lognormal.fit(emptyData);
-    assert(lognormal.getMean() == 0.0);
-    assert(lognormal.getStandardDeviation() == 1.0);
+    EXPECT_EQ(lognormal.getMean(), 0.0);
+    EXPECT_EQ(lognormal.getStandardDeviation(), 1.0);
 
     // Test with single point (should fit based on actual behavior)
     std::vector<Observation> singlePoint = {2.5};
     lognormal.fit(singlePoint);
     // Based on debug output: mean=0.916291, stddev=1e-30
-    assert(lognormal.getMean() > 0.0);
-    assert(lognormal.getStandardDeviation() > 0.0);
+    EXPECT_GT(lognormal.getMean(), 0.0);
+    EXPECT_GT(lognormal.getStandardDeviation(), 0.0);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(LogNormalDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
     try {
         LogNormalDistribution lognormal(0.0, 0.0); // Zero std dev
-        assert(false);                             // Should not reach here
+        ADD_FAILURE();                             // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         LogNormalDistribution lognormal(0.0, -1.0); // Negative std dev
-        assert(false);                              // Should not reach here
+        ADD_FAILURE();                              // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
@@ -121,108 +108,77 @@ void testParameterValidation() {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        LogNormalDistribution lognormal(nan_val, 1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(LogNormalDistribution lognormal(nan_val, 1.0), std::invalid_argument);
 
-    try {
-        LogNormalDistribution lognormal(inf_val, 1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(LogNormalDistribution lognormal(inf_val, 1.0), std::invalid_argument);
 
     // Test setters validation
     LogNormalDistribution lognormal(0.0, 1.0);
 
-    try {
-        lognormal.setMean(nan_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(lognormal.setMean(nan_val), std::invalid_argument);
 
-    try {
-        lognormal.setStandardDeviation(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(lognormal.setStandardDeviation(0.0), std::invalid_argument);
 
-    try {
-        lognormal.setStandardDeviation(-1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(lognormal.setStandardDeviation(-1.0), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(LogNormalDistributionTest, StringRepresentation) {
 
     LogNormalDistribution lognormal(2.5, 1.5);
     std::string str = lognormal.toString();
 
     // Should contain key information based on new format:
     // "LogNormal Distribution:\n      μ (log mean) = 2.5\n      σ (log std. deviation) = 1.5\n      Mean = ...\n      Variance = ...\n"
-    assert(str.find("LogNormal") != std::string::npos);
-    assert(str.find("Distribution") != std::string::npos);
-    assert(str.find("2.5") != std::string::npos);
-    assert(str.find("1.5") != std::string::npos);
-    assert(str.find("Mean") != std::string::npos);
-    assert(str.find("log std. deviation") != std::string::npos);
+    EXPECT_NE(str.find("LogNormal"), std::string::npos);
+    EXPECT_NE(str.find("Distribution"), std::string::npos);
+    EXPECT_NE(str.find("2.5"), std::string::npos);
+    EXPECT_NE(str.find("1.5"), std::string::npos);
+    EXPECT_NE(str.find("Mean"), std::string::npos);
+    EXPECT_NE(str.find("log std. deviation"), std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(LogNormalDistributionTest, CopyMoveSemantics) {
 
     LogNormalDistribution original(3.14, 2.71);
 
     // Test copy constructor
     LogNormalDistribution copied(original);
-    assert(copied.getMean() == original.getMean());
-    assert(copied.getStandardDeviation() == original.getStandardDeviation());
+    EXPECT_EQ(copied.getMean(), original.getMean());
+    EXPECT_EQ(copied.getStandardDeviation(), original.getStandardDeviation());
 
     // Test copy assignment
     LogNormalDistribution assigned;
     assigned = original;
-    assert(assigned.getMean() == original.getMean());
-    assert(assigned.getStandardDeviation() == original.getStandardDeviation());
+    EXPECT_EQ(assigned.getMean(), original.getMean());
+    EXPECT_EQ(assigned.getStandardDeviation(), original.getStandardDeviation());
 
     // Test move constructor
     LogNormalDistribution moved(std::move(original));
-    assert(moved.getMean() == 3.14);
-    assert(moved.getStandardDeviation() == 2.71);
+    EXPECT_EQ(moved.getMean(), 3.14);
+    EXPECT_EQ(moved.getStandardDeviation(), 2.71);
 
     // Test move assignment
     LogNormalDistribution moveAssigned;
     LogNormalDistribution temp(1.41, 1.73);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getMean() == 1.41);
-    assert(moveAssigned.getStandardDeviation() == 1.73);
+    EXPECT_EQ(moveAssigned.getMean(), 1.41);
+    EXPECT_EQ(moveAssigned.getStandardDeviation(), 1.73);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test invalid input handling
  */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(LogNormalDistributionTest, InvalidInputHandling) {
 
     LogNormalDistribution lognormal(0.0, 1.0);
 
@@ -231,61 +187,55 @@ void testInvalidInputHandling() {
     double inf_val = std::numeric_limits<double>::infinity();
     double neg_inf_val = -std::numeric_limits<double>::infinity();
 
-    assert(lognormal.getProbability(nan_val) == 0.0);
-    assert(lognormal.getProbability(inf_val) == 0.0);
-    assert(lognormal.getProbability(neg_inf_val) == 0.0);
+    EXPECT_EQ(lognormal.getProbability(nan_val), 0.0);
+    EXPECT_EQ(lognormal.getProbability(inf_val), 0.0);
+    EXPECT_EQ(lognormal.getProbability(neg_inf_val), 0.0);
 
     // Negative and zero values should return 0
-    assert(lognormal.getProbability(-1.0) == 0.0);
-    assert(lognormal.getProbability(0.0) == 0.0);
+    EXPECT_EQ(lognormal.getProbability(-1.0), 0.0);
+    EXPECT_EQ(lognormal.getProbability(0.0), 0.0);
 
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
 }
 
 /**
  * Test reset functionality
  */
-void testResetFunctionality() {
-    std::cout << "Testing reset functionality..." << std::endl;
+TEST(LogNormalDistributionTest, ResetFunctionality) {
 
     LogNormalDistribution lognormal(10.0, 5.0);
     lognormal.reset();
 
-    assert(lognormal.getMean() == 0.0);
-    assert(lognormal.getStandardDeviation() == 1.0);
+    EXPECT_EQ(lognormal.getMean(), 0.0);
+    EXPECT_EQ(lognormal.getStandardDeviation(), 1.0);
 
-    std::cout << "✓ Reset functionality tests passed" << std::endl;
 }
 
 /**
  * Test relationship to normal distribution
  */
-void testLogNormalProperties() {
-    std::cout << "Testing LogNormal distribution properties..." << std::endl;
+TEST(LogNormalDistributionTest, LogNormalProperties) {
 
     LogNormalDistribution lognormal(0.0, 1.0);
 
     // Test that log-normal is only defined for positive values
-    assert(lognormal.getProbability(0.0) == 0.0);
-    assert(lognormal.getProbability(-1.0) == 0.0);
+    EXPECT_EQ(lognormal.getProbability(0.0), 0.0);
+    EXPECT_EQ(lognormal.getProbability(-1.0), 0.0);
 
     // Test some positive values
     double prob1 = lognormal.getProbability(1.0);
     double prob2 = lognormal.getProbability(2.0);
     double prob3 = lognormal.getProbability(0.5);
 
-    assert(prob1 > 0.0);
-    assert(prob2 > 0.0);
-    assert(prob3 > 0.0);
+    EXPECT_GT(prob1, 0.0);
+    EXPECT_GT(prob2, 0.0);
+    EXPECT_GT(prob3, 0.0);
 
-    std::cout << "✓ LogNormal property tests passed" << std::endl;
 }
 
 /**
  * Test fitting validation
  */
-void testFittingValidation() {
-    std::cout << "Testing fitting validation..." << std::endl;
+TEST(LogNormalDistributionTest, FittingValidation) {
 
     LogNormalDistribution lognormal;
 
@@ -296,53 +246,49 @@ void testFittingValidation() {
     // by ignoring them (they're not in the support)
     lognormal.fit(invalidData);
     // Should have fitted to positive values {1.0, 2.0, 3.0}
-    assert(lognormal.getMean() > 0.0);
-    assert(lognormal.getStandardDeviation() > 0.0);
+    EXPECT_GT(lognormal.getMean(), 0.0);
+    EXPECT_GT(lognormal.getStandardDeviation(), 0.0);
 
     // Test with zero values (should be ignored)
     std::vector<Observation> zeroData = {0.0, 1.0, 2.0};
     lognormal.fit(zeroData);
     // Should have fitted to positive values {1.0, 2.0}
-    assert(lognormal.getMean() > 0.0);
-    assert(lognormal.getStandardDeviation() > 0.0);
+    EXPECT_GT(lognormal.getMean(), 0.0);
+    EXPECT_GT(lognormal.getStandardDeviation(), 0.0);
 
-    std::cout << "✓ Fitting validation tests passed" << std::endl;
 }
 
 /**
  * Test statistical moments
  */
-void testStatisticalMoments() {
-    std::cout << "Testing statistical moments..." << std::endl;
+TEST(LogNormalDistributionTest, StatisticalMoments) {
 
     LogNormalDistribution lognormal(1.0, 0.5);
 
     // For Log-Normal(μ=1.0, σ=0.5):
     // Distribution mean = exp(μ + σ²/2) = exp(1.0 + 0.25/2) = exp(1.125)
     double expectedDistMean = std::exp(1.0 + 0.25 / 2.0);
-    assert(std::abs(lognormal.getDistributionMean() - expectedDistMean) < 1e-10);
+    EXPECT_NEAR(lognormal.getDistributionMean(), expectedDistMean, 1e-10);
 
     // Distribution variance = (exp(σ²) - 1) * exp(2μ + σ²)
     //                      = (exp(0.25) - 1) * exp(2.0 + 0.25)
     double expectedVar = (std::exp(0.25) - 1.0) * std::exp(2.0 + 0.25);
-    assert(std::abs(lognormal.getVariance() - expectedVar) < 1e-10);
+    EXPECT_NEAR(lognormal.getVariance(), expectedVar, 1e-10);
 
     // Test median = exp(μ) = exp(1.0) ≈ 2.718
     double expectedMedian = std::exp(1.0);
-    assert(std::abs(lognormal.getMedian() - expectedMedian) < 1e-10);
+    EXPECT_NEAR(lognormal.getMedian(), expectedMedian, 1e-10);
 
     // Test mode = exp(μ - σ²) = exp(1.0 - 0.25) = exp(0.75)
     double expectedMode = std::exp(1.0 - 0.25);
-    assert(std::abs(lognormal.getMode() - expectedMode) < 1e-10);
+    EXPECT_NEAR(lognormal.getMode(), expectedMode, 1e-10);
 
-    std::cout << "✓ Statistical moments tests passed" << std::endl;
 }
 
 /**
  * Test log probability calculations (Gold Standard)
  */
-void testLogProbability() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(LogNormalDistributionTest, LogProbability) {
 
     LogNormalDistribution lognormal(0.0, 1.0); // Standard log-normal
 
@@ -355,9 +301,9 @@ void testLogProbability() {
     double logP2 = lognormal.getLogProbability(x2);
     double logP3 = lognormal.getLogProbability(x3);
 
-    assert(std::isfinite(logP1));
-    assert(std::isfinite(logP2));
-    assert(std::isfinite(logP3));
+    EXPECT_TRUE(std::isfinite(logP1));
+    EXPECT_TRUE(std::isfinite(logP2));
+    EXPECT_TRUE(std::isfinite(logP3));
 
     // For Log-Normal(0,1): log(f(x)) = -ln(x) - ln(√(2π)) - ½(ln(x))²
     double expectedLogP1 =
@@ -367,77 +313,73 @@ void testLogProbability() {
     double expectedLogP3 =
         -std::log(x3) - 0.5 * std::log(2.0 * M_PI) - 0.5 * std::pow(std::log(x3), 2);
 
-    assert(std::abs(logP1 - expectedLogP1) < 1e-10);
-    assert(std::abs(logP2 - expectedLogP2) < 1e-10);
-    assert(std::abs(logP3 - expectedLogP3) < 1e-10);
+    EXPECT_NEAR(logP1, expectedLogP1, 1e-10);
+    EXPECT_NEAR(logP2, expectedLogP2, 1e-10);
+    EXPECT_NEAR(logP3, expectedLogP3, 1e-10);
 
     // Test invalid inputs return -infinity
-    assert(lognormal.getLogProbability(-0.1) == -std::numeric_limits<double>::infinity());
-    assert(lognormal.getLogProbability(0.0) == -std::numeric_limits<double>::infinity());
-    assert(std::isnan(lognormal.getLogProbability(std::numeric_limits<double>::quiet_NaN())) ||
-           lognormal.getLogProbability(std::numeric_limits<double>::quiet_NaN()) ==
-               -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(lognormal.getLogProbability(-0.1), -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(lognormal.getLogProbability(0.0), -std::numeric_limits<double>::infinity());
+    EXPECT_TRUE(std::isnan(lognormal.getLogProbability(std::numeric_limits<double>::quiet_NaN())) ||
+                lognormal.getLogProbability(std::numeric_limits<double>::quiet_NaN()) ==
+                    -std::numeric_limits<double>::infinity());
 
-    std::cout << "✓ Log probability tests passed" << std::endl;
 }
 
 /**
  * Test CDF calculations (Gold Standard)
  */
-void testCDFCalculations() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(LogNormalDistributionTest, CDFCalculations) {
 
     LogNormalDistribution lognormal(0.0, 1.0);
 
     // Test boundary values
-    assert(lognormal.getCumulativeProbability(-0.1) == 0.0);
-    assert(lognormal.getCumulativeProbability(0.0) == 0.0);
+    EXPECT_EQ(lognormal.getCumulativeProbability(-0.1), 0.0);
+    EXPECT_EQ(lognormal.getCumulativeProbability(0.0), 0.0);
 
     // Test monotonicity
     double cdf1 = lognormal.getCumulativeProbability(0.5);
     double cdf2 = lognormal.getCumulativeProbability(1.0);
     double cdf3 = lognormal.getCumulativeProbability(2.0);
-    assert(cdf1 < cdf2);
-    assert(cdf2 < cdf3);
+    EXPECT_LT(cdf1, cdf2);
+    EXPECT_LT(cdf2, cdf3);
 
     // Test that CDF values are in [0,1]
-    assert(cdf1 >= 0.0 && cdf1 <= 1.0);
-    assert(cdf2 >= 0.0 && cdf2 <= 1.0);
-    assert(cdf3 >= 0.0 && cdf3 <= 1.0);
+    EXPECT_TRUE(cdf1 >= 0.0 && cdf1 <= 1.0);
+    EXPECT_TRUE(cdf2 >= 0.0 && cdf2 <= 1.0);
+    EXPECT_TRUE(cdf3 >= 0.0 && cdf3 <= 1.0);
 
     // Test known value: for Log-Normal(0,1), CDF(1) = 0.5 (median)
     double cdfAt1 = lognormal.getCumulativeProbability(1.0);
-    assert(std::abs(cdfAt1 - 0.5) < 1e-6);
+    EXPECT_NEAR(cdfAt1, 0.5, 1e-6);
 
     // Test approach to 1 for large values
     double cdfLarge = lognormal.getCumulativeProbability(100.0);
-    assert(cdfLarge > 0.99);
+    EXPECT_GT(cdfLarge, 0.99);
 
-    std::cout << "✓ CDF calculation tests passed" << std::endl;
 }
 
 /**
  * Test equality and I/O operators (Gold Standard)
  */
-void testEqualityAndIO() {
-    std::cout << "Testing equality and I/O operators..." << std::endl;
+TEST(LogNormalDistributionTest, EqualityAndIO) {
 
     LogNormalDistribution ln1(2.0, 1.5);
     LogNormalDistribution ln2(2.0, 1.5);
     LogNormalDistribution ln3(3.0, 1.5);
 
-    assert(ln1 == ln2);
-    assert(ln2 == ln1);
-    assert(!(ln1 == ln3));
-    assert(ln1 != ln3);
+    EXPECT_EQ(ln1, ln2);
+    EXPECT_EQ(ln2, ln1);
+    EXPECT_FALSE(ln1 == ln3);
+    EXPECT_NE(ln1, ln3);
 
     std::ostringstream oss;
     oss << ln1;
     std::string output = oss.str();
-    assert(output.find("LogNormal Distribution") != std::string::npos);
+    EXPECT_NE(output.find("LogNormal Distribution"), std::string::npos);
     // Check for mean and standard deviation values in the output format
-    assert(output.find("Mean") != std::string::npos);
-    assert(output.find("std. deviation") != std::string::npos);
+    EXPECT_NE(output.find("Mean"), std::string::npos);
+    EXPECT_NE(output.find("std. deviation"), std::string::npos);
 
     // Test stream input operator
     std::istringstream iss(output);
@@ -445,17 +387,15 @@ void testEqualityAndIO() {
     iss >> inputDist;
 
     if (iss.good() || iss.eof()) {
-        assert(inputDist == ln1);
+        EXPECT_EQ(inputDist, ln1);
     }
 
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
 }
 
 /**
  * Test numerical stability (Gold Standard)
  */
-void testNumericalStability() {
-    std::cout << "Testing numerical stability..." << std::endl;
+TEST(LogNormalDistributionTest, NumericalStability) {
 
     // Test extreme parameter values
     LogNormalDistribution smallSigma(0.0, 0.1);
@@ -466,30 +406,28 @@ void testNumericalStability() {
     double probLarge = largeSigma.getProbability(1.0);
     double probLargeMu = largeMu.getProbability(1000.0);
 
-    assert(probSmall > 0.0 && std::isfinite(probSmall));
-    assert(probLarge > 0.0 && std::isfinite(probLarge));
-    assert(probLargeMu > 0.0 && std::isfinite(probLargeMu));
+    EXPECT_TRUE(probSmall > 0.0 && std::isfinite(probSmall));
+    EXPECT_TRUE(probLarge > 0.0 && std::isfinite(probLarge));
+    EXPECT_TRUE(probLargeMu > 0.0 && std::isfinite(probLargeMu));
 
     // Test log probability with extreme values
     double logProbSmall = smallSigma.getLogProbability(1.0);
     double logProbLarge = largeSigma.getLogProbability(1.0);
-    assert(std::isfinite(logProbSmall));
-    assert(std::isfinite(logProbLarge));
+    EXPECT_TRUE(std::isfinite(logProbSmall));
+    EXPECT_TRUE(std::isfinite(logProbLarge));
 
     // Test CDF stability
     double cdfSmall = smallSigma.getCumulativeProbability(1.0);
     double cdfLarge = largeSigma.getCumulativeProbability(1.0);
-    assert(cdfSmall >= 0.0 && cdfSmall <= 1.0 && std::isfinite(cdfSmall));
-    assert(cdfLarge >= 0.0 && cdfLarge <= 1.0 && std::isfinite(cdfLarge));
+    EXPECT_TRUE(cdfSmall >= 0.0 && cdfSmall <= 1.0 && std::isfinite(cdfSmall));
+    EXPECT_TRUE(cdfLarge >= 0.0 && cdfLarge <= 1.0 && std::isfinite(cdfLarge));
 
-    std::cout << "✓ Numerical stability tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics (Gold Standard)
  */
-void testPerformanceCharacteristics() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(LogNormalDistributionTest, PerformanceCharacteristics) {
 
     LogNormalDistribution lognormal(1.0, 0.5);
     const int iterations = 10000;
@@ -540,18 +478,16 @@ void testPerformanceCharacteristics() {
               << " μs/point (" << fitData.size() << " points)" << std::endl;
 
     // Performance requirements
-    assert(pdf_time_per_call < 5.0);    // Less than 5 μs per PDF call
-    assert(logpdf_time_per_call < 3.0); // Less than 3 μs per log PDF call
-    assert(fitTimePerPoint < 50.0);     // Less than 50 μs per data point for fitting
+    EXPECT_LT(pdf_time_per_call, 5.0);    // Less than 5 μs per PDF call
+    EXPECT_LT(logpdf_time_per_call, 3.0); // Less than 3 μs per log PDF call
+    EXPECT_LT(fitTimePerPoint, 50.0);     // Less than 50 μs per data point for fitting
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
 /**
  * Test caching mechanism (Gold Standard)
  */
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
+TEST(LogNormalDistributionTest, Caching) {
 
     LogNormalDistribution lognormal(1.0, 0.5);
 
@@ -564,21 +500,21 @@ void testCaching() {
     double prob2 = lognormal.getProbability(2.0);
     double logProb2 = lognormal.getLogProbability(2.0);
 
-    assert(prob1 != prob2);       // Should be different after parameter change
-    assert(logProb1 != logProb2); // Should be different after parameter change
+    EXPECT_NE(prob1, prob2);       // Should be different after parameter change
+    EXPECT_NE(logProb1, logProb2); // Should be different after parameter change
 
     // Change standard deviation parameter
     lognormal.setStandardDeviation(1.0);
     double prob3 = lognormal.getProbability(2.0);
     double logProb3 = lognormal.getLogProbability(2.0);
 
-    assert(prob2 != prob3);       // Should be different after parameter change
-    assert(logProb2 != logProb3); // Should be different after parameter change
+    EXPECT_NE(prob2, prob3);       // Should be different after parameter change
+    EXPECT_NE(logProb2, logProb3); // Should be different after parameter change
 
     // Test that copy constructor preserves cache state
     LogNormalDistribution copied(lognormal);
-    assert(copied.getProbability(2.0) == lognormal.getProbability(2.0));
-    assert(copied.getLogProbability(2.0) == lognormal.getLogProbability(2.0));
+    EXPECT_EQ(copied.getProbability(2.0), lognormal.getProbability(2.0));
+    EXPECT_EQ(copied.getLogProbability(2.0), lognormal.getLogProbability(2.0));
 
     // Test that cached values are consistent
     double prob4 = lognormal.getProbability(2.0);
@@ -586,48 +522,13 @@ void testCaching() {
     double logProb4 = lognormal.getLogProbability(2.0);
 
     // Multiple calls should return identical results (using cache)
-    assert(lognormal.getProbability(2.0) == prob4);
-    assert(lognormal.getCumulativeProbability(2.0) == cdf4);
-    assert(lognormal.getLogProbability(2.0) == logProb4);
+    EXPECT_EQ(lognormal.getProbability(2.0), prob4);
+    EXPECT_EQ(lognormal.getCumulativeProbability(2.0), cdf4);
+    EXPECT_EQ(lognormal.getLogProbability(2.0), logProb4);
 
-    std::cout << "✓ Caching tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running LogNormal distribution tests..." << std::endl;
-    std::cout << "=======================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testInvalidInputHandling();
-        testResetFunctionality();
-        testLogNormalProperties();
-        testFittingValidation();
-        testStatisticalMoments();
-
-        // Gold Standard Tests
-        testLogProbability();
-        testCDFCalculations();
-        testEqualityAndIO();
-        testNumericalStability();
-        testPerformanceCharacteristics();
-        testCaching();
-
-        std::cout << "=======================================" << std::endl;
-        std::cout << "✅ All LogNormal distribution tests passed (including Gold Standard)!"
-                  << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_log_normal_distribution.cpp
+++ b/tests/distributions/test_log_normal_distribution.cpp
@@ -26,7 +26,6 @@ TEST(LogNormalDistributionTest, BasicFunctionality) {
     LogNormalDistribution lognormal2(5.0, 2.5);
     EXPECT_EQ(lognormal2.getMean(), 5.0);
     EXPECT_EQ(lognormal2.getStandardDeviation(), 2.5);
-
 }
 
 /**
@@ -53,7 +52,6 @@ TEST(LogNormalDistributionTest, Probabilities) {
     // Test that probability density is reasonable (should be small for continuous dist)
     EXPECT_LT(prob1, 1.0);   // Should be less than 1 for probability density
     EXPECT_GT(prob1, 1e-10); // Should be greater than zero
-
 }
 
 /**
@@ -81,7 +79,6 @@ TEST(LogNormalDistributionTest, Fitting) {
     // Based on debug output: mean=0.916291, stddev=1e-30
     EXPECT_GT(lognormal.getMean(), 0.0);
     EXPECT_GT(lognormal.getStandardDeviation(), 0.0);
-
 }
 
 /**
@@ -120,7 +117,6 @@ TEST(LogNormalDistributionTest, ParameterValidation) {
     EXPECT_THROW(lognormal.setStandardDeviation(0.0), std::invalid_argument);
 
     EXPECT_THROW(lognormal.setStandardDeviation(-1.0), std::invalid_argument);
-
 }
 
 /**
@@ -172,7 +168,6 @@ TEST(LogNormalDistributionTest, CopyMoveSemantics) {
     moveAssigned = std::move(temp);
     EXPECT_EQ(moveAssigned.getMean(), 1.41);
     EXPECT_EQ(moveAssigned.getStandardDeviation(), 1.73);
-
 }
 
 /**
@@ -194,7 +189,6 @@ TEST(LogNormalDistributionTest, InvalidInputHandling) {
     // Negative and zero values should return 0
     EXPECT_EQ(lognormal.getProbability(-1.0), 0.0);
     EXPECT_EQ(lognormal.getProbability(0.0), 0.0);
-
 }
 
 /**
@@ -207,7 +201,6 @@ TEST(LogNormalDistributionTest, ResetFunctionality) {
 
     EXPECT_EQ(lognormal.getMean(), 0.0);
     EXPECT_EQ(lognormal.getStandardDeviation(), 1.0);
-
 }
 
 /**
@@ -229,7 +222,6 @@ TEST(LogNormalDistributionTest, LogNormalProperties) {
     EXPECT_GT(prob1, 0.0);
     EXPECT_GT(prob2, 0.0);
     EXPECT_GT(prob3, 0.0);
-
 }
 
 /**
@@ -255,7 +247,6 @@ TEST(LogNormalDistributionTest, FittingValidation) {
     // Should have fitted to positive values {1.0, 2.0}
     EXPECT_GT(lognormal.getMean(), 0.0);
     EXPECT_GT(lognormal.getStandardDeviation(), 0.0);
-
 }
 
 /**
@@ -282,7 +273,6 @@ TEST(LogNormalDistributionTest, StatisticalMoments) {
     // Test mode = exp(μ - σ²) = exp(1.0 - 0.25) = exp(0.75)
     double expectedMode = std::exp(1.0 - 0.25);
     EXPECT_NEAR(lognormal.getMode(), expectedMode, 1e-10);
-
 }
 
 /**
@@ -323,7 +313,6 @@ TEST(LogNormalDistributionTest, LogProbability) {
     EXPECT_TRUE(std::isnan(lognormal.getLogProbability(std::numeric_limits<double>::quiet_NaN())) ||
                 lognormal.getLogProbability(std::numeric_limits<double>::quiet_NaN()) ==
                     -std::numeric_limits<double>::infinity());
-
 }
 
 /**
@@ -356,7 +345,6 @@ TEST(LogNormalDistributionTest, CDFCalculations) {
     // Test approach to 1 for large values
     double cdfLarge = lognormal.getCumulativeProbability(100.0);
     EXPECT_GT(cdfLarge, 0.99);
-
 }
 
 /**
@@ -389,7 +377,6 @@ TEST(LogNormalDistributionTest, EqualityAndIO) {
     if (iss.good() || iss.eof()) {
         EXPECT_EQ(inputDist, ln1);
     }
-
 }
 
 /**
@@ -421,7 +408,6 @@ TEST(LogNormalDistributionTest, NumericalStability) {
     double cdfLarge = largeSigma.getCumulativeProbability(1.0);
     EXPECT_TRUE(cdfSmall >= 0.0 && cdfSmall <= 1.0 && std::isfinite(cdfSmall));
     EXPECT_TRUE(cdfLarge >= 0.0 && cdfLarge <= 1.0 && std::isfinite(cdfLarge));
-
 }
 
 /**
@@ -481,7 +467,6 @@ TEST(LogNormalDistributionTest, PerformanceCharacteristics) {
     EXPECT_LT(pdf_time_per_call, 5.0);    // Less than 5 μs per PDF call
     EXPECT_LT(logpdf_time_per_call, 3.0); // Less than 3 μs per log PDF call
     EXPECT_LT(fitTimePerPoint, 50.0);     // Less than 50 μs per data point for fitting
-
 }
 
 /**
@@ -525,7 +510,6 @@ TEST(LogNormalDistributionTest, Caching) {
     EXPECT_EQ(lognormal.getProbability(2.0), prob4);
     EXPECT_EQ(lognormal.getCumulativeProbability(2.0), cdf4);
     EXPECT_EQ(lognormal.getLogProbability(2.0), logProb4);
-
 }
 
 int main(int argc, char **argv) {

--- a/tests/distributions/test_negative_binomial_distribution.cpp
+++ b/tests/distributions/test_negative_binomial_distribution.cpp
@@ -1,18 +1,12 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <limits>
 #include <chrono>
 #include <sstream>
 #include "libhmm/distributions/negative_binomial_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::NegativeBinomialDistribution;
 using libhmm::Observation;
@@ -20,27 +14,24 @@ using libhmm::Observation;
 /**
  * Test basic Negative Binomial distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Negative Binomial distribution functionality..." << std::endl;
+TEST(NegativeBinomialDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     NegativeBinomialDistribution negbinom;
-    assert(negbinom.getR() == 5.0);
-    assert(negbinom.getP() == 0.5);
+    EXPECT_EQ(negbinom.getR(), 5.0);
+    EXPECT_EQ(negbinom.getP(), 0.5);
 
     // Test parameterized constructor
     NegativeBinomialDistribution negbinom2(3.0, 0.7);
-    assert(negbinom2.getR() == 3.0);
-    assert(negbinom2.getP() == 0.7);
+    EXPECT_EQ(negbinom2.getR(), 3.0);
+    EXPECT_EQ(negbinom2.getP(), 0.7);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(NegativeBinomialDistributionTest, Probabilities) {
 
     NegativeBinomialDistribution negbinom(5.0, 0.5);
 
@@ -49,29 +40,27 @@ void testProbabilities() {
     double prob1 = negbinom.getProbability(1.0);
     double prob5 = negbinom.getProbability(5.0);
 
-    assert(prob0 > 0.0);
-    assert(prob1 > 0.0);
-    assert(prob5 > 0.0);
+    EXPECT_GT(prob0, 0.0);
+    EXPECT_GT(prob1, 0.0);
+    EXPECT_GT(prob5, 0.0);
 
     // For negative binomial, probabilities should be positive and decreasing in general
     // (but the exact pattern depends on parameters, so we just check they're positive)
 
     // Test out of range values
-    assert(negbinom.getProbability(-1.0) == 0.0);
+    EXPECT_EQ(negbinom.getProbability(-1.0), 0.0);
 
     // Test edge case p = 1
     NegativeBinomialDistribution negbinom_p1(5.0, 1.0);
-    assert(negbinom_p1.getProbability(0.0) == 1.0);
-    assert(negbinom_p1.getProbability(1.0) == 0.0);
+    EXPECT_EQ(negbinom_p1.getProbability(0.0), 1.0);
+    EXPECT_EQ(negbinom_p1.getProbability(1.0), 0.0);
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(NegativeBinomialDistributionTest, Fitting) {
 
     NegativeBinomialDistribution negbinom;
 
@@ -80,62 +69,60 @@ void testFitting() {
     negbinom.fit(data);
 
     // After fitting, parameters should be positive and valid
-    assert(negbinom.getR() > 0.0);
-    assert(negbinom.getP() > 0.0 && negbinom.getP() <= 1.0);
+    EXPECT_GT(negbinom.getR(), 0.0);
+    EXPECT_TRUE(negbinom.getP() > 0.0 && negbinom.getP() <= 1.0);
 
     // Test with empty data (should reset to default)
     std::vector<Observation> emptyData;
     negbinom.fit(emptyData);
-    assert(negbinom.getR() == 5.0);
-    assert(negbinom.getP() == 0.5);
+    EXPECT_EQ(negbinom.getR(), 5.0);
+    EXPECT_EQ(negbinom.getP(), 0.5);
 
     // Test with single point (should reset)
     std::vector<Observation> singlePoint = {5};
     negbinom.fit(singlePoint);
-    assert(negbinom.getR() == 5.0);
-    assert(negbinom.getP() == 0.5);
+    EXPECT_EQ(negbinom.getR(), 5.0);
+    EXPECT_EQ(negbinom.getP(), 0.5);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(NegativeBinomialDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
     try {
         NegativeBinomialDistribution negbinom(0.0, 0.5); // Zero r
-        assert(false);                                   // Should not reach here
+        ADD_FAILURE();                                   // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         NegativeBinomialDistribution negbinom(-1.0, 0.5); // Negative r
-        assert(false);                                    // Should not reach here
+        ADD_FAILURE();                                    // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         NegativeBinomialDistribution negbinom(5.0, 0.0); // Zero p
-        assert(false);                                   // Should not reach here
+        ADD_FAILURE();                                   // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         NegativeBinomialDistribution negbinom(5.0, -0.1); // Negative p
-        assert(false);                                    // Should not reach here
+        ADD_FAILURE();                                    // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         NegativeBinomialDistribution negbinom(5.0, 1.5); // p > 1
-        assert(false);                                   // Should not reach here
+        ADD_FAILURE();                                   // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
@@ -144,110 +131,79 @@ void testParameterValidation() {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        NegativeBinomialDistribution negbinom(nan_val, 0.5);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(NegativeBinomialDistribution negbinom(nan_val, 0.5), std::invalid_argument);
 
-    try {
-        NegativeBinomialDistribution negbinom(5.0, inf_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(NegativeBinomialDistribution negbinom(5.0, inf_val), std::invalid_argument);
 
     // Test setters validation
     NegativeBinomialDistribution negbinom(5.0, 0.5);
 
-    try {
-        negbinom.setR(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(negbinom.setR(0.0), std::invalid_argument);
 
-    try {
-        negbinom.setP(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(negbinom.setP(0.0), std::invalid_argument);
 
-    try {
-        negbinom.setP(1.5);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(negbinom.setP(1.5), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(NegativeBinomialDistributionTest, StringRepresentation) {
 
     NegativeBinomialDistribution negbinom(8.0, 0.4);
     std::string str = negbinom.toString();
 
     // Should contain key information based on standardized format:
     // "Negative Binomial Distribution:\n      r (successes) = 8.0\n      p (success probability) = 0.4\n      Mean = 12.0\n      Variance = 30.0\n"
-    assert(str.find("Negative Binomial") != std::string::npos);
-    assert(str.find("Distribution") != std::string::npos);
-    assert(str.find("8.0") != std::string::npos);
-    assert(str.find("0.4") != std::string::npos);
-    assert(str.find("successes") != std::string::npos);
-    assert(str.find("success probability") != std::string::npos);
-    assert(str.find("Mean") != std::string::npos);
-    assert(str.find("Variance") != std::string::npos);
+    EXPECT_NE(str.find("Negative Binomial"), std::string::npos);
+    EXPECT_NE(str.find("Distribution"), std::string::npos);
+    EXPECT_NE(str.find("8.0"), std::string::npos);
+    EXPECT_NE(str.find("0.4"), std::string::npos);
+    EXPECT_NE(str.find("successes"), std::string::npos);
+    EXPECT_NE(str.find("success probability"), std::string::npos);
+    EXPECT_NE(str.find("Mean"), std::string::npos);
+    EXPECT_NE(str.find("Variance"), std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(NegativeBinomialDistributionTest, CopyMoveSemantics) {
 
     NegativeBinomialDistribution original(7.5, 0.6);
 
     // Test copy constructor
     NegativeBinomialDistribution copied(original);
-    assert(copied.getR() == original.getR());
-    assert(copied.getP() == original.getP());
+    EXPECT_EQ(copied.getR(), original.getR());
+    EXPECT_EQ(copied.getP(), original.getP());
 
     // Test copy assignment
     NegativeBinomialDistribution assigned;
     assigned = original;
-    assert(assigned.getR() == original.getR());
-    assert(assigned.getP() == original.getP());
+    EXPECT_EQ(assigned.getR(), original.getR());
+    EXPECT_EQ(assigned.getP(), original.getP());
 
     // Test move constructor
     NegativeBinomialDistribution moved(std::move(original));
-    assert(moved.getR() == 7.5);
-    assert(moved.getP() == 0.6);
+    EXPECT_EQ(moved.getR(), 7.5);
+    EXPECT_EQ(moved.getP(), 0.6);
 
     // Test move assignment
     NegativeBinomialDistribution moveAssigned;
     NegativeBinomialDistribution temp(3.2, 0.8);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getR() == 3.2);
-    assert(moveAssigned.getP() == 0.8);
+    EXPECT_EQ(moveAssigned.getR(), 3.2);
+    EXPECT_EQ(moveAssigned.getP(), 0.8);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test invalid input handling
  */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(NegativeBinomialDistributionTest, InvalidInputHandling) {
 
     NegativeBinomialDistribution negbinom(5.0, 0.5);
 
@@ -256,37 +212,33 @@ void testInvalidInputHandling() {
     double inf_val = std::numeric_limits<double>::infinity();
     double neg_inf_val = -std::numeric_limits<double>::infinity();
 
-    assert(negbinom.getProbability(nan_val) == 0.0);
-    assert(negbinom.getProbability(inf_val) == 0.0);
-    assert(negbinom.getProbability(neg_inf_val) == 0.0);
+    EXPECT_EQ(negbinom.getProbability(nan_val), 0.0);
+    EXPECT_EQ(negbinom.getProbability(inf_val), 0.0);
+    EXPECT_EQ(negbinom.getProbability(neg_inf_val), 0.0);
 
     // Negative values should return 0
-    assert(negbinom.getProbability(-1.0) == 0.0);
-    assert(negbinom.getProbability(-0.5) == 0.0);
+    EXPECT_EQ(negbinom.getProbability(-1.0), 0.0);
+    EXPECT_EQ(negbinom.getProbability(-0.5), 0.0);
 
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
 }
 
 /**
  * Test reset functionality
  */
-void testResetFunctionality() {
-    std::cout << "Testing reset functionality..." << std::endl;
+TEST(NegativeBinomialDistributionTest, ResetFunctionality) {
 
     NegativeBinomialDistribution negbinom(10.0, 0.2);
     negbinom.reset();
 
-    assert(negbinom.getR() == 5.0);
-    assert(negbinom.getP() == 0.5);
+    EXPECT_EQ(negbinom.getR(), 5.0);
+    EXPECT_EQ(negbinom.getP(), 0.5);
 
-    std::cout << "✓ Reset functionality tests passed" << std::endl;
 }
 
 /**
  * Test negative binomial distribution properties
  */
-void testNegativeBinomialProperties() {
-    std::cout << "Testing Negative Binomial distribution properties..." << std::endl;
+TEST(NegativeBinomialDistributionTest, NegativeBinomialProperties) {
 
     NegativeBinomialDistribution negbinom(4.0, 0.3);
 
@@ -299,21 +251,19 @@ void testNegativeBinomialProperties() {
     double expected_mean = 4.0 * (1.0 - 0.3) / 0.3;
     double expected_variance = 4.0 * (1.0 - 0.3) / (0.3 * 0.3);
 
-    assert(std::abs(mean - expected_mean) < 1e-10);
-    assert(std::abs(variance - expected_variance) < 1e-10);
-    assert(std::abs(stddev - std::sqrt(variance)) < 1e-10);
+    EXPECT_NEAR(mean, expected_mean, 1e-10);
+    EXPECT_NEAR(variance, expected_variance, 1e-10);
+    EXPECT_NEAR(stddev, std::sqrt(variance), 1e-10);
 
     // Test that variance > mean (over-dispersion property)
-    assert(variance > mean);
+    EXPECT_GT(variance, mean);
 
-    std::cout << "✓ Negative Binomial property tests passed" << std::endl;
 }
 
 /**
  * Test fitting validation
  */
-void testFittingValidation() {
-    std::cout << "Testing fitting validation..." << std::endl;
+TEST(NegativeBinomialDistributionTest, FittingValidation) {
 
     NegativeBinomialDistribution negbinom;
 
@@ -322,8 +272,8 @@ void testFittingValidation() {
     try {
         negbinom.fit(invalidData);
         // If it doesn't throw, the parameters should still be valid
-        assert(negbinom.getR() > 0.0);
-        assert(negbinom.getP() > 0.0 && negbinom.getP() <= 1.0);
+        EXPECT_GT(negbinom.getR(), 0.0);
+        EXPECT_TRUE(negbinom.getP() > 0.0 && negbinom.getP() <= 1.0);
     } catch (const std::exception &) {
         // It's also acceptable to throw for invalid data
     }
@@ -332,17 +282,15 @@ void testFittingValidation() {
     std::vector<Observation> underDispersedData = {1.0, 1.0, 1.0, 1.0, 1.0};
     negbinom.fit(underDispersedData);
     // Should fall back to defaults since negative binomial is not appropriate
-    assert(negbinom.getR() == 5.0);
-    assert(negbinom.getP() == 0.5);
+    EXPECT_EQ(negbinom.getR(), 5.0);
+    EXPECT_EQ(negbinom.getP(), 0.5);
 
-    std::cout << "✓ Fitting validation tests passed" << std::endl;
 }
 
 /**
  * Test statistical moments
  */
-void testStatisticalMoments() {
-    std::cout << "Testing statistical moments..." << std::endl;
+TEST(NegativeBinomialDistributionTest, StatisticalMoments) {
 
     NegativeBinomialDistribution negbinom(6.0, 0.4);
 
@@ -354,36 +302,32 @@ void testStatisticalMoments() {
     double expected_mean = 6.0 * 0.6 / 0.4;             // r*(1-p)/p
     double expected_variance = 6.0 * 0.6 / (0.4 * 0.4); // r*(1-p)/p²
 
-    assert(std::abs(mean - expected_mean) < 1e-10);
-    assert(std::abs(variance - expected_variance) < 1e-10);
-    assert(std::abs(stddev * stddev - variance) < 1e-10);
+    EXPECT_NEAR(mean, expected_mean, 1e-10);
+    EXPECT_NEAR(variance, expected_variance, 1e-10);
+    EXPECT_NEAR(stddev * stddev, variance, 1e-10);
 
-    std::cout << "✓ Statistical moments tests passed" << std::endl;
 }
 
 /**
  * Test over-dispersion property
  */
-void testOverDispersion() {
-    std::cout << "Testing over-dispersion property..." << std::endl;
+TEST(NegativeBinomialDistributionTest, OverDispersion) {
 
     // Negative binomial should exhibit over-dispersion (variance > mean)
     NegativeBinomialDistribution negbinom1(2.0, 0.3);
     NegativeBinomialDistribution negbinom2(10.0, 0.7);
     NegativeBinomialDistribution negbinom3(1.5, 0.1);
 
-    assert(negbinom1.getVariance() > negbinom1.getMean());
-    assert(negbinom2.getVariance() > negbinom2.getMean());
-    assert(negbinom3.getVariance() > negbinom3.getMean());
+    EXPECT_GT(negbinom1.getVariance(), negbinom1.getMean());
+    EXPECT_GT(negbinom2.getVariance(), negbinom2.getMean());
+    EXPECT_GT(negbinom3.getVariance(), negbinom3.getMean());
 
-    std::cout << "✓ Over-dispersion property tests passed" << std::endl;
 }
 
 /**
  * Test log probability calculations
  */
-void testLogProbability() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(NegativeBinomialDistributionTest, LogProbability) {
 
     NegativeBinomialDistribution negbinom(5.0, 0.4);
 
@@ -393,38 +337,36 @@ void testLogProbability() {
     double logProb5 = negbinom.getLogProbability(5.0);
 
     // Log probabilities should be real numbers
-    assert(!std::isnan(logProb0));
-    assert(!std::isnan(logProb1));
-    assert(!std::isnan(logProb5));
+    EXPECT_FALSE(std::isnan(logProb0));
+    EXPECT_FALSE(std::isnan(logProb1));
+    EXPECT_FALSE(std::isnan(logProb5));
 
     // Verify relationship: exp(log_prob) ≈ prob
     double prob0 = negbinom.getProbability(0.0);
     double prob1 = negbinom.getProbability(1.0);
 
-    assert(std::abs(std::exp(logProb0) - prob0) < 1e-10);
-    assert(std::abs(std::exp(logProb1) - prob1) < 1e-10);
+    EXPECT_NEAR(std::exp(logProb0), prob0, 1e-10);
+    EXPECT_NEAR(std::exp(logProb1), prob1, 1e-10);
 
     // Test invalid inputs
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    assert(negbinom.getLogProbability(nan_val) == -std::numeric_limits<double>::infinity());
-    assert(negbinom.getLogProbability(inf_val) == -std::numeric_limits<double>::infinity());
-    assert(negbinom.getLogProbability(-1.0) == -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(negbinom.getLogProbability(nan_val), -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(negbinom.getLogProbability(inf_val), -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(negbinom.getLogProbability(-1.0), -std::numeric_limits<double>::infinity());
 
     // Test edge case p = 1
     NegativeBinomialDistribution negbinom_p1(5.0, 1.0);
-    assert(negbinom_p1.getLogProbability(0.0) == 0.0); // log(1) = 0
-    assert(negbinom_p1.getLogProbability(1.0) == -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(negbinom_p1.getLogProbability(0.0), 0.0); // log(1) = 0
+    EXPECT_EQ(negbinom_p1.getLogProbability(1.0), -std::numeric_limits<double>::infinity());
 
-    std::cout << "✓ Log probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test CDF calculations
  */
-void testCDF() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(NegativeBinomialDistributionTest, CDF) {
 
     NegativeBinomialDistribution negbinom(3.0, 0.6);
 
@@ -435,70 +377,66 @@ void testCDF() {
     double cdf10 = negbinom.getCumulativeProbability(10.0);
 
     // CDF should be non-decreasing
-    assert(cdf0 <= cdf1);
-    assert(cdf1 <= cdf5);
-    assert(cdf5 <= cdf10);
+    EXPECT_LE(cdf0, cdf1);
+    EXPECT_LE(cdf1, cdf5);
+    EXPECT_LE(cdf5, cdf10);
 
     // CDF should be in [0,1]
-    assert(cdf0 >= 0.0 && cdf0 <= 1.0);
-    assert(cdf1 >= 0.0 && cdf1 <= 1.0);
-    assert(cdf5 >= 0.0 && cdf5 <= 1.0);
-    assert(cdf10 >= 0.0 && cdf10 <= 1.0);
+    EXPECT_TRUE(cdf0 >= 0.0 && cdf0 <= 1.0);
+    EXPECT_TRUE(cdf1 >= 0.0 && cdf1 <= 1.0);
+    EXPECT_TRUE(cdf5 >= 0.0 && cdf5 <= 1.0);
+    EXPECT_TRUE(cdf10 >= 0.0 && cdf10 <= 1.0);
 
     // CDF should equal probability at 0
-    assert(std::abs(cdf0 - negbinom.getProbability(0.0)) < 1e-10);
+    EXPECT_NEAR(cdf0, negbinom.getProbability(0.0), 1e-10);
 
     // Test boundary cases
-    assert(negbinom.getCumulativeProbability(-1.0) == 0.0);
+    EXPECT_EQ(negbinom.getCumulativeProbability(-1.0), 0.0);
 
     // Test invalid inputs
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    assert(negbinom.getCumulativeProbability(nan_val) == 0.0);
-    assert(negbinom.getCumulativeProbability(inf_val) == 0.0);
+    EXPECT_EQ(negbinom.getCumulativeProbability(nan_val), 0.0);
+    EXPECT_EQ(negbinom.getCumulativeProbability(inf_val), 0.0);
 
-    std::cout << "✓ CDF calculation tests passed" << std::endl;
 }
 
 /**
  * Test additional statistical properties
  */
-void testAdditionalStatistics() {
-    std::cout << "Testing additional statistical properties..." << std::endl;
+TEST(NegativeBinomialDistributionTest, AdditionalStatistics) {
 
     NegativeBinomialDistribution negbinom(4.0, 0.3);
 
     // Test mode calculation
     int mode = negbinom.getMode();
-    assert(mode >= 0);
+    EXPECT_TRUE(mode >= 0);
 
     // For r > 1, mode should be floor((r-1)*(1-p)/p)
     int expected_mode = static_cast<int>(std::floor((4.0 - 1.0) * (1.0 - 0.3) / 0.3));
-    assert(mode == expected_mode);
+    EXPECT_EQ(mode, expected_mode);
 
     // Test case where r <= 1
     NegativeBinomialDistribution negbinom_small_r(0.5, 0.3);
-    assert(negbinom_small_r.getMode() == 0);
+    EXPECT_EQ(negbinom_small_r.getMode(), 0);
 
     // Test skewness
     double skewness = negbinom.getSkewness();
     double expected_skewness = (2.0 - 0.3) / std::sqrt(4.0 * (1.0 - 0.3));
-    assert(std::abs(skewness - expected_skewness) < 1e-10);
+    EXPECT_NEAR(skewness, expected_skewness, 1e-10);
 
     // Test kurtosis
     double kurtosis = negbinom.getKurtosis();
     double expected_kurtosis = 3.0 + (6.0 / 4.0) + (0.3 * 0.3) / (4.0 * (1.0 - 0.3));
-    assert(std::abs(kurtosis - expected_kurtosis) < 1e-10);
+    EXPECT_NEAR(kurtosis, expected_kurtosis, 1e-10);
 
-    std::cout << "✓ Additional statistical properties tests passed" << std::endl;
 }
 
 /**
  * Test equality operators
  */
-void testEqualityOperators() {
-    std::cout << "Testing equality operators..." << std::endl;
+TEST(NegativeBinomialDistributionTest, EqualityOperators) {
 
     NegativeBinomialDistribution negbinom1(5.0, 0.4);
     NegativeBinomialDistribution negbinom2(5.0, 0.4);
@@ -506,23 +444,21 @@ void testEqualityOperators() {
     NegativeBinomialDistribution negbinom4(6.0, 0.4);
 
     // Test equality
-    assert(negbinom1 == negbinom2);
-    assert(!(negbinom1 == negbinom3));
-    assert(!(negbinom1 == negbinom4));
+    EXPECT_EQ(negbinom1, negbinom2);
+    EXPECT_FALSE(negbinom1 == negbinom3);
+    EXPECT_FALSE(negbinom1 == negbinom4);
 
     // Test inequality
-    assert(!(negbinom1 != negbinom2));
-    assert(negbinom1 != negbinom3);
-    assert(negbinom1 != negbinom4);
+    EXPECT_FALSE(negbinom1 != negbinom2);
+    EXPECT_NE(negbinom1, negbinom3);
+    EXPECT_NE(negbinom1, negbinom4);
 
-    std::cout << "✓ Equality operator tests passed" << std::endl;
 }
 
 /**
  * Test stream operators
  */
-void testStreamOperators() {
-    std::cout << "Testing stream operators..." << std::endl;
+TEST(NegativeBinomialDistributionTest, StreamOperators) {
 
     NegativeBinomialDistribution original(7.5, 0.35);
 
@@ -531,9 +467,9 @@ void testStreamOperators() {
     oss << original;
     std::string output = oss.str();
 
-    assert(output.find("Negative Binomial") != std::string::npos);
-    assert(output.find("7.5") != std::string::npos);
-    assert(output.find("0.35") != std::string::npos);
+    EXPECT_NE(output.find("Negative Binomial"), std::string::npos);
+    EXPECT_NE(output.find("7.5"), std::string::npos);
+    EXPECT_NE(output.find("0.35"), std::string::npos);
 
     // Test input operator via roundtrip
     NegativeBinomialDistribution source(3.2, 0.8);
@@ -543,8 +479,8 @@ void testStreamOperators() {
     NegativeBinomialDistribution parsed;
     iss >> parsed;
 
-    assert(std::abs(parsed.getR() - 3.2) < 1e-10);
-    assert(std::abs(parsed.getP() - 0.8) < 1e-10);
+    EXPECT_NEAR(parsed.getR(), 3.2, 1e-10);
+    EXPECT_NEAR(parsed.getP(), 0.8, 1e-10);
 
     // Test input operator with a second set of parameters
     NegativeBinomialDistribution source2(4.5, 0.6);
@@ -554,17 +490,15 @@ void testStreamOperators() {
     NegativeBinomialDistribution parsed2;
     iss2 >> parsed2;
 
-    assert(std::abs(parsed2.getR() - 4.5) < 1e-10);
-    assert(std::abs(parsed2.getP() - 0.6) < 1e-10);
+    EXPECT_NEAR(parsed2.getR(), 4.5, 1e-10);
+    EXPECT_NEAR(parsed2.getP(), 0.6, 1e-10);
 
-    std::cout << "✓ Stream operator tests passed" << std::endl;
 }
 
 /**
  * Test caching performance and correctness
  */
-void testCaching() {
-    std::cout << "Testing caching performance and correctness..." << std::endl;
+TEST(NegativeBinomialDistributionTest, Caching) {
 
     NegativeBinomialDistribution negbinom(6.0, 0.4);
 
@@ -576,62 +510,58 @@ void testCaching() {
     double prob1_second = negbinom.getProbability(1.0);
     double logProb1_second = negbinom.getLogProbability(1.0);
 
-    assert(prob1_first == prob1_second);
-    assert(logProb1_first == logProb1_second);
+    EXPECT_EQ(prob1_first, prob1_second);
+    EXPECT_EQ(logProb1_first, logProb1_second);
 
     // Changing parameters should invalidate cache
     negbinom.setP(0.5);
     double prob1_after_change = negbinom.getProbability(1.0);
 
     // Result should be different after parameter change
-    assert(prob1_after_change != prob1_first);
+    EXPECT_NE(prob1_after_change, prob1_first);
 
     // Test cache invalidation with setR
     negbinom.setR(7.0);
     double prob1_after_r_change = negbinom.getProbability(1.0);
-    assert(prob1_after_r_change != prob1_after_change);
+    EXPECT_NE(prob1_after_r_change, prob1_after_change);
 
     // Test cache invalidation with setParameters
     negbinom.setParameters(8.0, 0.3);
     double prob1_after_both_change = negbinom.getProbability(1.0);
-    assert(prob1_after_both_change != prob1_after_r_change);
+    EXPECT_NE(prob1_after_both_change, prob1_after_r_change);
 
-    std::cout << "✓ Caching tests passed" << std::endl;
 }
 
 /**
  * Test numerical stability
  */
-void testNumericalStability() {
-    std::cout << "Testing numerical stability..." << std::endl;
+TEST(NegativeBinomialDistributionTest, NumericalStability) {
 
     // Test with large parameters
     NegativeBinomialDistribution large_negbinom(100.0, 0.99);
     double prob_large = large_negbinom.getProbability(0.0);
-    assert(prob_large > 0.0 && prob_large <= 1.0);
-    assert(!std::isnan(prob_large) && !std::isinf(prob_large));
+    EXPECT_TRUE(prob_large > 0.0 && prob_large <= 1.0);
+    EXPECT_FALSE(std::isnan(prob_large) && !std::isinf(prob_large));
 
     // Test with small parameters
     NegativeBinomialDistribution small_negbinom(0.1, 0.01);
     double prob_small = small_negbinom.getProbability(10.0);
-    assert(prob_small >= 0.0 && prob_small <= 1.0);
-    assert(!std::isnan(prob_small));
+    EXPECT_TRUE(prob_small >= 0.0 && prob_small <= 1.0);
+    EXPECT_FALSE(std::isnan(prob_small));
 
     // Test log probability for better numerical stability
     double logProb_large = large_negbinom.getLogProbability(0.0);
     double logProb_small = small_negbinom.getLogProbability(10.0);
 
-    assert(!std::isnan(logProb_large));
-    assert(!std::isnan(logProb_small));
+    EXPECT_FALSE(std::isnan(logProb_large));
+    EXPECT_FALSE(std::isnan(logProb_small));
 
-    std::cout << "✓ Numerical stability tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics
  */
-void testPerformance() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(NegativeBinomialDistributionTest, Performance) {
 
     NegativeBinomialDistribution negbinom(8.0, 0.4);
 
@@ -680,49 +610,13 @@ void testPerformance() {
               << " μs/point (" << fitData.size() << " points)" << std::endl;
 
     // Performance requirements (should be reasonable)
-    assert(pdfTimePerCall < 10.0);   // Less than 10 μs per PDF call
-    assert(logPdfTimePerCall < 5.0); // Less than 5 μs per log PDF call
-    assert(fitTimePerPoint < 20.0);  // Less than 20 μs per data point for fitting
+    EXPECT_LT(pdfTimePerCall, 10.0);   // Less than 10 μs per PDF call
+    EXPECT_LT(logPdfTimePerCall, 5.0); // Less than 5 μs per log PDF call
+    EXPECT_LT(fitTimePerPoint, 20.0);  // Less than 20 μs per data point for fitting
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running Negative Binomial distribution tests..." << std::endl;
-    std::cout << "===============================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testInvalidInputHandling();
-        testResetFunctionality();
-        testNegativeBinomialProperties();
-        testFittingValidation();
-        testStatisticalMoments();
-        testOverDispersion();
-        testLogProbability();
-        testCDF();
-        testAdditionalStatistics();
-        testEqualityOperators();
-        testStreamOperators();
-        testCaching();
-        testNumericalStability();
-        testPerformance();
-
-        std::cout << "===============================================" << std::endl;
-        std::cout << "✅ All Gold Standard Negative Binomial distribution tests passed!"
-                  << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_negative_binomial_distribution.cpp
+++ b/tests/distributions/test_negative_binomial_distribution.cpp
@@ -25,7 +25,6 @@ TEST(NegativeBinomialDistributionTest, BasicFunctionality) {
     NegativeBinomialDistribution negbinom2(3.0, 0.7);
     EXPECT_EQ(negbinom2.getR(), 3.0);
     EXPECT_EQ(negbinom2.getP(), 0.7);
-
 }
 
 /**
@@ -54,7 +53,6 @@ TEST(NegativeBinomialDistributionTest, Probabilities) {
     NegativeBinomialDistribution negbinom_p1(5.0, 1.0);
     EXPECT_EQ(negbinom_p1.getProbability(0.0), 1.0);
     EXPECT_EQ(negbinom_p1.getProbability(1.0), 0.0);
-
 }
 
 /**
@@ -83,7 +81,6 @@ TEST(NegativeBinomialDistributionTest, Fitting) {
     negbinom.fit(singlePoint);
     EXPECT_EQ(negbinom.getR(), 5.0);
     EXPECT_EQ(negbinom.getP(), 0.5);
-
 }
 
 /**
@@ -143,7 +140,6 @@ TEST(NegativeBinomialDistributionTest, ParameterValidation) {
     EXPECT_THROW(negbinom.setP(0.0), std::invalid_argument);
 
     EXPECT_THROW(negbinom.setP(1.5), std::invalid_argument);
-
 }
 
 /**
@@ -197,7 +193,6 @@ TEST(NegativeBinomialDistributionTest, CopyMoveSemantics) {
     moveAssigned = std::move(temp);
     EXPECT_EQ(moveAssigned.getR(), 3.2);
     EXPECT_EQ(moveAssigned.getP(), 0.8);
-
 }
 
 /**
@@ -219,7 +214,6 @@ TEST(NegativeBinomialDistributionTest, InvalidInputHandling) {
     // Negative values should return 0
     EXPECT_EQ(negbinom.getProbability(-1.0), 0.0);
     EXPECT_EQ(negbinom.getProbability(-0.5), 0.0);
-
 }
 
 /**
@@ -232,7 +226,6 @@ TEST(NegativeBinomialDistributionTest, ResetFunctionality) {
 
     EXPECT_EQ(negbinom.getR(), 5.0);
     EXPECT_EQ(negbinom.getP(), 0.5);
-
 }
 
 /**
@@ -257,7 +250,6 @@ TEST(NegativeBinomialDistributionTest, NegativeBinomialProperties) {
 
     // Test that variance > mean (over-dispersion property)
     EXPECT_GT(variance, mean);
-
 }
 
 /**
@@ -284,7 +276,6 @@ TEST(NegativeBinomialDistributionTest, FittingValidation) {
     // Should fall back to defaults since negative binomial is not appropriate
     EXPECT_EQ(negbinom.getR(), 5.0);
     EXPECT_EQ(negbinom.getP(), 0.5);
-
 }
 
 /**
@@ -305,7 +296,6 @@ TEST(NegativeBinomialDistributionTest, StatisticalMoments) {
     EXPECT_NEAR(mean, expected_mean, 1e-10);
     EXPECT_NEAR(variance, expected_variance, 1e-10);
     EXPECT_NEAR(stddev * stddev, variance, 1e-10);
-
 }
 
 /**
@@ -321,7 +311,6 @@ TEST(NegativeBinomialDistributionTest, OverDispersion) {
     EXPECT_GT(negbinom1.getVariance(), negbinom1.getMean());
     EXPECT_GT(negbinom2.getVariance(), negbinom2.getMean());
     EXPECT_GT(negbinom3.getVariance(), negbinom3.getMean());
-
 }
 
 /**
@@ -360,7 +349,6 @@ TEST(NegativeBinomialDistributionTest, LogProbability) {
     NegativeBinomialDistribution negbinom_p1(5.0, 1.0);
     EXPECT_EQ(negbinom_p1.getLogProbability(0.0), 0.0); // log(1) = 0
     EXPECT_EQ(negbinom_p1.getLogProbability(1.0), -std::numeric_limits<double>::infinity());
-
 }
 
 /**
@@ -399,7 +387,6 @@ TEST(NegativeBinomialDistributionTest, CDF) {
 
     EXPECT_EQ(negbinom.getCumulativeProbability(nan_val), 0.0);
     EXPECT_EQ(negbinom.getCumulativeProbability(inf_val), 0.0);
-
 }
 
 /**
@@ -430,7 +417,6 @@ TEST(NegativeBinomialDistributionTest, AdditionalStatistics) {
     double kurtosis = negbinom.getKurtosis();
     double expected_kurtosis = 3.0 + (6.0 / 4.0) + (0.3 * 0.3) / (4.0 * (1.0 - 0.3));
     EXPECT_NEAR(kurtosis, expected_kurtosis, 1e-10);
-
 }
 
 /**
@@ -452,7 +438,6 @@ TEST(NegativeBinomialDistributionTest, EqualityOperators) {
     EXPECT_FALSE(negbinom1 != negbinom2);
     EXPECT_NE(negbinom1, negbinom3);
     EXPECT_NE(negbinom1, negbinom4);
-
 }
 
 /**
@@ -492,7 +477,6 @@ TEST(NegativeBinomialDistributionTest, StreamOperators) {
 
     EXPECT_NEAR(parsed2.getR(), 4.5, 1e-10);
     EXPECT_NEAR(parsed2.getP(), 0.6, 1e-10);
-
 }
 
 /**
@@ -529,7 +513,6 @@ TEST(NegativeBinomialDistributionTest, Caching) {
     negbinom.setParameters(8.0, 0.3);
     double prob1_after_both_change = negbinom.getProbability(1.0);
     EXPECT_NE(prob1_after_both_change, prob1_after_r_change);
-
 }
 
 /**
@@ -555,7 +538,6 @@ TEST(NegativeBinomialDistributionTest, NumericalStability) {
 
     EXPECT_FALSE(std::isnan(logProb_large));
     EXPECT_FALSE(std::isnan(logProb_small));
-
 }
 
 /**
@@ -613,7 +595,6 @@ TEST(NegativeBinomialDistributionTest, Performance) {
     EXPECT_LT(pdfTimePerCall, 10.0);   // Less than 10 μs per PDF call
     EXPECT_LT(logPdfTimePerCall, 5.0); // Less than 5 μs per log PDF call
     EXPECT_LT(fitTimePerPoint, 20.0);  // Less than 20 μs per data point for fitting
-
 }
 
 int main(int argc, char **argv) {

--- a/tests/distributions/test_pareto_distribution.cpp
+++ b/tests/distributions/test_pareto_distribution.cpp
@@ -1,19 +1,13 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <climits>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 #include "libhmm/distributions/pareto_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::Observation;
 using libhmm::ParetoDistribution;
@@ -21,34 +15,31 @@ using libhmm::ParetoDistribution;
 /**
  * Test basic Pareto distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Pareto distribution functionality..." << std::endl;
+TEST(ParetoDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     ParetoDistribution pareto;
-    assert(pareto.getK() == 1.0);
-    assert(pareto.getXm() == 1.0);
+    EXPECT_EQ(pareto.getK(), 1.0);
+    EXPECT_EQ(pareto.getXm(), 1.0);
 
     // Test parameterized constructor
     ParetoDistribution pareto2(2.5, 1.5);
-    assert(pareto2.getK() == 2.5);
-    assert(pareto2.getXm() == 1.5);
+    EXPECT_EQ(pareto2.getK(), 2.5);
+    EXPECT_EQ(pareto2.getXm(), 1.5);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(ParetoDistributionTest, Probabilities) {
 
     ParetoDistribution pareto(2.0, 1.0); // k=2, xm=1
 
     // Test that probability is zero for values below xm
-    assert(pareto.getProbability(0.5) == 0.0);
-    assert(pareto.getProbability(0.0) == 0.0);
-    assert(pareto.getProbability(-1.0) == 0.0);
+    EXPECT_EQ(pareto.getProbability(0.5), 0.0);
+    EXPECT_EQ(pareto.getProbability(0.0), 0.0);
+    EXPECT_EQ(pareto.getProbability(-1.0), 0.0);
 
     // Test that probability is positive for values > xm (might be 0 exactly at xm)
     double prob1 = pareto.getProbability(1.0); // At xm
@@ -56,85 +47,81 @@ void testProbabilities() {
     double prob3 = pareto.getProbability(3.0);
 
     // Note: some implementations may return 0 exactly at xm
-    assert(prob1 >= 0.0);
-    assert(prob2 > 0.0);
-    assert(prob3 > 0.0);
+    EXPECT_TRUE(prob1 >= 0.0);
+    EXPECT_GT(prob2, 0.0);
+    EXPECT_GT(prob3, 0.0);
 
     // For Pareto distribution, density should decrease as x increases
     // Note: if prob1 is 0 at xm, then we can't compare it
     if (prob1 > 0.0) {
-        assert(prob1 > prob2);
+        EXPECT_GT(prob1, prob2);
     }
-    assert(prob2 > prob3);
+    EXPECT_GT(prob2, prob3);
 
     // Test that probability density is reasonable (should be small for continuous dist)
-    assert(prob2 < 100.0); // Should be reasonable
-    assert(prob2 > 1e-10); // Should be greater than zero
+    EXPECT_LT(prob2, 100.0); // Should be reasonable
+    EXPECT_GT(prob2, 1e-10); // Should be greater than zero
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(ParetoDistributionTest, Fitting) {
 
     ParetoDistribution pareto;
 
     // Test with known data (values should be >= xm)
     std::vector<Observation> data = {1.0, 2.0, 3.0, 4.0, 5.0};
     pareto.fit(data);
-    assert(pareto.getK() > 0.0);  // Should have some reasonable value
-    assert(pareto.getXm() > 0.0); // Should have some reasonable value
+    EXPECT_GT(pareto.getK(), 0.0);  // Should have some reasonable value
+    EXPECT_GT(pareto.getXm(), 0.0); // Should have some reasonable value
 
     // Test with empty data (should reset to default)
     std::vector<Observation> emptyData;
     pareto.fit(emptyData);
-    assert(pareto.getK() == 1.0);
-    assert(pareto.getXm() == 1.0);
+    EXPECT_EQ(pareto.getK(), 1.0);
+    EXPECT_EQ(pareto.getXm(), 1.0);
 
     // Test with single point (should reset based on actual behavior)
     std::vector<Observation> singlePoint = {2.5};
     pareto.fit(singlePoint);
     // Based on debug output: k=1, xm=1 (resets to default)
-    assert(pareto.getK() == 1.0);
-    assert(pareto.getXm() == 1.0);
+    EXPECT_EQ(pareto.getK(), 1.0);
+    EXPECT_EQ(pareto.getXm(), 1.0);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(ParetoDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
     try {
         ParetoDistribution pareto(0.0, 1.0); // Zero k
-        assert(false);                       // Should not reach here
+        ADD_FAILURE();                       // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         ParetoDistribution pareto(-1.0, 1.0); // Negative k
-        assert(false);                        // Should not reach here
+        ADD_FAILURE();                        // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         ParetoDistribution pareto(1.0, 0.0); // Zero xm
-        assert(false);                       // Should not reach here
+        ADD_FAILURE();                       // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         ParetoDistribution pareto(1.0, -1.0); // Negative xm
-        assert(false);                        // Should not reach here
+        ADD_FAILURE();                        // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
@@ -143,115 +130,79 @@ void testParameterValidation() {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        ParetoDistribution pareto(nan_val, 1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(ParetoDistribution pareto(nan_val, 1.0), std::invalid_argument);
 
-    try {
-        ParetoDistribution pareto(1.0, inf_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(ParetoDistribution pareto(1.0, inf_val), std::invalid_argument);
 
     // Test setters validation
     ParetoDistribution pareto(1.0, 1.0);
 
-    try {
-        pareto.setK(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(pareto.setK(0.0), std::invalid_argument);
 
-    try {
-        pareto.setK(-1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(pareto.setK(-1.0), std::invalid_argument);
 
-    try {
-        pareto.setXm(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(pareto.setXm(0.0), std::invalid_argument);
 
-    try {
-        pareto.setXm(-1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(pareto.setXm(-1.0), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(ParetoDistributionTest, StringRepresentation) {
 
     ParetoDistribution pareto(2.5, 1.5);
     std::string str = pareto.toString();
 
     // Should contain key information based on new format:
     // "Pareto Distribution:\n      k (shape parameter) = 2.5\n      x_m (scale parameter) = 1.5\n      Mean = 2.5\n      Variance = ...\n"
-    assert(str.find("Pareto") != std::string::npos);
-    assert(str.find("Distribution") != std::string::npos);
-    assert(str.find("2.5") != std::string::npos);
-    assert(str.find("1.5") != std::string::npos);
-    assert(str.find("shape parameter") != std::string::npos);
-    assert(str.find("scale parameter") != std::string::npos);
+    EXPECT_NE(str.find("Pareto"), std::string::npos);
+    EXPECT_NE(str.find("Distribution"), std::string::npos);
+    EXPECT_NE(str.find("2.5"), std::string::npos);
+    EXPECT_NE(str.find("1.5"), std::string::npos);
+    EXPECT_NE(str.find("shape parameter"), std::string::npos);
+    EXPECT_NE(str.find("scale parameter"), std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(ParetoDistributionTest, CopyMoveSemantics) {
 
     ParetoDistribution original(3.14, 2.71);
 
     // Test copy constructor
     ParetoDistribution copied(original);
-    assert(copied.getK() == original.getK());
-    assert(copied.getXm() == original.getXm());
+    EXPECT_EQ(copied.getK(), original.getK());
+    EXPECT_EQ(copied.getXm(), original.getXm());
 
     // Test copy assignment
     ParetoDistribution assigned;
     assigned = original;
-    assert(assigned.getK() == original.getK());
-    assert(assigned.getXm() == original.getXm());
+    EXPECT_EQ(assigned.getK(), original.getK());
+    EXPECT_EQ(assigned.getXm(), original.getXm());
 
     // Test move constructor
     ParetoDistribution moved(std::move(original));
-    assert(moved.getK() == 3.14);
-    assert(moved.getXm() == 2.71);
+    EXPECT_EQ(moved.getK(), 3.14);
+    EXPECT_EQ(moved.getXm(), 2.71);
 
     // Test move assignment
     ParetoDistribution moveAssigned;
     ParetoDistribution temp(1.41, 1.73);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getK() == 1.41);
-    assert(moveAssigned.getXm() == 1.73);
+    EXPECT_EQ(moveAssigned.getK(), 1.41);
+    EXPECT_EQ(moveAssigned.getXm(), 1.73);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test invalid input handling
  */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(ParetoDistributionTest, InvalidInputHandling) {
 
     ParetoDistribution pareto(2.0, 1.0);
 
@@ -260,67 +211,61 @@ void testInvalidInputHandling() {
     double inf_val = std::numeric_limits<double>::infinity();
     double neg_inf_val = -std::numeric_limits<double>::infinity();
 
-    assert(pareto.getProbability(nan_val) == 0.0);
-    assert(pareto.getProbability(inf_val) == 0.0);
-    assert(pareto.getProbability(neg_inf_val) == 0.0);
+    EXPECT_EQ(pareto.getProbability(nan_val), 0.0);
+    EXPECT_EQ(pareto.getProbability(inf_val), 0.0);
+    EXPECT_EQ(pareto.getProbability(neg_inf_val), 0.0);
 
     // Values below xm should return 0
-    assert(pareto.getProbability(0.5) == 0.0);
-    assert(pareto.getProbability(0.0) == 0.0);
-    assert(pareto.getProbability(-1.0) == 0.0);
+    EXPECT_EQ(pareto.getProbability(0.5), 0.0);
+    EXPECT_EQ(pareto.getProbability(0.0), 0.0);
+    EXPECT_EQ(pareto.getProbability(-1.0), 0.0);
 
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
 }
 
 /**
  * Test reset functionality
  */
-void testResetFunctionality() {
-    std::cout << "Testing reset functionality..." << std::endl;
+TEST(ParetoDistributionTest, ResetFunctionality) {
 
     ParetoDistribution pareto(10.0, 5.0);
     pareto.reset();
 
-    assert(pareto.getK() == 1.0);
-    assert(pareto.getXm() == 1.0);
+    EXPECT_EQ(pareto.getK(), 1.0);
+    EXPECT_EQ(pareto.getXm(), 1.0);
 
-    std::cout << "✓ Reset functionality tests passed" << std::endl;
 }
 
 /**
  * Test Pareto distribution properties
  */
-void testParetoProperties() {
-    std::cout << "Testing Pareto distribution properties..." << std::endl;
+TEST(ParetoDistributionTest, ParetoProperties) {
 
     ParetoDistribution pareto(2.0, 1.0);
 
     // Test that Pareto is only defined for x >= xm
-    assert(pareto.getProbability(0.5) == 0.0);  // Below xm
-    assert(pareto.getProbability(0.99) == 0.0); // Below xm
+    EXPECT_EQ(pareto.getProbability(0.5), 0.0);  // Below xm
+    EXPECT_EQ(pareto.getProbability(0.99), 0.0); // Below xm
 
     // Test at and above xm
     double probAtXm = pareto.getProbability(1.0);    // At xm
     double probAboveXm = pareto.getProbability(2.0); // Above xm
 
     // Note: some implementations may return 0 exactly at xm
-    assert(probAtXm >= 0.0);
-    assert(probAboveXm > 0.0);
+    EXPECT_TRUE(probAtXm >= 0.0);
+    EXPECT_GT(probAboveXm, 0.0);
 
     // Pareto distribution has heavy tail - probability decreases as power law
     // Only compare if both are positive
     if (probAtXm > 0.0) {
-        assert(probAtXm > probAboveXm);
+        EXPECT_GT(probAtXm, probAboveXm);
     }
 
-    std::cout << "✓ Pareto property tests passed" << std::endl;
 }
 
 /**
  * Test fitting validation
  */
-void testFittingValidation() {
-    std::cout << "Testing fitting validation..." << std::endl;
+TEST(ParetoDistributionTest, FittingValidation) {
 
     ParetoDistribution pareto;
 
@@ -334,8 +279,8 @@ void testFittingValidation() {
         // If it doesn't throw, check if parameters are valid (non-NaN, positive)
         // Some implementations may produce invalid parameters with bad data
         if (!std::isnan(pareto.getK()) && !std::isnan(pareto.getXm())) {
-            assert(pareto.getK() > 0.0);
-            assert(pareto.getXm() > 0.0);
+            EXPECT_GT(pareto.getK(), 0.0);
+            EXPECT_GT(pareto.getXm(), 0.0);
         }
         // If parameters are invalid, that's also acceptable behavior
     } catch (const std::exception &) {
@@ -348,21 +293,19 @@ void testFittingValidation() {
         pareto.fit(zeroData);
         // Check if parameters are valid (non-NaN, positive)
         if (!std::isnan(pareto.getK()) && !std::isnan(pareto.getXm())) {
-            assert(pareto.getK() > 0.0);
-            assert(pareto.getXm() > 0.0);
+            EXPECT_GT(pareto.getK(), 0.0);
+            EXPECT_GT(pareto.getXm(), 0.0);
         }
     } catch (const std::exception &) {
         // Acceptable to reject zero values
     }
 
-    std::cout << "✓ Fitting validation tests passed" << std::endl;
 }
 
 /**
  * Test log probability calculations
  */
-void testLogProbability() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(ParetoDistributionTest, LogProbability) {
 
     ParetoDistribution pareto(2.0, 1.0);
 
@@ -371,74 +314,70 @@ void testLogProbability() {
     double logProb2 = pareto.getLogProbability(2.0);
     double logProb3 = pareto.getLogProbability(3.0);
 
-    assert(std::isfinite(logProb1));
-    assert(std::isfinite(logProb2));
-    assert(std::isfinite(logProb3));
+    EXPECT_TRUE(std::isfinite(logProb1));
+    EXPECT_TRUE(std::isfinite(logProb2));
+    EXPECT_TRUE(std::isfinite(logProb3));
 
     // Log probabilities should decrease as x increases (for decreasing PDF)
-    assert(logProb1 > logProb2);
-    assert(logProb2 > logProb3);
+    EXPECT_GT(logProb1, logProb2);
+    EXPECT_GT(logProb2, logProb3);
 
     // Test that log probability is -infinity for invalid values
-    assert(pareto.getLogProbability(0.5) == -std::numeric_limits<double>::infinity());
-    assert(pareto.getLogProbability(-1.0) == -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(pareto.getLogProbability(0.5), -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(pareto.getLogProbability(-1.0), -std::numeric_limits<double>::infinity());
 
-    std::cout << "✓ Log probability tests passed" << std::endl;
 }
 
 /**
  * Test CDF calculations
  */
-void testCDFCalculations() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(ParetoDistributionTest, CDFCalculations) {
 
     ParetoDistribution pareto(2.0, 1.0);
 
     // Test boundary values
-    assert(pareto.getCumulativeProbability(-1.0) == 0.0);
-    assert(pareto.getCumulativeProbability(0.5) == 0.0);
-    assert(pareto.getCumulativeProbability(1.0) == 0.0); // At xm
+    EXPECT_EQ(pareto.getCumulativeProbability(-1.0), 0.0);
+    EXPECT_EQ(pareto.getCumulativeProbability(0.5), 0.0);
+    EXPECT_EQ(pareto.getCumulativeProbability(1.0), 0.0); // At xm
 
     // Test known values
     double cdf_at_2 = pareto.getCumulativeProbability(2.0);    // CDF at x = 2*xm
     double expected_cdf_at_2 = 1.0 - std::pow(1.0 / 2.0, 2.0); // 1 - (xm/x)^k = 1 - (1/2)^2 = 0.75
-    assert(std::abs(cdf_at_2 - expected_cdf_at_2) < 1e-10);
+    EXPECT_NEAR(cdf_at_2, expected_cdf_at_2, 1e-10);
 
     // Test monotonicity
     double cdf1 = pareto.getCumulativeProbability(1.5);
     double cdf2 = pareto.getCumulativeProbability(2.0);
     double cdf3 = pareto.getCumulativeProbability(3.0);
-    assert(cdf1 < cdf2);
-    assert(cdf2 < cdf3);
+    EXPECT_LT(cdf1, cdf2);
+    EXPECT_LT(cdf2, cdf3);
 
     // Test that CDF approaches 1 for large values
     double cdf_large = pareto.getCumulativeProbability(100.0);
-    assert(cdf_large > 0.99);
+    EXPECT_GT(cdf_large, 0.99);
 
-    std::cout << "✓ CDF calculation tests passed" << std::endl;
 }
 
 /**
  * Test equality and I/O operators
  */
-void testEqualityAndIO() {
-    std::cout << "Testing equality and I/O operators..." << std::endl;
+TEST(ParetoDistributionTest, EqualityAndIO) {
 
     ParetoDistribution p1(2.0, 1.5);
     ParetoDistribution p2(2.0, 1.5);
     ParetoDistribution p3(3.0, 1.5);
 
-    assert(p1 == p2);
-    assert(p2 == p1);
-    assert(!(p1 == p3));
-    assert(p1 != p3);
+    EXPECT_EQ(p1, p2);
+    EXPECT_EQ(p2, p1);
+    EXPECT_FALSE(p1 == p3);
+    EXPECT_NE(p1, p3);
 
     std::ostringstream oss;
     oss << p1;
     std::string output = oss.str();
-    assert(output.find("Pareto Distribution") != std::string::npos);
-    assert(output.find("2.0") != std::string::npos);
-    assert(output.find("1.5") != std::string::npos);
+    EXPECT_NE(output.find("Pareto Distribution"), std::string::npos);
+    EXPECT_NE(output.find("2.0"), std::string::npos);
+    EXPECT_NE(output.find("1.5"), std::string::npos);
 
     std::cout << "Stream output: " << output << std::endl;
 
@@ -448,17 +387,15 @@ void testEqualityAndIO() {
     iss >> inputDist;
 
     if (iss.good() || iss.eof()) {
-        assert(inputDist == p1);
+        EXPECT_EQ(inputDist, p1);
     }
 
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
 }
 
 /**
  * Test numerical stability
  */
-void testNumericalStability() {
-    std::cout << "Testing numerical stability..." << std::endl;
+TEST(ParetoDistributionTest, NumericalStability) {
 
     ParetoDistribution smallK(0.1, 1.0);
     ParetoDistribution largeK(10.0, 1.0);  // Reduced from 100.0 to avoid extreme values
@@ -473,27 +410,25 @@ void testNumericalStability() {
     std::cout << "  probLarge = " << probLarge << std::endl;
     std::cout << "  probLargeXm = " << probLargeXm << std::endl;
 
-    assert(probSmall > 0.0 && std::isfinite(probSmall));
-    assert(probLarge > 0.0 && std::isfinite(probLarge));
-    assert(probLargeXm > 0.0 && std::isfinite(probLargeXm));
+    EXPECT_TRUE(probSmall > 0.0 && std::isfinite(probSmall));
+    EXPECT_TRUE(probLarge > 0.0 && std::isfinite(probLarge));
+    EXPECT_TRUE(probLargeXm > 0.0 && std::isfinite(probLargeXm));
 
     // Test CDF stability
     double cdfSmall = smallK.getCumulativeProbability(2.0);
     double cdfLarge = largeK.getCumulativeProbability(2.0);
     double cdfLargeXm = largeXm.getCumulativeProbability(20.0);
 
-    assert(cdfSmall >= 0.0 && cdfSmall <= 1.0 && std::isfinite(cdfSmall));
-    assert(cdfLarge >= 0.0 && cdfLarge <= 1.0 && std::isfinite(cdfLarge));
-    assert(cdfLargeXm >= 0.0 && cdfLargeXm <= 1.0 && std::isfinite(cdfLargeXm));
+    EXPECT_TRUE(cdfSmall >= 0.0 && cdfSmall <= 1.0 && std::isfinite(cdfSmall));
+    EXPECT_TRUE(cdfLarge >= 0.0 && cdfLarge <= 1.0 && std::isfinite(cdfLarge));
+    EXPECT_TRUE(cdfLargeXm >= 0.0 && cdfLargeXm <= 1.0 && std::isfinite(cdfLargeXm));
 
-    std::cout << "✓ Numerical stability tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics
  */
-void testPerformanceCharacteristics() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(ParetoDistributionTest, PerformanceCharacteristics) {
 
     ParetoDistribution pareto(2.0, 1.0);
     const int iterations = 10000; // Reduced for consistency
@@ -544,19 +479,16 @@ void testPerformanceCharacteristics() {
               << " μs/point (" << fitData.size() << " points)" << std::endl;
 
     // Performance requirements (relaxed for Pareto due to complexity)
-    assert(pdf_time_per_call < 5.0);    // Less than 5 μs per PDF call
-    assert(logpdf_time_per_call < 3.0); // Less than 3 μs per log PDF call
-    assert(fitTimePerPoint <
-           50.0); // Less than 50 μs per data point for fitting (Pareto fitting is complex)
+    EXPECT_LT(pdf_time_per_call, 5.0);    // Less than 5 μs per PDF call
+    EXPECT_LT(logpdf_time_per_call, 3.0); // Less than 3 μs per log PDF call
+    EXPECT_LT(fitTimePerPoint, 50.0); // Less than 50 μs per data point for fitting (Pareto fitting is complex)
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
 /**
  * Test caching mechanism
  */
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
+TEST(ParetoDistributionTest, Caching) {
 
     ParetoDistribution pareto(2.0, 1.0);
 
@@ -564,51 +496,20 @@ void testCaching() {
     pareto.setK(3.0);
     double prob2 = pareto.getProbability(2.0);
 
-    assert(prob1 != prob2);
+    EXPECT_NE(prob1, prob2);
 
     pareto.reset();                            // Reset back to k=1.0, xm=1.0
     double prob3 = pareto.getProbability(3.0); // Use x=3.0 instead of x=2.0
-    assert(prob1 != prob3);
+    EXPECT_NE(prob1, prob3);
 
     // Test that cache invalidation works correctly
     pareto.setXm(2.0);
     double prob4 = pareto.getProbability(3.0);
-    assert(std::isfinite(prob4) && prob4 > 0.0);
+    EXPECT_TRUE(std::isfinite(prob4) && prob4 > 0.0);
 
-    std::cout << "✓ Caching mechanism tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running Pareto distribution tests..." << std::endl;
-    std::cout << "====================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testInvalidInputHandling();
-        testResetFunctionality();
-        testParetoProperties();
-        testFittingValidation();
-        testLogProbability();
-        testCDFCalculations();
-        testEqualityAndIO();
-        testNumericalStability();
-        testPerformanceCharacteristics();
-        testCaching();
-
-        std::cout << "====================================" << std::endl;
-        std::cout << "✅ All Pareto distribution tests passed!" << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_pareto_distribution.cpp
+++ b/tests/distributions/test_pareto_distribution.cpp
@@ -26,7 +26,6 @@ TEST(ParetoDistributionTest, BasicFunctionality) {
     ParetoDistribution pareto2(2.5, 1.5);
     EXPECT_EQ(pareto2.getK(), 2.5);
     EXPECT_EQ(pareto2.getXm(), 1.5);
-
 }
 
 /**
@@ -61,7 +60,6 @@ TEST(ParetoDistributionTest, Probabilities) {
     // Test that probability density is reasonable (should be small for continuous dist)
     EXPECT_LT(prob2, 100.0); // Should be reasonable
     EXPECT_GT(prob2, 1e-10); // Should be greater than zero
-
 }
 
 /**
@@ -89,7 +87,6 @@ TEST(ParetoDistributionTest, Fitting) {
     // Based on debug output: k=1, xm=1 (resets to default)
     EXPECT_EQ(pareto.getK(), 1.0);
     EXPECT_EQ(pareto.getXm(), 1.0);
-
 }
 
 /**
@@ -144,7 +141,6 @@ TEST(ParetoDistributionTest, ParameterValidation) {
     EXPECT_THROW(pareto.setXm(0.0), std::invalid_argument);
 
     EXPECT_THROW(pareto.setXm(-1.0), std::invalid_argument);
-
 }
 
 /**
@@ -196,7 +192,6 @@ TEST(ParetoDistributionTest, CopyMoveSemantics) {
     moveAssigned = std::move(temp);
     EXPECT_EQ(moveAssigned.getK(), 1.41);
     EXPECT_EQ(moveAssigned.getXm(), 1.73);
-
 }
 
 /**
@@ -219,7 +214,6 @@ TEST(ParetoDistributionTest, InvalidInputHandling) {
     EXPECT_EQ(pareto.getProbability(0.5), 0.0);
     EXPECT_EQ(pareto.getProbability(0.0), 0.0);
     EXPECT_EQ(pareto.getProbability(-1.0), 0.0);
-
 }
 
 /**
@@ -232,7 +226,6 @@ TEST(ParetoDistributionTest, ResetFunctionality) {
 
     EXPECT_EQ(pareto.getK(), 1.0);
     EXPECT_EQ(pareto.getXm(), 1.0);
-
 }
 
 /**
@@ -259,7 +252,6 @@ TEST(ParetoDistributionTest, ParetoProperties) {
     if (probAtXm > 0.0) {
         EXPECT_GT(probAtXm, probAboveXm);
     }
-
 }
 
 /**
@@ -299,7 +291,6 @@ TEST(ParetoDistributionTest, FittingValidation) {
     } catch (const std::exception &) {
         // Acceptable to reject zero values
     }
-
 }
 
 /**
@@ -325,7 +316,6 @@ TEST(ParetoDistributionTest, LogProbability) {
     // Test that log probability is -infinity for invalid values
     EXPECT_EQ(pareto.getLogProbability(0.5), -std::numeric_limits<double>::infinity());
     EXPECT_EQ(pareto.getLogProbability(-1.0), -std::numeric_limits<double>::infinity());
-
 }
 
 /**
@@ -355,7 +345,6 @@ TEST(ParetoDistributionTest, CDFCalculations) {
     // Test that CDF approaches 1 for large values
     double cdf_large = pareto.getCumulativeProbability(100.0);
     EXPECT_GT(cdf_large, 0.99);
-
 }
 
 /**
@@ -389,7 +378,6 @@ TEST(ParetoDistributionTest, EqualityAndIO) {
     if (iss.good() || iss.eof()) {
         EXPECT_EQ(inputDist, p1);
     }
-
 }
 
 /**
@@ -422,7 +410,6 @@ TEST(ParetoDistributionTest, NumericalStability) {
     EXPECT_TRUE(cdfSmall >= 0.0 && cdfSmall <= 1.0 && std::isfinite(cdfSmall));
     EXPECT_TRUE(cdfLarge >= 0.0 && cdfLarge <= 1.0 && std::isfinite(cdfLarge));
     EXPECT_TRUE(cdfLargeXm >= 0.0 && cdfLargeXm <= 1.0 && std::isfinite(cdfLargeXm));
-
 }
 
 /**
@@ -481,8 +468,8 @@ TEST(ParetoDistributionTest, PerformanceCharacteristics) {
     // Performance requirements (relaxed for Pareto due to complexity)
     EXPECT_LT(pdf_time_per_call, 5.0);    // Less than 5 μs per PDF call
     EXPECT_LT(logpdf_time_per_call, 3.0); // Less than 3 μs per log PDF call
-    EXPECT_LT(fitTimePerPoint, 50.0); // Less than 50 μs per data point for fitting (Pareto fitting is complex)
-
+    EXPECT_LT(fitTimePerPoint,
+              50.0); // Less than 50 μs per data point for fitting (Pareto fitting is complex)
 }
 
 /**
@@ -506,7 +493,6 @@ TEST(ParetoDistributionTest, Caching) {
     pareto.setXm(2.0);
     double prob4 = pareto.getProbability(3.0);
     EXPECT_TRUE(std::isfinite(prob4) && prob4 > 0.0);
-
 }
 
 int main(int argc, char **argv) {

--- a/tests/distributions/test_poisson_distribution.cpp
+++ b/tests/distributions/test_poisson_distribution.cpp
@@ -30,7 +30,6 @@ TEST(PoissonDistributionTest, BasicFunctionality) {
     EXPECT_EQ(poisson2.getMean(), 3.5);
     EXPECT_EQ(poisson2.getVariance(), 3.5);
     EXPECT_NEAR(poisson2.getStandardDeviation(), std::sqrt(3.5), 1e-10);
-
 }
 
 /**
@@ -57,7 +56,6 @@ TEST(PoissonDistributionTest, Probabilities) {
     EXPECT_EQ(poisson.getProbability(-1.0), 0.0);
     EXPECT_EQ(poisson.getProbability(1.5), 0.0); // non-integer
     EXPECT_EQ(poisson.getProbability(std::numeric_limits<double>::infinity()), 0.0);
-
 }
 
 /**
@@ -82,7 +80,6 @@ TEST(PoissonDistributionTest, Fitting) {
     // Test with invalid data (should throw)
     std::vector<Observation> invalidData = {1, 2, -1, 3};
     EXPECT_THROW(poisson.fit(invalidData), std::invalid_argument);
-
 }
 
 /**
@@ -95,12 +92,12 @@ TEST(PoissonDistributionTest, ParameterValidation) {
 
     EXPECT_THROW(PoissonDistribution poisson(0.0), std::invalid_argument);
 
-    EXPECT_THROW(PoissonDistribution poisson(std::numeric_limits<double>::infinity()), std::invalid_argument);
+    EXPECT_THROW(PoissonDistribution poisson(std::numeric_limits<double>::infinity()),
+                 std::invalid_argument);
 
     // Test setLambda validation
     PoissonDistribution poisson(1.0);
     EXPECT_THROW(poisson.setLambda(-1.0), std::invalid_argument);
-
 }
 
 /**
@@ -145,7 +142,6 @@ TEST(PoissonDistributionTest, CopyMoveSemantics) {
     PoissonDistribution temp(2.71);
     moveAssigned = std::move(temp);
     EXPECT_EQ(moveAssigned.getLambda(), 2.71);
-
 }
 
 /**
@@ -168,7 +164,6 @@ TEST(PoissonDistributionTest, NumericalStability) {
     double probExtreme = poissonExtreme.getProbability(200.0); // Far from mean
     // Should return a very small but positive number, or 0 due to underflow
     EXPECT_TRUE(probExtreme >= 0.0);
-
 }
 
 /**
@@ -195,10 +190,9 @@ TEST(PoissonDistributionTest, LogProbability) {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
     EXPECT_TRUE(std::isinf(poisson.getLogProbability(nan_val)) &&
-           poisson.getLogProbability(nan_val) < 0);
+                poisson.getLogProbability(nan_val) < 0);
     EXPECT_TRUE(std::isinf(poisson.getLogProbability(inf_val)) &&
-           poisson.getLogProbability(inf_val) < 0);
-
+                poisson.getLogProbability(inf_val) < 0);
 }
 
 /**
@@ -231,7 +225,6 @@ TEST(PoissonDistributionTest, CDF) {
     PoissonDistribution poissonLarge(200.0);
     double cdfLarge = poissonLarge.getCumulativeProbability(200.0);
     EXPECT_TRUE(cdfLarge >= 0.0 && cdfLarge <= 1.0);
-
 }
 
 /**
@@ -257,7 +250,6 @@ TEST(PoissonDistributionTest, EqualityAndIO) {
     std::string output = oss.str();
     EXPECT_FALSE(output.empty());
     EXPECT_NE(output.find("Poisson"), std::string::npos);
-
 }
 
 /**
@@ -314,8 +306,8 @@ TEST(PoissonDistributionTest, Performance) {
     // Performance requirements (should be reasonable)
     EXPECT_LT(pdfTimePerCall, 10.0);   // Less than 10 μs per PDF call
     EXPECT_LT(logPdfTimePerCall, 5.0); // Less than 5 μs per log PDF call
-    EXPECT_LT(fitTimePerPoint, 5.0); // Less than 5 μs per data point for fitting (Poisson fitting is simple)
-
+    EXPECT_LT(fitTimePerPoint,
+              5.0); // Less than 5 μs per data point for fitting (Poisson fitting is simple)
 }
 
 /**
@@ -343,7 +335,6 @@ TEST(PoissonDistributionTest, Caching) {
     double logProb1 = poisson.getLogProbability(3.0);
     double logProb2 = poisson.getLogProbability(3.0);
     EXPECT_EQ(logProb1, logProb2);
-
 }
 
 int main(int argc, char **argv) {

--- a/tests/distributions/test_poisson_distribution.cpp
+++ b/tests/distributions/test_poisson_distribution.cpp
@@ -1,19 +1,13 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <limits>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 #include "libhmm/distributions/poisson_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::Observation;
 using libhmm::PoissonDistribution;
@@ -21,60 +15,55 @@ using libhmm::PoissonDistribution;
 /**
  * Test basic Poisson distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Poisson distribution functionality..." << std::endl;
+TEST(PoissonDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     PoissonDistribution poisson;
-    assert(poisson.getLambda() == 1.0);
-    assert(poisson.getMean() == 1.0);
-    assert(poisson.getVariance() == 1.0);
-    assert(std::abs(poisson.getStandardDeviation() - 1.0) < 1e-10);
+    EXPECT_EQ(poisson.getLambda(), 1.0);
+    EXPECT_EQ(poisson.getMean(), 1.0);
+    EXPECT_EQ(poisson.getVariance(), 1.0);
+    EXPECT_NEAR(poisson.getStandardDeviation(), 1.0, 1e-10);
 
     // Test parameterized constructor
     PoissonDistribution poisson2(3.5);
-    assert(poisson2.getLambda() == 3.5);
-    assert(poisson2.getMean() == 3.5);
-    assert(poisson2.getVariance() == 3.5);
-    assert(std::abs(poisson2.getStandardDeviation() - std::sqrt(3.5)) < 1e-10);
+    EXPECT_EQ(poisson2.getLambda(), 3.5);
+    EXPECT_EQ(poisson2.getMean(), 3.5);
+    EXPECT_EQ(poisson2.getVariance(), 3.5);
+    EXPECT_NEAR(poisson2.getStandardDeviation(), std::sqrt(3.5), 1e-10);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(PoissonDistributionTest, Probabilities) {
 
     PoissonDistribution poisson(2.0);
 
     // Test known values for λ = 2.0
     // P(X=0) = e^(-2) ≈ 0.1353
     double p0 = poisson.getProbability(0.0);
-    assert(std::abs(p0 - std::exp(-2.0)) < 1e-10);
+    EXPECT_NEAR(p0, std::exp(-2.0), 1e-10);
 
     // P(X=1) = 2 * e^(-2) ≈ 0.2707
     double p1 = poisson.getProbability(1.0);
-    assert(std::abs(p1 - 2.0 * std::exp(-2.0)) < 1e-10);
+    EXPECT_NEAR(p1, 2.0 * std::exp(-2.0), 1e-10);
 
     // P(X=2) = 4/2 * e^(-2) = 2 * e^(-2) ≈ 0.2707
     double p2 = poisson.getProbability(2.0);
-    assert(std::abs(p2 - 2.0 * std::exp(-2.0)) < 1e-10);
+    EXPECT_NEAR(p2, 2.0 * std::exp(-2.0), 1e-10);
 
     // Invalid inputs should return 0
-    assert(poisson.getProbability(-1.0) == 0.0);
-    assert(poisson.getProbability(1.5) == 0.0); // non-integer
-    assert(poisson.getProbability(std::numeric_limits<double>::infinity()) == 0.0);
+    EXPECT_EQ(poisson.getProbability(-1.0), 0.0);
+    EXPECT_EQ(poisson.getProbability(1.5), 0.0); // non-integer
+    EXPECT_EQ(poisson.getProbability(std::numeric_limits<double>::infinity()), 0.0);
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(PoissonDistributionTest, Fitting) {
 
     PoissonDistribution poisson;
 
@@ -83,144 +72,109 @@ void testFitting() {
     double expectedMean = 2.5; // Sum = 25, n = 10
 
     poisson.fit(data);
-    assert(std::abs(poisson.getLambda() - expectedMean) < 1e-10);
+    EXPECT_NEAR(poisson.getLambda(), expectedMean, 1e-10);
 
     // Test with empty data (should reset to default)
     std::vector<Observation> emptyData;
     poisson.fit(emptyData);
-    assert(poisson.getLambda() == 1.0);
+    EXPECT_EQ(poisson.getLambda(), 1.0);
 
     // Test with invalid data (should throw)
     std::vector<Observation> invalidData = {1, 2, -1, 3};
-    try {
-        poisson.fit(invalidData);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(poisson.fit(invalidData), std::invalid_argument);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(PoissonDistributionTest, ParameterValidation) {
 
     // Test invalid lambda values in constructor
-    try {
-        PoissonDistribution poisson(-1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(PoissonDistribution poisson(-1.0), std::invalid_argument);
 
-    try {
-        PoissonDistribution poisson(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(PoissonDistribution poisson(0.0), std::invalid_argument);
 
-    try {
-        PoissonDistribution poisson(std::numeric_limits<double>::infinity());
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(PoissonDistribution poisson(std::numeric_limits<double>::infinity()), std::invalid_argument);
 
     // Test setLambda validation
     PoissonDistribution poisson(1.0);
-    try {
-        poisson.setLambda(-1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(poisson.setLambda(-1.0), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(PoissonDistributionTest, StringRepresentation) {
 
     PoissonDistribution poisson(2.5);
     std::string str = poisson.toString();
 
     // Should contain key information
-    assert(str.find("Poisson") != std::string::npos);
-    assert(str.find("2.5") != std::string::npos);
-    assert(str.find("Mean") != std::string::npos);
-    assert(str.find("Variance") != std::string::npos);
+    EXPECT_NE(str.find("Poisson"), std::string::npos);
+    EXPECT_NE(str.find("2.5"), std::string::npos);
+    EXPECT_NE(str.find("Mean"), std::string::npos);
+    EXPECT_NE(str.find("Variance"), std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(PoissonDistributionTest, CopyMoveSemantics) {
 
     PoissonDistribution original(3.14);
 
     // Test copy constructor
     PoissonDistribution copied(original);
-    assert(copied.getLambda() == original.getLambda());
+    EXPECT_EQ(copied.getLambda(), original.getLambda());
 
     // Test copy assignment
     PoissonDistribution assigned;
     assigned = original;
-    assert(assigned.getLambda() == original.getLambda());
+    EXPECT_EQ(assigned.getLambda(), original.getLambda());
 
     // Test move constructor
     PoissonDistribution moved(std::move(original));
-    assert(moved.getLambda() == 3.14);
+    EXPECT_EQ(moved.getLambda(), 3.14);
 
     // Test move assignment
     PoissonDistribution moveAssigned;
     PoissonDistribution temp(2.71);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getLambda() == 2.71);
+    EXPECT_EQ(moveAssigned.getLambda(), 2.71);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test numerical stability with large values
  */
-void testNumericalStability() {
-    std::cout << "Testing numerical stability..." << std::endl;
+TEST(PoissonDistributionTest, NumericalStability) {
 
     // Test with large lambda
     PoissonDistribution poissonLarge(500.0);
     double probLarge = poissonLarge.getProbability(500.0); // Should be around mode
-    assert(probLarge > 0.0 && probLarge < 1.0);
+    EXPECT_TRUE(probLarge > 0.0 && probLarge < 1.0);
 
     // Test with very small lambda
     PoissonDistribution poissonSmall(1e-6);
     double probSmall = poissonSmall.getProbability(0.0);
-    assert(probSmall > 0.0 && probSmall < 1.0);
+    EXPECT_TRUE(probSmall > 0.0 && probSmall < 1.0);
 
     // Test extreme cases that might cause overflow/underflow
     PoissonDistribution poissonExtreme(100.0);
     double probExtreme = poissonExtreme.getProbability(200.0); // Far from mean
     // Should return a very small but positive number, or 0 due to underflow
-    assert(probExtreme >= 0.0);
+    EXPECT_TRUE(probExtreme >= 0.0);
 
-    std::cout << "✓ Numerical stability tests passed" << std::endl;
 }
 
 /**
  * Test log probability calculations
  */
-void testLogProbability() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(PoissonDistributionTest, LogProbability) {
 
     PoissonDistribution poisson(2.0);
 
@@ -229,30 +183,28 @@ void testLogProbability() {
     double prob2 = poisson.getProbability(2.0);
 
     // log(prob) should equal logProb (within numerical precision)
-    assert(std::abs(std::log(prob2) - logProb2) < 1e-10);
+    EXPECT_NEAR(std::log(prob2), logProb2, 1e-10);
 
     // Test invalid inputs (should return -infinity)
     double logProbNeg = poisson.getLogProbability(-1.0);
     double logProbFloat = poisson.getLogProbability(2.5);
-    assert(std::isinf(logProbNeg) && logProbNeg < 0);
-    assert(std::isinf(logProbFloat) && logProbFloat < 0);
+    EXPECT_TRUE(std::isinf(logProbNeg) && logProbNeg < 0);
+    EXPECT_TRUE(std::isinf(logProbFloat) && logProbFloat < 0);
 
     // Test with invalid inputs
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
-    assert(std::isinf(poisson.getLogProbability(nan_val)) &&
+    EXPECT_TRUE(std::isinf(poisson.getLogProbability(nan_val)) &&
            poisson.getLogProbability(nan_val) < 0);
-    assert(std::isinf(poisson.getLogProbability(inf_val)) &&
+    EXPECT_TRUE(std::isinf(poisson.getLogProbability(inf_val)) &&
            poisson.getLogProbability(inf_val) < 0);
 
-    std::cout << "✓ Log probability tests passed" << std::endl;
 }
 
 /**
  * Test CDF calculations
  */
-void testCDF() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(PoissonDistributionTest, CDF) {
 
     PoissonDistribution poisson(2.0);
 
@@ -261,61 +213,57 @@ void testCDF() {
     double cdf2 = poisson.getCumulativeProbability(2.0);
     double cdf10 = poisson.getCumulativeProbability(10.0);
 
-    assert(cdf0 >= 0.0 && cdf0 <= 1.0);
-    assert(cdf2 >= 0.0 && cdf2 <= 1.0);
-    assert(cdf10 >= 0.0 && cdf10 <= 1.0);
+    EXPECT_TRUE(cdf0 >= 0.0 && cdf0 <= 1.0);
+    EXPECT_TRUE(cdf2 >= 0.0 && cdf2 <= 1.0);
+    EXPECT_TRUE(cdf10 >= 0.0 && cdf10 <= 1.0);
 
     // CDF should be monotonic
-    assert(cdf0 <= cdf2);
-    assert(cdf2 <= cdf10);
+    EXPECT_LE(cdf0, cdf2);
+    EXPECT_LE(cdf2, cdf10);
 
     // CDF should approach 1 for large values
-    assert(cdf10 > 0.99);
+    EXPECT_GT(cdf10, 0.99);
 
     // Test boundary cases
-    assert(poisson.getCumulativeProbability(-1.0) == 0.0);
+    EXPECT_EQ(poisson.getCumulativeProbability(-1.0), 0.0);
 
     // Test large lambda normal approximation
     PoissonDistribution poissonLarge(200.0);
     double cdfLarge = poissonLarge.getCumulativeProbability(200.0);
-    assert(cdfLarge >= 0.0 && cdfLarge <= 1.0);
+    EXPECT_TRUE(cdfLarge >= 0.0 && cdfLarge <= 1.0);
 
-    std::cout << "✓ CDF tests passed" << std::endl;
 }
 
 /**
  * Test equality and I/O operators
  */
-void testEqualityAndIO() {
-    std::cout << "Testing equality and I/O operators..." << std::endl;
+TEST(PoissonDistributionTest, EqualityAndIO) {
 
     PoissonDistribution poisson1(2.5);
     PoissonDistribution poisson2(2.5);
     PoissonDistribution poisson3(3.0);
 
     // Test equality
-    assert(poisson1 == poisson2);
-    assert(!(poisson1 == poisson3));
+    EXPECT_EQ(poisson1, poisson2);
+    EXPECT_FALSE(poisson1 == poisson3);
 
     // Test inequality
-    assert(!(poisson1 != poisson2));
-    assert(poisson1 != poisson3);
+    EXPECT_FALSE(poisson1 != poisson2);
+    EXPECT_NE(poisson1, poisson3);
 
     // Test stream output
     std::ostringstream oss;
     oss << poisson1;
     std::string output = oss.str();
-    assert(!output.empty());
-    assert(output.find("Poisson") != std::string::npos);
+    EXPECT_FALSE(output.empty());
+    EXPECT_NE(output.find("Poisson"), std::string::npos);
 
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics
  */
-void testPerformance() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(PoissonDistributionTest, Performance) {
 
     PoissonDistribution poisson(10.0);
 
@@ -364,19 +312,16 @@ void testPerformance() {
               << " μs/point (" << fitData.size() << " points)" << std::endl;
 
     // Performance requirements (should be reasonable)
-    assert(pdfTimePerCall < 10.0);   // Less than 10 μs per PDF call
-    assert(logPdfTimePerCall < 5.0); // Less than 5 μs per log PDF call
-    assert(fitTimePerPoint <
-           5.0); // Less than 5 μs per data point for fitting (Poisson fitting is simple)
+    EXPECT_LT(pdfTimePerCall, 10.0);   // Less than 10 μs per PDF call
+    EXPECT_LT(logPdfTimePerCall, 5.0); // Less than 5 μs per log PDF call
+    EXPECT_LT(fitTimePerPoint, 5.0); // Less than 5 μs per data point for fitting (Poisson fitting is simple)
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
 /**
  * Test caching mechanism
  */
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
+TEST(PoissonDistributionTest, Caching) {
 
     PoissonDistribution poisson(3.0);
 
@@ -385,52 +330,23 @@ void testCaching() {
 
     // Second calculation should use cache (should be identical)
     double prob2 = poisson.getProbability(3.0);
-    assert(prob1 == prob2);
+    EXPECT_EQ(prob1, prob2);
 
     // Changing parameters should invalidate cache
     poisson.setLambda(5.0);
     double prob3 = poisson.getProbability(3.0);
 
     // The probabilities should be different (λ=3 vs λ=5 significantly affects P(X=3))
-    assert(std::abs(prob3 - prob1) > 1e-6);
+    EXPECT_GT(std::abs(prob3 - prob1), 1e-6);
 
     // Test that log probability also works with caching
     double logProb1 = poisson.getLogProbability(3.0);
     double logProb2 = poisson.getLogProbability(3.0);
-    assert(logProb1 == logProb2);
+    EXPECT_EQ(logProb1, logProb2);
 
-    std::cout << "✓ Caching tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running Poisson distribution tests..." << std::endl;
-    std::cout << "=====================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testNumericalStability();
-
-        // Gold Standard Tests
-        testLogProbability();
-        testCDF();
-        testEqualityAndIO();
-        testPerformance();
-        testCaching();
-
-        std::cout << "=====================================" << std::endl;
-        std::cout << "✅ All Poisson distribution tests passed!" << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_rayleigh_distribution.cpp
+++ b/tests/distributions/test_rayleigh_distribution.cpp
@@ -21,7 +21,6 @@ TEST(RayleighDistributionTest, BasicFunctionality) {
     // Test parameterized constructor
     RayleighDistribution rayleigh2(2.5);
     EXPECT_EQ(rayleigh2.getSigma(), 2.5);
-
 }
 
 TEST(RayleighDistributionTest, Probabilities) {
@@ -44,7 +43,6 @@ TEST(RayleighDistributionTest, Probabilities) {
     // Test boundary value at x=0
     double probAt0 = rayleigh.getProbability(0.0);
     EXPECT_EQ(probAt0, 0.0);
-
 }
 
 TEST(RayleighDistributionTest, Fitting) {
@@ -60,7 +58,6 @@ TEST(RayleighDistributionTest, Fitting) {
     std::vector<Observation> emptyData;
     rayleigh.fit(emptyData);
     EXPECT_EQ(rayleigh.getSigma(), 1.0);
-
 }
 
 TEST(RayleighDistributionTest, ParameterValidation) {
@@ -76,7 +73,6 @@ TEST(RayleighDistributionTest, ParameterValidation) {
     EXPECT_THROW(RayleighDistribution rayleigh(nan_val), std::invalid_argument);
 
     EXPECT_THROW(RayleighDistribution rayleigh(inf_val), std::invalid_argument);
-
 }
 
 TEST(RayleighDistributionTest, Statistics) {
@@ -91,7 +87,6 @@ TEST(RayleighDistributionTest, Statistics) {
     EXPECT_TRUE(mean > 1.25 && mean < 1.26);         // σ * √(π/2) ≈ 1.253
     EXPECT_TRUE(variance > 0.42 && variance < 0.43); // σ² * (4-π)/2 ≈ 0.429
     EXPECT_NEAR(stddev, std::sqrt(variance), 1e-10);
-
 }
 
 TEST(RayleighDistributionTest, StatisticalMoments) {
@@ -104,7 +99,6 @@ TEST(RayleighDistributionTest, StatisticalMoments) {
     EXPECT_NEAR(rayleigh.getMean(), expectedMean, 1e-10);
     EXPECT_NEAR(rayleigh.getVariance(), expectedVar, 1e-10);
     EXPECT_NEAR(rayleigh.getStandardDeviation(), std::sqrt(expectedVar), 1e-10);
-
 }
 
 TEST(RayleighDistributionTest, StringRepresentation) {
@@ -132,7 +126,6 @@ TEST(RayleighDistributionTest, CopyMoveSemantics) {
 
     RayleighDistribution moved(std::move(original));
     EXPECT_EQ(moved.getSigma(), 2.0);
-
 }
 
 TEST(RayleighDistributionTest, EqualityAndIO) {
@@ -160,7 +153,6 @@ TEST(RayleighDistributionTest, EqualityAndIO) {
     if (!iss.fail()) {
         EXPECT_NEAR(inputDist.getSigma(), 3.14, 1e-10);
     }
-
 }
 
 TEST(RayleighDistributionTest, Caching) {
@@ -182,7 +174,6 @@ TEST(RayleighDistributionTest, Caching) {
     double prob4 = rayleigh.getProbability(1.0);
     EXPECT_NE(prob1, prob4);
     EXPECT_NE(prob2, prob4);
-
 }
 
 TEST(RayleighDistributionTest, CDFCalculations) {
@@ -208,7 +199,6 @@ TEST(RayleighDistributionTest, CDFCalculations) {
     // Test that CDF approaches 1 for large values
     double cdf_large = rayleigh.getCumulativeProbability(10.0);
     EXPECT_GT(cdf_large, 0.99);
-
 }
 
 TEST(RayleighDistributionTest, NumericalStability) {
@@ -228,7 +218,6 @@ TEST(RayleighDistributionTest, NumericalStability) {
 
     EXPECT_TRUE(cdfSmall >= 0.0 && cdfSmall <= 1.0 && std::isfinite(cdfSmall));
     EXPECT_TRUE(cdfLarge >= 0.0 && cdfLarge <= 1.0 && std::isfinite(cdfLarge));
-
 }
 
 TEST(RayleighDistributionTest, PerformanceCharacteristics) {
@@ -285,7 +274,6 @@ TEST(RayleighDistributionTest, PerformanceCharacteristics) {
     EXPECT_LT(pdfTimePerCall, 1.0);    // Less than 1 μs per PDF call
     EXPECT_LT(logPdfTimePerCall, 1.0); // Less than 1 μs per log PDF call
     EXPECT_LT(fitTimePerPoint, 0.1);   // Less than 0.1 μs per data point for fitting
-
 }
 
 int main(int argc, char **argv) {

--- a/tests/distributions/test_rayleigh_distribution.cpp
+++ b/tests/distributions/test_rayleigh_distribution.cpp
@@ -1,120 +1,85 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <climits>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 #include "libhmm/distributions/rayleigh_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::Observation;
 using libhmm::RayleighDistribution;
 
-void testBasicFunctionality() {
-    std::cout << "Testing basic Rayleigh distribution functionality..." << std::endl;
+TEST(RayleighDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     RayleighDistribution rayleigh;
-    assert(rayleigh.getSigma() == 1.0);
+    EXPECT_EQ(rayleigh.getSigma(), 1.0);
 
     // Test parameterized constructor
     RayleighDistribution rayleigh2(2.5);
-    assert(rayleigh2.getSigma() == 2.5);
+    EXPECT_EQ(rayleigh2.getSigma(), 2.5);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(RayleighDistributionTest, Probabilities) {
 
     RayleighDistribution rayleigh(1.0); // σ=1
 
     // Test that probability is zero for negative and zero values
-    assert(rayleigh.getProbability(-0.1) == 0.0);
-    assert(rayleigh.getProbability(0.0) == 0.0);
+    EXPECT_EQ(rayleigh.getProbability(-0.1), 0.0);
+    EXPECT_EQ(rayleigh.getProbability(0.0), 0.0);
 
     // Test that probability is positive for positive values
     double prob1 = rayleigh.getProbability(0.5);
     double prob2 = rayleigh.getProbability(1.0);
     double prob3 = rayleigh.getProbability(2.0);
 
-    assert(prob1 > 0.0);
-    assert(prob2 > 0.0);
-    assert(prob3 > 0.0);
+    EXPECT_GT(prob1, 0.0);
+    EXPECT_GT(prob2, 0.0);
+    EXPECT_GT(prob3, 0.0);
 
     // Test boundary value at x=0
     double probAt0 = rayleigh.getProbability(0.0);
-    assert(probAt0 == 0.0);
+    EXPECT_EQ(probAt0, 0.0);
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(RayleighDistributionTest, Fitting) {
 
     RayleighDistribution rayleigh;
 
     // Test with known data
     std::vector<Observation> data = {0.5, 1.0, 1.5, 2.0, 2.5, 3.0};
     rayleigh.fit(data);
-    assert(rayleigh.getSigma() > 0.0);
+    EXPECT_GT(rayleigh.getSigma(), 0.0);
 
     // Test with empty data (should reset to default)
     std::vector<Observation> emptyData;
     rayleigh.fit(emptyData);
-    assert(rayleigh.getSigma() == 1.0);
+    EXPECT_EQ(rayleigh.getSigma(), 1.0);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(RayleighDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
-    try {
-        RayleighDistribution rayleigh(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(RayleighDistribution rayleigh(0.0), std::invalid_argument);
 
-    try {
-        RayleighDistribution rayleigh(-1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(RayleighDistribution rayleigh(-1.0), std::invalid_argument);
 
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        RayleighDistribution rayleigh(nan_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(RayleighDistribution rayleigh(nan_val), std::invalid_argument);
 
-    try {
-        RayleighDistribution rayleigh(inf_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(RayleighDistribution rayleigh(inf_val), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
-void testStatistics() {
-    std::cout << "Testing Rayleigh distribution statistics..." << std::endl;
+TEST(RayleighDistributionTest, Statistics) {
 
     RayleighDistribution rayleigh(1.0);
 
@@ -123,77 +88,69 @@ void testStatistics() {
     double variance = rayleigh.getVariance();
     double stddev = rayleigh.getStandardDeviation();
 
-    assert(mean > 1.25 && mean < 1.26);         // σ * √(π/2) ≈ 1.253
-    assert(variance > 0.42 && variance < 0.43); // σ² * (4-π)/2 ≈ 0.429
-    assert(std::abs(stddev - std::sqrt(variance)) < 1e-10);
+    EXPECT_TRUE(mean > 1.25 && mean < 1.26);         // σ * √(π/2) ≈ 1.253
+    EXPECT_TRUE(variance > 0.42 && variance < 0.43); // σ² * (4-π)/2 ≈ 0.429
+    EXPECT_NEAR(stddev, std::sqrt(variance), 1e-10);
 
-    std::cout << "✓ Statistics tests passed" << std::endl;
 }
 
-void testStatisticalMoments() {
-    std::cout << "Testing statistical moments and properties..." << std::endl;
+TEST(RayleighDistributionTest, StatisticalMoments) {
 
     RayleighDistribution rayleigh(1.0);
 
     double expectedMean = libhmm::constants::math::SQRT_PI_OVER_TWO;
     double expectedVar = libhmm::constants::math::FOUR_MINUS_PI_OVER_TWO;
 
-    assert(std::abs(rayleigh.getMean() - expectedMean) < 1e-10);
-    assert(std::abs(rayleigh.getVariance() - expectedVar) < 1e-10);
-    assert(std::abs(rayleigh.getStandardDeviation() - std::sqrt(expectedVar)) < 1e-10);
+    EXPECT_NEAR(rayleigh.getMean(), expectedMean, 1e-10);
+    EXPECT_NEAR(rayleigh.getVariance(), expectedVar, 1e-10);
+    EXPECT_NEAR(rayleigh.getStandardDeviation(), std::sqrt(expectedVar), 1e-10);
 
-    std::cout << "✓ Statistical moments tests passed" << std::endl;
 }
 
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(RayleighDistributionTest, StringRepresentation) {
 
     RayleighDistribution rayleigh(1.0);
     std::string str = rayleigh.toString();
 
-    assert(str.find("Rayleigh") != std::string::npos);
-    assert(str.find("Distribution") != std::string::npos);
-    assert(str.find("1.0") != std::string::npos);
+    EXPECT_NE(str.find("Rayleigh"), std::string::npos);
+    EXPECT_NE(str.find("Distribution"), std::string::npos);
+    EXPECT_NE(str.find("1.0"), std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(RayleighDistributionTest, CopyMoveSemantics) {
 
     RayleighDistribution original(2.0);
 
     RayleighDistribution copied(original);
-    assert(copied.getSigma() == original.getSigma());
+    EXPECT_EQ(copied.getSigma(), original.getSigma());
 
     RayleighDistribution assigned;
     assigned = original;
-    assert(assigned.getSigma() == original.getSigma());
+    EXPECT_EQ(assigned.getSigma(), original.getSigma());
 
     RayleighDistribution moved(std::move(original));
-    assert(moved.getSigma() == 2.0);
+    EXPECT_EQ(moved.getSigma(), 2.0);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
-void testEqualityAndIO() {
-    std::cout << "Testing equality and I/O operators..." << std::endl;
+TEST(RayleighDistributionTest, EqualityAndIO) {
 
     RayleighDistribution r1(1.0);
     RayleighDistribution r2(1.0);
     RayleighDistribution r3(2.0);
 
-    assert(r1 == r2);
-    assert(r2 == r1);
-    assert(!(r1 == r3));
-    assert(r1 != r3);
+    EXPECT_EQ(r1, r2);
+    EXPECT_EQ(r2, r1);
+    EXPECT_FALSE(r1 == r3);
+    EXPECT_NE(r1, r3);
 
     std::ostringstream oss;
     oss << r1.toString();
     std::string output = oss.str();
-    assert(output.find("Rayleigh") != std::string::npos);
-    assert(output.find("1.0") != std::string::npos);
+    EXPECT_NE(output.find("Rayleigh"), std::string::npos);
+    EXPECT_NE(output.find("1.0"), std::string::npos);
 
     std::cout << "Stream output: " << output << std::endl;
 
@@ -201,14 +158,12 @@ void testEqualityAndIO() {
     RayleighDistribution inputDist;
     iss >> inputDist;
     if (!iss.fail()) {
-        assert(std::abs(inputDist.getSigma() - 3.14) < 1e-10);
+        EXPECT_NEAR(inputDist.getSigma(), 3.14, 1e-10);
     }
 
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
 }
 
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
+TEST(RayleighDistributionTest, Caching) {
 
     RayleighDistribution rayleigh(1.0);
 
@@ -216,51 +171,47 @@ void testCaching() {
     rayleigh.setSigma(2.0);
     double prob2 = rayleigh.getProbability(1.0);
 
-    assert(prob1 != prob2);
+    EXPECT_NE(prob1, prob2);
 
     rayleigh.reset(); // Reset back to sigma=1.0
     double prob3 = rayleigh.getProbability(1.0);
-    assert(std::abs(prob1 - prob3) < 1e-10); // Should be the same as original
+    EXPECT_NEAR(prob1, prob3, 1e-10); // Should be the same as original
 
     // Test that cache invalidation works correctly
     rayleigh.setSigma(3.0);
     double prob4 = rayleigh.getProbability(1.0);
-    assert(prob1 != prob4);
-    assert(prob2 != prob4);
+    EXPECT_NE(prob1, prob4);
+    EXPECT_NE(prob2, prob4);
 
-    std::cout << "✓ Caching mechanism tests passed" << std::endl;
 }
 
-void testCDFCalculations() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(RayleighDistributionTest, CDFCalculations) {
 
     RayleighDistribution rayleigh(1.0);
 
     // Test boundary values
-    assert(rayleigh.getCumulativeProbability(-1.0) == 0.0);
-    assert(rayleigh.getCumulativeProbability(0.0) == 0.0);
+    EXPECT_EQ(rayleigh.getCumulativeProbability(-1.0), 0.0);
+    EXPECT_EQ(rayleigh.getCumulativeProbability(0.0), 0.0);
 
     // Test known values
     double cdf_at_sigma = rayleigh.getCumulativeProbability(1.0); // CDF at x = σ
     double expected_cdf_at_sigma = 1.0 - std::exp(-0.5);          // 1 - exp(-1²/(2*1²))
-    assert(std::abs(cdf_at_sigma - expected_cdf_at_sigma) < 1e-10);
+    EXPECT_NEAR(cdf_at_sigma, expected_cdf_at_sigma, 1e-10);
 
     // Test monotonicity
     double cdf1 = rayleigh.getCumulativeProbability(0.5);
     double cdf2 = rayleigh.getCumulativeProbability(1.0);
     double cdf3 = rayleigh.getCumulativeProbability(2.0);
-    assert(cdf1 < cdf2);
-    assert(cdf2 < cdf3);
+    EXPECT_LT(cdf1, cdf2);
+    EXPECT_LT(cdf2, cdf3);
 
     // Test that CDF approaches 1 for large values
     double cdf_large = rayleigh.getCumulativeProbability(10.0);
-    assert(cdf_large > 0.99);
+    EXPECT_GT(cdf_large, 0.99);
 
-    std::cout << "✓ CDF calculation tests passed" << std::endl;
 }
 
-void testNumericalStability() {
-    std::cout << "Testing numerical stability..." << std::endl;
+TEST(RayleighDistributionTest, NumericalStability) {
 
     RayleighDistribution smallSigma(0.001);
     RayleighDistribution largeSigma(1000.0);
@@ -268,21 +219,19 @@ void testNumericalStability() {
     double probSmall = smallSigma.getProbability(0.0001);
     double probLarge = largeSigma.getProbability(500.0);
 
-    assert(probSmall > 0.0 && std::isfinite(probSmall));
-    assert(probLarge > 0.0 && std::isfinite(probLarge));
+    EXPECT_TRUE(probSmall > 0.0 && std::isfinite(probSmall));
+    EXPECT_TRUE(probLarge > 0.0 && std::isfinite(probLarge));
 
     // Test CDF stability
     double cdfSmall = smallSigma.getCumulativeProbability(0.0001);
     double cdfLarge = largeSigma.getCumulativeProbability(500.0);
 
-    assert(cdfSmall >= 0.0 && cdfSmall <= 1.0 && std::isfinite(cdfSmall));
-    assert(cdfLarge >= 0.0 && cdfLarge <= 1.0 && std::isfinite(cdfLarge));
+    EXPECT_TRUE(cdfSmall >= 0.0 && cdfSmall <= 1.0 && std::isfinite(cdfSmall));
+    EXPECT_TRUE(cdfLarge >= 0.0 && cdfLarge <= 1.0 && std::isfinite(cdfLarge));
 
-    std::cout << "✓ Numerical stability tests passed" << std::endl;
 }
 
-void testPerformanceCharacteristics() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(RayleighDistributionTest, PerformanceCharacteristics) {
 
     RayleighDistribution rayleigh(1.0);
 
@@ -333,41 +282,13 @@ void testPerformanceCharacteristics() {
               << " μs/point (" << fitData.size() << " points)" << std::endl;
 
     // Performance requirements (should be fast)
-    assert(pdfTimePerCall < 1.0);    // Less than 1 μs per PDF call
-    assert(logPdfTimePerCall < 1.0); // Less than 1 μs per log PDF call
-    assert(fitTimePerPoint < 0.1);   // Less than 0.1 μs per data point for fitting
+    EXPECT_LT(pdfTimePerCall, 1.0);    // Less than 1 μs per PDF call
+    EXPECT_LT(logPdfTimePerCall, 1.0); // Less than 1 μs per log PDF call
+    EXPECT_LT(fitTimePerPoint, 0.1);   // Less than 0.1 μs per data point for fitting
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running Rayleigh distribution tests..." << std::endl;
-    std::cout << "=====================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testFitting();
-        testParameterValidation();
-        testStatistics();
-        testStatisticalMoments();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testEqualityAndIO();
-        testCaching();
-        testCDFCalculations();
-        testNumericalStability();
-        testPerformanceCharacteristics();
-
-        std::cout << "=====================================" << std::endl;
-        std::cout << "✅ All Rayleigh distribution tests passed!" << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_student_t_distribution.cpp
+++ b/tests/distributions/test_student_t_distribution.cpp
@@ -1,11 +1,5 @@
 #include <gtest/gtest.h>
 #include "libhmm/distributions/student_t_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
 #include <memory>
 #include <vector>
 #include <cmath>
@@ -21,47 +15,44 @@ using namespace libhmm;
 /**
  * Test basic Student's t-distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Student's t-distribution functionality..." << std::endl;
+TEST(StudentTDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     StudentTDistribution t_dist;
-    assert(t_dist.getDegreesOfFreedom() == 1.0);
+    EXPECT_EQ(t_dist.getDegreesOfFreedom(), 1.0);
 
     // Test parameterized constructor
     StudentTDistribution t_dist2(5.0);
-    assert(t_dist2.getDegreesOfFreedom() == 5.0);
+    EXPECT_EQ(t_dist2.getDegreesOfFreedom(), 5.0);
 
     // Test parameter setter
     t_dist.setDegreesOfFreedom(3.0);
-    assert(t_dist.getDegreesOfFreedom() == 3.0);
+    EXPECT_EQ(t_dist.getDegreesOfFreedom(), 3.0);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(StudentTDistributionTest, Probabilities) {
 
     StudentTDistribution t_dist(2.0); // df = 2
 
     // Test symmetric property: f(x) = f(-x)
     double prob_pos = t_dist.getProbability(1.0);
     double prob_neg = t_dist.getProbability(-1.0);
-    assert(std::abs(prob_pos - prob_neg) < 1e-10);
+    EXPECT_NEAR(prob_pos, prob_neg, 1e-10);
 
     // Test that probability is highest at x = 0 (mode)
     double prob_at_zero = t_dist.getProbability(0.0);
     double prob_at_one = t_dist.getProbability(1.0);
     double prob_at_two = t_dist.getProbability(2.0);
 
-    assert(prob_at_zero > prob_at_one);
-    assert(prob_at_one > prob_at_two);
-    assert(prob_at_zero > 0.0);
-    assert(prob_at_one > 0.0);
-    assert(prob_at_two > 0.0);
+    EXPECT_GT(prob_at_zero, prob_at_one);
+    EXPECT_GT(prob_at_one, prob_at_two);
+    EXPECT_GT(prob_at_zero, 0.0);
+    EXPECT_GT(prob_at_one, 0.0);
+    EXPECT_GT(prob_at_two, 0.0);
 
     // Test with different degrees of freedom
     StudentTDistribution t_dist_1(1.0);   // Cauchy distribution
@@ -72,53 +63,49 @@ void testProbabilities() {
 
     // Higher df should have lower tails (lower probability at extreme values)
     // But for t(1) vs t(30), t(30) should have higher peak and lower tails
-    assert(prob_1 > 0.0);
-    assert(prob_30 > 0.0);
+    EXPECT_GT(prob_1, 0.0);
+    EXPECT_GT(prob_30, 0.0);
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test statistical properties
  */
-void testStatisticalProperties() {
-    std::cout << "Testing statistical properties..." << std::endl;
+TEST(StudentTDistributionTest, StatisticalProperties) {
 
     // Test mean properties
     StudentTDistribution t_dist_1(1.0); // df = 1, mean undefined
     StudentTDistribution t_dist_2(2.0); // df = 2, mean = 0
     StudentTDistribution t_dist_5(5.0); // df = 5, mean = 0
 
-    assert(!t_dist_1.hasFiniteMean());
-    assert(t_dist_2.hasFiniteMean());
-    assert(t_dist_5.hasFiniteMean());
+    EXPECT_FALSE(t_dist_1.hasFiniteMean());
+    EXPECT_TRUE(t_dist_2.hasFiniteMean());
+    EXPECT_TRUE(t_dist_5.hasFiniteMean());
 
-    assert(std::isnan(t_dist_1.getMean()));
-    assert(t_dist_2.getMean() == 0.0);
-    assert(t_dist_5.getMean() == 0.0);
+    EXPECT_TRUE(std::isnan(t_dist_1.getMean()));
+    EXPECT_EQ(t_dist_2.getMean(), 0.0);
+    EXPECT_EQ(t_dist_5.getMean(), 0.0);
 
     // Test variance properties
-    assert(!t_dist_1.hasFiniteVariance());
-    assert(!t_dist_2.hasFiniteVariance()); // df = 2, variance infinite
+    EXPECT_FALSE(t_dist_1.hasFiniteVariance());
+    EXPECT_FALSE(t_dist_2.hasFiniteVariance()); // df = 2, variance infinite
 
     StudentTDistribution t_dist_3(3.0); // df = 3, variance = 3/(3-2) = 3
-    assert(t_dist_3.hasFiniteVariance());
-    assert(std::abs(t_dist_3.getVariance() - 3.0) < 1e-10);
-    assert(std::abs(t_dist_3.getStandardDeviation() - std::sqrt(3.0)) < 1e-10);
+    EXPECT_TRUE(t_dist_3.hasFiniteVariance());
+    EXPECT_NEAR(t_dist_3.getVariance(), 3.0, 1e-10);
+    EXPECT_NEAR(t_dist_3.getStandardDeviation(), std::sqrt(3.0), 1e-10);
 
     // Test variance formula: Var = ν/(ν-2) for ν > 2
     StudentTDistribution t_dist_10(10.0);
     double expected_var = 10.0 / (10.0 - 2.0);
-    assert(std::abs(t_dist_10.getVariance() - expected_var) < 1e-10);
+    EXPECT_NEAR(t_dist_10.getVariance(), expected_var, 1e-10);
 
-    std::cout << "✓ Statistical properties tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(StudentTDistributionTest, Fitting) {
 
     StudentTDistribution t_dist;
 
@@ -127,41 +114,39 @@ void testFitting() {
     t_dist.fit(data);
 
     // After fitting, degrees of freedom should be positive and reasonable
-    assert(t_dist.getDegreesOfFreedom() > 0.0);
-    assert(t_dist.getDegreesOfFreedom() < 1000.0); // Reasonable upper bound
+    EXPECT_GT(t_dist.getDegreesOfFreedom(), 0.0);
+    EXPECT_LT(t_dist.getDegreesOfFreedom(), 1000.0); // Reasonable upper bound
 
     // Test with insufficient data
     std::vector<Observation> single_point = {1.0};
     t_dist.fit(single_point);
-    assert(t_dist.getDegreesOfFreedom() == 1.0); // Should reset to default
+    EXPECT_EQ(t_dist.getDegreesOfFreedom(), 1.0); // Should reset to default
 
     // Test with empty data - should reset to defaults
     std::vector<Observation> empty_data;
     t_dist.fit(empty_data);
-    assert(t_dist.getDegreesOfFreedom() == 1.0);
-    assert(t_dist.getLocation() == 0.0);
-    assert(t_dist.getScale() == 1.0);
+    EXPECT_EQ(t_dist.getDegreesOfFreedom(), 1.0);
+    EXPECT_EQ(t_dist.getLocation(), 0.0);
+    EXPECT_EQ(t_dist.getScale(), 1.0);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(StudentTDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
     try {
         StudentTDistribution t_dist(0.0); // Zero degrees of freedom
-        assert(false);                    // Should not reach here
+        ADD_FAILURE();                    // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         StudentTDistribution t_dist(-1.0); // Negative degrees of freedom
-        assert(false);                     // Should not reach here
+        ADD_FAILURE();                     // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
@@ -170,132 +155,102 @@ void testParameterValidation() {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        StudentTDistribution t_dist(nan_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(StudentTDistribution t_dist(nan_val), std::invalid_argument);
 
-    try {
-        StudentTDistribution t_dist(inf_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(StudentTDistribution t_dist(inf_val), std::invalid_argument);
 
     // Test setter validation
     StudentTDistribution t_dist(1.0);
 
-    try {
-        t_dist.setDegreesOfFreedom(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(t_dist.setDegreesOfFreedom(0.0), std::invalid_argument);
 
-    try {
-        t_dist.setDegreesOfFreedom(-5.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(t_dist.setDegreesOfFreedom(-5.0), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation and serialization
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(StudentTDistributionTest, StringRepresentation) {
 
     StudentTDistribution t_dist(3.5);
     std::string str = t_dist.toString();
 
     // Should contain key information
-    assert(str.find("StudentT Distribution") != std::string::npos);
-    assert(str.find("3.5") != std::string::npos);
-    assert(str.find("nu") != std::string::npos);
+    EXPECT_NE(str.find("StudentT Distribution"), std::string::npos);
+    EXPECT_NE(str.find("3.5"), std::string::npos);
+    EXPECT_NE(str.find("nu"), std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(StudentTDistributionTest, CopyMoveSemantics) {
 
     StudentTDistribution original(4.2);
 
     // Test copy constructor
     StudentTDistribution copied(original);
-    assert(copied.getDegreesOfFreedom() == original.getDegreesOfFreedom());
-    assert(copied.getProbability(1.0) == original.getProbability(1.0));
+    EXPECT_EQ(copied.getDegreesOfFreedom(), original.getDegreesOfFreedom());
+    EXPECT_EQ(copied.getProbability(1.0), original.getProbability(1.0));
 
     // Test copy assignment
     StudentTDistribution assigned(1.0);
     assigned = original;
-    assert(assigned.getDegreesOfFreedom() == original.getDegreesOfFreedom());
-    assert(assigned.getProbability(1.0) == original.getProbability(1.0));
+    EXPECT_EQ(assigned.getDegreesOfFreedom(), original.getDegreesOfFreedom());
+    EXPECT_EQ(assigned.getProbability(1.0), original.getProbability(1.0));
 
     // Test move constructor
     double original_df = original.getDegreesOfFreedom();
     StudentTDistribution moved(std::move(original));
-    assert(moved.getDegreesOfFreedom() == original_df);
+    EXPECT_EQ(moved.getDegreesOfFreedom(), original_df);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test equality operators
  */
-void testEqualityOperators() {
-    std::cout << "Testing equality operators..." << std::endl;
+TEST(StudentTDistributionTest, EqualityOperators) {
 
     StudentTDistribution t1(3.0);
     StudentTDistribution t2(3.0);
     StudentTDistribution t3(4.0);
 
-    assert(t1 == t2);
-    assert(!(t1 == t3));
-    assert(t1 != t3);
-    assert(!(t1 != t2));
+    EXPECT_EQ(t1, t2);
+    EXPECT_FALSE(t1 == t3);
+    EXPECT_NE(t1, t3);
+    EXPECT_FALSE(t1 != t2);
 
-    std::cout << "✓ Equality operator tests passed" << std::endl;
 }
 
 /**
  * Test edge cases and numerical stability
  */
-void testEdgeCases() {
-    std::cout << "Testing edge cases..." << std::endl;
+TEST(StudentTDistributionTest, EdgeCases) {
 
     // Test very small degrees of freedom
     StudentTDistribution t_small(1e-5);
     double prob_small = t_small.getProbability(0.0);
-    assert(std::isfinite(prob_small) && prob_small > 0.0);
+    EXPECT_TRUE(std::isfinite(prob_small) && prob_small > 0.0);
 
     // Test very large degrees of freedom (should approach normal distribution)
     StudentTDistribution t_large(1e5);
     double prob_large = t_large.getProbability(0.0);
-    assert(std::isfinite(prob_large) && prob_large > 0.0);
+    EXPECT_TRUE(std::isfinite(prob_large) && prob_large > 0.0);
 
     // Test reset functionality
     StudentTDistribution t_test(10.0);
     t_test.reset();
-    assert(t_test.getDegreesOfFreedom() == 1.0);
+    EXPECT_EQ(t_test.getDegreesOfFreedom(), 1.0);
 
-    std::cout << "✓ Edge cases tests passed" << std::endl;
 }
 
 /**
  * Test log probability calculations
  */
-void testLogProbability() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(StudentTDistributionTest, LogProbability) {
 
     StudentTDistribution t_dist(2.0); // df=2
 
@@ -304,23 +259,21 @@ void testLogProbability() {
     double log_prob_1 = t_dist.getLogProbability(1.0);
     double log_prob_2 = t_dist.getLogProbability(2.0);
 
-    assert(std::isfinite(log_prob_0));
-    assert(std::isfinite(log_prob_1));
-    assert(std::isfinite(log_prob_2));
+    EXPECT_TRUE(std::isfinite(log_prob_0));
+    EXPECT_TRUE(std::isfinite(log_prob_1));
+    EXPECT_TRUE(std::isfinite(log_prob_2));
 
     // Test consistency between probability and log probability
     double prob_0 = t_dist.getProbability(0.0);
     double calculated_log_prob_0 = std::log(prob_0);
-    assert(std::abs(calculated_log_prob_0 - log_prob_0) < 1e-10);
+    EXPECT_NEAR(calculated_log_prob_0, log_prob_0, 1e-10);
 
-    std::cout << "✓ Log probability tests passed" << std::endl;
 }
 
 /**
  * Test cumulative distribution function
  */
-void testCDF() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(StudentTDistributionTest, CDF) {
 
     StudentTDistribution t_dist(3.0); // df=3
 
@@ -329,35 +282,31 @@ void testCDF() {
     double cdf_1 = t_dist.getCumulativeProbability(1.0);
     double cdf_2 = t_dist.getCumulativeProbability(2.0);
 
-    assert(cdf_0 > 0.0 && cdf_0 < 1.0);
-    assert(cdf_1 > cdf_0);
-    assert(cdf_2 > cdf_1);
+    EXPECT_TRUE(cdf_0 > 0.0 && cdf_0 < 1.0);
+    EXPECT_GT(cdf_1, cdf_0);
+    EXPECT_GT(cdf_2, cdf_1);
 
-    std::cout << "✓ CDF tests passed" << std::endl;
 }
 
 /**
  * Test invalid input handling
  */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(StudentTDistributionTest, InvalidInputHandling) {
 
     StudentTDistribution t_dist(4.0);
 
     // Test probability with NaN (should return 0.0 like other distributions)
-    assert(t_dist.getProbability(std::numeric_limits<double>::quiet_NaN()) == 0.0);
+    EXPECT_EQ(t_dist.getProbability(std::numeric_limits<double>::quiet_NaN()), 0.0);
 
     // Test CDF with NaN (should return NaN for CDF)
-    assert(std::isnan(t_dist.getCumulativeProbability(std::numeric_limits<double>::quiet_NaN())));
+    EXPECT_TRUE(std::isnan(t_dist.getCumulativeProbability(std::numeric_limits<double>::quiet_NaN())));
 
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
 }
 
 /**
  * Test caching behavior
  */
-void testCaching() {
-    std::cout << "Testing caching behavior..." << std::endl;
+TEST(StudentTDistributionTest, Caching) {
 
     StudentTDistribution t_dist(5.0);
 
@@ -367,16 +316,14 @@ void testCaching() {
     // Change degrees of freedom to invalidate cache
     t_dist.setDegreesOfFreedom(10.0);
     double prob2 = t_dist.getProbability(1.5);
-    assert(prob1 != prob2); // Should differ because cache was invalidated
+    EXPECT_NE(prob1, prob2); // Should differ because cache was invalidated
 
-    std::cout << "✓ Caching behavior tests passed" << std::endl;
 }
 
 /**
  * Test performance of key functions
  */
-void testPerformance() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(StudentTDistributionTest, Performance) {
 
     StudentTDistribution t_dist(6.0);
 
@@ -427,45 +374,16 @@ void testPerformance() {
               << " μs/point (" << fitData.size() << " points)" << std::endl;
 
     // Performance requirements (should be reasonable)
-    assert(pdfTimePerCall < 10.0);   // Less than 10 μs per PDF call
-    assert(logPdfTimePerCall < 5.0); // Less than 5 μs per log PDF call
-    assert(fitTimePerPoint < 50.0);  // Less than 50 μs per data point for fitting
+    EXPECT_LT(pdfTimePerCall, 10.0);   // Less than 10 μs per PDF call
+    EXPECT_LT(logPdfTimePerCall, 5.0); // Less than 5 μs per log PDF call
+    EXPECT_LT(fitTimePerPoint, 50.0);  // Less than 50 μs per data point for fitting
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
 /**
  * Main test function
  */
-int main() {
-    std::cout << "=== Student's t-Distribution Unit Tests ===" << std::endl;
-    std::cout << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testLogProbability();
-        testCDF();
-        testInvalidInputHandling();
-        testStatisticalProperties();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testEqualityOperators();
-        testCaching();
-        testPerformance();
-        testEdgeCases();
-
-        std::cout << std::endl;
-        std::cout << "🎉 All Student's t-distribution tests passed!" << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_student_t_distribution.cpp
+++ b/tests/distributions/test_student_t_distribution.cpp
@@ -28,7 +28,6 @@ TEST(StudentTDistributionTest, BasicFunctionality) {
     // Test parameter setter
     t_dist.setDegreesOfFreedom(3.0);
     EXPECT_EQ(t_dist.getDegreesOfFreedom(), 3.0);
-
 }
 
 /**
@@ -65,7 +64,6 @@ TEST(StudentTDistributionTest, Probabilities) {
     // But for t(1) vs t(30), t(30) should have higher peak and lower tails
     EXPECT_GT(prob_1, 0.0);
     EXPECT_GT(prob_30, 0.0);
-
 }
 
 /**
@@ -99,7 +97,6 @@ TEST(StudentTDistributionTest, StatisticalProperties) {
     StudentTDistribution t_dist_10(10.0);
     double expected_var = 10.0 / (10.0 - 2.0);
     EXPECT_NEAR(t_dist_10.getVariance(), expected_var, 1e-10);
-
 }
 
 /**
@@ -128,7 +125,6 @@ TEST(StudentTDistributionTest, Fitting) {
     EXPECT_EQ(t_dist.getDegreesOfFreedom(), 1.0);
     EXPECT_EQ(t_dist.getLocation(), 0.0);
     EXPECT_EQ(t_dist.getScale(), 1.0);
-
 }
 
 /**
@@ -165,7 +161,6 @@ TEST(StudentTDistributionTest, ParameterValidation) {
     EXPECT_THROW(t_dist.setDegreesOfFreedom(0.0), std::invalid_argument);
 
     EXPECT_THROW(t_dist.setDegreesOfFreedom(-5.0), std::invalid_argument);
-
 }
 
 /**
@@ -206,7 +201,6 @@ TEST(StudentTDistributionTest, CopyMoveSemantics) {
     double original_df = original.getDegreesOfFreedom();
     StudentTDistribution moved(std::move(original));
     EXPECT_EQ(moved.getDegreesOfFreedom(), original_df);
-
 }
 
 /**
@@ -222,7 +216,6 @@ TEST(StudentTDistributionTest, EqualityOperators) {
     EXPECT_FALSE(t1 == t3);
     EXPECT_NE(t1, t3);
     EXPECT_FALSE(t1 != t2);
-
 }
 
 /**
@@ -244,7 +237,6 @@ TEST(StudentTDistributionTest, EdgeCases) {
     StudentTDistribution t_test(10.0);
     t_test.reset();
     EXPECT_EQ(t_test.getDegreesOfFreedom(), 1.0);
-
 }
 
 /**
@@ -267,7 +259,6 @@ TEST(StudentTDistributionTest, LogProbability) {
     double prob_0 = t_dist.getProbability(0.0);
     double calculated_log_prob_0 = std::log(prob_0);
     EXPECT_NEAR(calculated_log_prob_0, log_prob_0, 1e-10);
-
 }
 
 /**
@@ -285,7 +276,6 @@ TEST(StudentTDistributionTest, CDF) {
     EXPECT_TRUE(cdf_0 > 0.0 && cdf_0 < 1.0);
     EXPECT_GT(cdf_1, cdf_0);
     EXPECT_GT(cdf_2, cdf_1);
-
 }
 
 /**
@@ -299,8 +289,8 @@ TEST(StudentTDistributionTest, InvalidInputHandling) {
     EXPECT_EQ(t_dist.getProbability(std::numeric_limits<double>::quiet_NaN()), 0.0);
 
     // Test CDF with NaN (should return NaN for CDF)
-    EXPECT_TRUE(std::isnan(t_dist.getCumulativeProbability(std::numeric_limits<double>::quiet_NaN())));
-
+    EXPECT_TRUE(
+        std::isnan(t_dist.getCumulativeProbability(std::numeric_limits<double>::quiet_NaN())));
 }
 
 /**
@@ -317,7 +307,6 @@ TEST(StudentTDistributionTest, Caching) {
     t_dist.setDegreesOfFreedom(10.0);
     double prob2 = t_dist.getProbability(1.5);
     EXPECT_NE(prob1, prob2); // Should differ because cache was invalidated
-
 }
 
 /**
@@ -377,7 +366,6 @@ TEST(StudentTDistributionTest, Performance) {
     EXPECT_LT(pdfTimePerCall, 10.0);   // Less than 10 μs per PDF call
     EXPECT_LT(logPdfTimePerCall, 5.0); // Less than 5 μs per log PDF call
     EXPECT_LT(fitTimePerPoint, 50.0);  // Less than 50 μs per data point for fitting
-
 }
 
 /**

--- a/tests/distributions/test_uniform_distribution.cpp
+++ b/tests/distributions/test_uniform_distribution.cpp
@@ -1,19 +1,13 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <limits>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 #include "libhmm/distributions/uniform_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::Observation;
 using libhmm::UniformDistribution;
@@ -21,59 +15,54 @@ using libhmm::UniformDistribution;
 /**
  * Test basic Uniform distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Uniform distribution functionality..." << std::endl;
+TEST(UniformDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     UniformDistribution uniform;
-    assert(uniform.getA() == 0.0);
-    assert(uniform.getB() == 1.0);
-    assert(uniform.getMin() == 0.0); // Alternative getter
-    assert(uniform.getMax() == 1.0); // Alternative getter
+    EXPECT_EQ(uniform.getA(), 0.0);
+    EXPECT_EQ(uniform.getB(), 1.0);
+    EXPECT_EQ(uniform.getMin(), 0.0); // Alternative getter
+    EXPECT_EQ(uniform.getMax(), 1.0); // Alternative getter
 
     // Test parameterized constructor
     UniformDistribution uniform2(2.0, 5.0);
-    assert(uniform2.getA() == 2.0);
-    assert(uniform2.getB() == 5.0);
+    EXPECT_EQ(uniform2.getA(), 2.0);
+    EXPECT_EQ(uniform2.getB(), 5.0);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(UniformDistributionTest, Probabilities) {
 
     UniformDistribution uniform(1.0, 4.0); // Uniform on [1, 4]
 
     // Test that probability is zero outside the interval
-    assert(uniform.getProbability(0.5) == 0.0);
-    assert(uniform.getProbability(4.5) == 0.0);
-    assert(uniform.getProbability(-1.0) == 0.0);
+    EXPECT_EQ(uniform.getProbability(0.5), 0.0);
+    EXPECT_EQ(uniform.getProbability(4.5), 0.0);
+    EXPECT_EQ(uniform.getProbability(-1.0), 0.0);
 
     // Test that probability is constant within the interval
     double expectedPdf = 1.0 / (4.0 - 1.0); // 1/3
-    assert(std::abs(uniform.getProbability(1.5) - expectedPdf) < 1e-10);
-    assert(std::abs(uniform.getProbability(2.0) - expectedPdf) < 1e-10);
-    assert(std::abs(uniform.getProbability(3.5) - expectedPdf) < 1e-10);
+    EXPECT_NEAR(uniform.getProbability(1.5), expectedPdf, 1e-10);
+    EXPECT_NEAR(uniform.getProbability(2.0), expectedPdf, 1e-10);
+    EXPECT_NEAR(uniform.getProbability(3.5), expectedPdf, 1e-10);
 
     // Test boundary values
-    assert(std::abs(uniform.getProbability(1.0) - expectedPdf) < 1e-10);
-    assert(std::abs(uniform.getProbability(4.0) - expectedPdf) < 1e-10);
+    EXPECT_NEAR(uniform.getProbability(1.0), expectedPdf, 1e-10);
+    EXPECT_NEAR(uniform.getProbability(4.0), expectedPdf, 1e-10);
 
     // Test that probability density is reasonable
-    assert(uniform.getProbability(2.0) > 0.0);
-    assert(uniform.getProbability(2.0) < 1.0);
+    EXPECT_GT(uniform.getProbability(2.0), 0.0);
+    EXPECT_LT(uniform.getProbability(2.0), 1.0);
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(UniformDistributionTest, Fitting) {
 
     UniformDistribution uniform;
 
@@ -82,42 +71,40 @@ void testFitting() {
     uniform.fit(data);
 
     // After fitting, bounds should encompass all data with some padding
-    assert(uniform.getA() <= 1.0);           // Should be at or below minimum
-    assert(uniform.getB() >= 5.0);           // Should be at or above maximum
-    assert(uniform.getA() < uniform.getB()); // Valid interval
+    EXPECT_LE(uniform.getA(), 1.0);           // Should be at or below minimum
+    EXPECT_TRUE(uniform.getB() >= 5.0);           // Should be at or above maximum
+    EXPECT_LT(uniform.getA(), uniform.getB()); // Valid interval
 
     // Test with empty data (should reset to default)
     std::vector<Observation> emptyData;
     uniform.fit(emptyData);
-    assert(uniform.getA() == 0.0);
-    assert(uniform.getB() == 1.0);
+    EXPECT_EQ(uniform.getA(), 0.0);
+    EXPECT_EQ(uniform.getB(), 1.0);
 
     // Test with single point (should reset to default for insufficient data)
     std::vector<Observation> singlePoint = {2.5};
     uniform.fit(singlePoint);
-    assert(uniform.getA() == 0.0);
-    assert(uniform.getB() == 1.0);
+    EXPECT_EQ(uniform.getA(), 0.0);
+    EXPECT_EQ(uniform.getB(), 1.0);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(UniformDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
     try {
         UniformDistribution uniform(5.0, 2.0); // a > b
-        assert(false);                         // Should not reach here
+        ADD_FAILURE();                         // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         UniformDistribution uniform(3.0, 3.0); // a == b
-        assert(false);                         // Should not reach here
+        ADD_FAILURE();                         // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
@@ -126,103 +113,87 @@ void testParameterValidation() {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        UniformDistribution uniform(nan_val, 1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(UniformDistribution uniform(nan_val, 1.0), std::invalid_argument);
 
-    try {
-        UniformDistribution uniform(1.0, inf_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(UniformDistribution uniform(1.0, inf_val), std::invalid_argument);
 
     // Test setters validation
     UniformDistribution uniform(1.0, 3.0);
 
     try {
         uniform.setA(4.0); // Would make a > b
-        assert(false);     // Should not reach here
+        ADD_FAILURE();     // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         uniform.setB(0.5); // Would make b < a
-        assert(false);     // Should not reach here
+        ADD_FAILURE();     // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(UniformDistributionTest, StringRepresentation) {
 
     UniformDistribution uniform(2.5, 7.5);
     std::string str = uniform.toString();
 
     // Should contain key information based on actual output format:
     // "Uniform Distribution:\n      a (lower bound) = 2.5\n      b (upper bound) = 7.5\n"
-    assert(str.find("Uniform") != std::string::npos);
-    assert(str.find("Distribution") != std::string::npos);
-    assert(str.find("2.5") != std::string::npos);
-    assert(str.find("7.5") != std::string::npos);
-    assert(str.find("a") != std::string::npos);
-    assert(str.find("lower bound") != std::string::npos);
-    assert(str.find("b") != std::string::npos);
-    assert(str.find("upper bound") != std::string::npos);
+    EXPECT_NE(str.find("Uniform"), std::string::npos);
+    EXPECT_NE(str.find("Distribution"), std::string::npos);
+    EXPECT_NE(str.find("2.5"), std::string::npos);
+    EXPECT_NE(str.find("7.5"), std::string::npos);
+    EXPECT_NE(str.find("a"), std::string::npos);
+    EXPECT_NE(str.find("lower bound"), std::string::npos);
+    EXPECT_NE(str.find("b"), std::string::npos);
+    EXPECT_NE(str.find("upper bound"), std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(UniformDistributionTest, CopyMoveSemantics) {
 
     UniformDistribution original(3.14, 6.28);
 
     // Test copy constructor
     UniformDistribution copied(original);
-    assert(copied.getA() == original.getA());
-    assert(copied.getB() == original.getB());
+    EXPECT_EQ(copied.getA(), original.getA());
+    EXPECT_EQ(copied.getB(), original.getB());
 
     // Test copy assignment
     UniformDistribution assigned;
     assigned = original;
-    assert(assigned.getA() == original.getA());
-    assert(assigned.getB() == original.getB());
+    EXPECT_EQ(assigned.getA(), original.getA());
+    EXPECT_EQ(assigned.getB(), original.getB());
 
     // Test move constructor
     UniformDistribution moved(std::move(original));
-    assert(moved.getA() == 3.14);
-    assert(moved.getB() == 6.28);
+    EXPECT_EQ(moved.getA(), 3.14);
+    EXPECT_EQ(moved.getB(), 6.28);
 
     // Test move assignment
     UniformDistribution moveAssigned;
     UniformDistribution temp(1.41, 2.73);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getA() == 1.41);
-    assert(moveAssigned.getB() == 2.73);
+    EXPECT_EQ(moveAssigned.getA(), 1.41);
+    EXPECT_EQ(moveAssigned.getB(), 2.73);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test invalid input handling
  */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(UniformDistributionTest, InvalidInputHandling) {
 
     UniformDistribution uniform(0.0, 1.0);
 
@@ -231,164 +202,142 @@ void testInvalidInputHandling() {
     double inf_val = std::numeric_limits<double>::infinity();
     double neg_inf_val = -std::numeric_limits<double>::infinity();
 
-    assert(uniform.getProbability(nan_val) == 0.0);
-    assert(uniform.getProbability(inf_val) == 0.0);
-    assert(uniform.getProbability(neg_inf_val) == 0.0);
+    EXPECT_EQ(uniform.getProbability(nan_val), 0.0);
+    EXPECT_EQ(uniform.getProbability(inf_val), 0.0);
+    EXPECT_EQ(uniform.getProbability(neg_inf_val), 0.0);
 
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
 }
 
 /**
  * Test reset functionality
  */
-void testResetFunctionality() {
-    std::cout << "Testing reset functionality..." << std::endl;
+TEST(UniformDistributionTest, ResetFunctionality) {
 
     UniformDistribution uniform(10.0, 20.0);
     uniform.reset();
 
-    assert(uniform.getA() == 0.0);
-    assert(uniform.getB() == 1.0);
+    EXPECT_EQ(uniform.getA(), 0.0);
+    EXPECT_EQ(uniform.getB(), 1.0);
 
-    std::cout << "✓ Reset functionality tests passed" << std::endl;
 }
 
 /**
  * Test uniform distribution properties
  */
-void testUniformProperties() {
-    std::cout << "Testing uniform distribution properties..." << std::endl;
+TEST(UniformDistributionTest, UniformProperties) {
 
     // Test standard uniform [0, 1]
     UniformDistribution standard(0.0, 1.0);
-    assert(std::abs(standard.getMean() - 0.5) < 1e-10);            // Mean = (0+1)/2 = 0.5
-    assert(std::abs(standard.getVariance() - 1.0 / 12.0) < 1e-10); // Variance = (1-0)²/12 = 1/12
+    EXPECT_NEAR(standard.getMean(), 0.5, 1e-10);            // Mean = (0+1)/2 = 0.5
+    EXPECT_NEAR(standard.getVariance(), 1.0 / 12.0, 1e-10); // Variance = (1-0)²/12 = 1/12
 
     // Test general case [2, 8]
     UniformDistribution general(2.0, 8.0);
     double expectedMean = (2.0 + 8.0) / 2.0;               // 5.0
     double expectedVar = (8.0 - 2.0) * (8.0 - 2.0) / 12.0; // 36/12 = 3.0
-    assert(std::abs(general.getMean() - expectedMean) < 1e-10);
-    assert(std::abs(general.getVariance() - expectedVar) < 1e-10);
+    EXPECT_NEAR(general.getMean(), expectedMean, 1e-10);
+    EXPECT_NEAR(general.getVariance(), expectedVar, 1e-10);
 
     // Test standard deviation relationship
-    assert(std::abs(general.getStandardDeviation() - std::sqrt(general.getVariance())) < 1e-10);
+    EXPECT_NEAR(general.getStandardDeviation(), std::sqrt(general.getVariance()), 1e-10);
 
     // Test that probability is constant within interval
     double pdf1 = general.getProbability(3.0);
     double pdf2 = general.getProbability(5.0);
     double pdf3 = general.getProbability(7.0);
-    assert(std::abs(pdf1 - pdf2) < 1e-10);
-    assert(std::abs(pdf2 - pdf3) < 1e-10);
+    EXPECT_NEAR(pdf1, pdf2, 1e-10);
+    EXPECT_NEAR(pdf2, pdf3, 1e-10);
 
-    std::cout << "✓ Uniform property tests passed" << std::endl;
 }
 
 /**
  * Test fitting validation
  */
-void testFittingValidation() {
-    std::cout << "Testing fitting validation..." << std::endl;
+TEST(UniformDistributionTest, FittingValidation) {
 
     UniformDistribution uniform;
 
     // Test with NaN values
     std::vector<Observation> nanData = {1.0, 2.0, std::numeric_limits<double>::quiet_NaN(), 3.0};
-    try {
-        uniform.fit(nanData);
-        assert(false); // Should throw exception
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(uniform.fit(nanData), std::invalid_argument);
 
     // Test with infinity values
     std::vector<Observation> infData = {1.0, 2.0, std::numeric_limits<double>::infinity(), 3.0};
-    try {
-        uniform.fit(infData);
-        assert(false); // Should throw exception
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(uniform.fit(infData), std::invalid_argument);
 
     // Test with valid data
     std::vector<Observation> validData = {1.5, 2.0, 3.5, 4.0, 2.5};
     try {
         uniform.fit(validData);
         // Should work fine, check that parameters are reasonable
-        assert(uniform.getA() < uniform.getB());
-        assert(uniform.getA() <= 1.5); // Should encompass minimum
-        assert(uniform.getB() >= 4.0); // Should encompass maximum
+        EXPECT_LT(uniform.getA(), uniform.getB());
+        EXPECT_LE(uniform.getA(), 1.5); // Should encompass minimum
+        EXPECT_TRUE(uniform.getB() >= 4.0); // Should encompass maximum
     } catch (const std::exception &) {
-        assert(false); // Should not throw
+        ADD_FAILURE(); // Should not throw
     }
 
-    std::cout << "✓ Fitting validation tests passed" << std::endl;
 }
 
 /**
  * Test parameter setters
  */
-void testParameterSetters() {
-    std::cout << "Testing parameter setters..." << std::endl;
+TEST(UniformDistributionTest, ParameterSetters) {
 
     UniformDistribution uniform(1.0, 5.0);
 
     // Test individual setters
     uniform.setA(0.5);
-    assert(uniform.getA() == 0.5);
-    assert(uniform.getB() == 5.0);
+    EXPECT_EQ(uniform.getA(), 0.5);
+    EXPECT_EQ(uniform.getB(), 5.0);
 
     uniform.setB(6.0);
-    assert(uniform.getA() == 0.5);
-    assert(uniform.getB() == 6.0);
+    EXPECT_EQ(uniform.getA(), 0.5);
+    EXPECT_EQ(uniform.getB(), 6.0);
 
     // Test setting both parameters
     uniform.setParameters(2.0, 8.0);
-    assert(uniform.getA() == 2.0);
-    assert(uniform.getB() == 8.0);
+    EXPECT_EQ(uniform.getA(), 2.0);
+    EXPECT_EQ(uniform.getB(), 8.0);
 
-    std::cout << "✓ Parameter setter tests passed" << std::endl;
 }
 
 /**
  * Test edge cases
  */
-void testEdgeCases() {
-    std::cout << "Testing edge cases..." << std::endl;
+TEST(UniformDistributionTest, EdgeCases) {
 
     // Test with very small interval
     UniformDistribution tiny(0.0, 1e-10);
-    assert(tiny.getProbability(5e-11) > 0.0);  // Should be within interval
-    assert(tiny.getProbability(2e-10) == 0.0); // Should be outside interval
+    EXPECT_GT(tiny.getProbability(5e-11), 0.0);  // Should be within interval
+    EXPECT_EQ(tiny.getProbability(2e-10), 0.0); // Should be outside interval
 
     // Test with large interval
     UniformDistribution large(-1e6, 1e6);
     double largePdf = large.getProbability(0.0);
-    assert(largePdf > 0.0);
-    assert(largePdf == 1.0 / (2e6)); // 1/(b-a)
+    EXPECT_GT(largePdf, 0.0);
+    EXPECT_EQ(largePdf, 1.0 / (2e6)); // 1/(b-a)
 
     // Test with negative interval
     UniformDistribution negative(-5.0, -2.0);
-    assert(negative.getProbability(-3.5) > 0.0);
-    assert(negative.getProbability(0.0) == 0.0);
-    assert(std::abs(negative.getMean() - (-3.5)) < 1e-10); // Mean = (-5 + -2)/2 = -3.5
+    EXPECT_GT(negative.getProbability(-3.5), 0.0);
+    EXPECT_EQ(negative.getProbability(0.0), 0.0);
+    EXPECT_NEAR(negative.getMean(), (-3.5), 1e-10); // Mean = (-5 + -2)/2 = -3.5
 
     // Test isApproximatelyEqual
     UniformDistribution u1(1.0, 3.0);
     UniformDistribution u2(1.000000001, 3.000000001);
     UniformDistribution u3(1.1, 3.1);
 
-    assert(u1.isApproximatelyEqual(u2, 1e-8));
-    assert(!u1.isApproximatelyEqual(u3, 1e-8));
+    EXPECT_TRUE(u1.isApproximatelyEqual(u2, 1e-8));
+    EXPECT_FALSE(u1.isApproximatelyEqual(u3, 1e-8));
 
-    std::cout << "✓ Edge cases tests passed" << std::endl;
 }
 
 /**
  * Test fitting with identical data
  */
-void testFittingIdenticalData() {
-    std::cout << "Testing fitting with identical data..." << std::endl;
+TEST(UniformDistributionTest, FittingIdenticalData) {
 
     UniformDistribution uniform;
 
@@ -397,101 +346,95 @@ void testFittingIdenticalData() {
     uniform.fit(identicalData);
 
     // Should create a small interval around the value
-    assert(uniform.getA() < 5.0);
-    assert(uniform.getB() > 5.0);
-    assert(uniform.getA() < uniform.getB());
+    EXPECT_LT(uniform.getA(), 5.0);
+    EXPECT_GT(uniform.getB(), 5.0);
+    EXPECT_LT(uniform.getA(), uniform.getB());
 
     // The value should be within the fitted interval
-    assert(uniform.getProbability(5.0) > 0.0);
+    EXPECT_GT(uniform.getProbability(5.0), 0.0);
 
-    std::cout << "✓ Fitting with identical data tests passed" << std::endl;
 }
 
 /**
  * Test log probability calculations
  */
-void testLogProbabilities() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(UniformDistributionTest, LogProbabilities) {
 
     UniformDistribution uniform(1.0, 4.0); // Uniform on [1, 4]
 
     // Test that log probability is -infinity outside the interval
-    assert(std::isinf(uniform.getLogProbability(0.5)) && uniform.getLogProbability(0.5) < 0);
-    assert(std::isinf(uniform.getLogProbability(4.5)) && uniform.getLogProbability(4.5) < 0);
-    assert(std::isinf(uniform.getLogProbability(-1.0)) && uniform.getLogProbability(-1.0) < 0);
+    EXPECT_TRUE(std::isinf(uniform.getLogProbability(0.5)) && uniform.getLogProbability(0.5) < 0);
+    EXPECT_TRUE(std::isinf(uniform.getLogProbability(4.5)) && uniform.getLogProbability(4.5) < 0);
+    EXPECT_TRUE(std::isinf(uniform.getLogProbability(-1.0)) && uniform.getLogProbability(-1.0) < 0);
 
     // Test that log probability is constant within the interval
     double expectedLogPdf = -std::log(4.0 - 1.0); // -log(3)
-    assert(std::abs(uniform.getLogProbability(1.5) - expectedLogPdf) < 1e-10);
-    assert(std::abs(uniform.getLogProbability(2.0) - expectedLogPdf) < 1e-10);
-    assert(std::abs(uniform.getLogProbability(3.5) - expectedLogPdf) < 1e-10);
+    EXPECT_NEAR(uniform.getLogProbability(1.5), expectedLogPdf, 1e-10);
+    EXPECT_NEAR(uniform.getLogProbability(2.0), expectedLogPdf, 1e-10);
+    EXPECT_NEAR(uniform.getLogProbability(3.5), expectedLogPdf, 1e-10);
 
     // Test boundary values
-    assert(std::abs(uniform.getLogProbability(1.0) - expectedLogPdf) < 1e-10);
-    assert(std::abs(uniform.getLogProbability(4.0) - expectedLogPdf) < 1e-10);
+    EXPECT_NEAR(uniform.getLogProbability(1.0), expectedLogPdf, 1e-10);
+    EXPECT_NEAR(uniform.getLogProbability(4.0), expectedLogPdf, 1e-10);
 
     // Test consistency between log and regular probability
     double x = 2.5;
-    assert(std::abs(std::log(uniform.getProbability(x)) - uniform.getLogProbability(x)) < 1e-10);
+    EXPECT_NEAR(std::log(uniform.getProbability(x)), uniform.getLogProbability(x), 1e-10);
 
-    std::cout << "✓ Log probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test CDF calculations
  */
-void testCDF() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(UniformDistributionTest, CDF) {
 
     UniformDistribution uniform(2.0, 8.0); // Uniform on [2, 8]
 
     // Test CDF values outside the interval
-    assert(uniform.CDF(1.0) == 0.0); // Below lower bound
-    assert(uniform.CDF(9.0) == 1.0); // Above upper bound
+    EXPECT_EQ(uniform.CDF(1.0), 0.0); // Below lower bound
+    EXPECT_EQ(uniform.CDF(9.0), 1.0); // Above upper bound
 
     // Test CDF at boundaries
-    assert(uniform.CDF(2.0) == 0.0); // At lower bound
-    assert(uniform.CDF(8.0) == 1.0); // At upper bound
+    EXPECT_EQ(uniform.CDF(2.0), 0.0); // At lower bound
+    EXPECT_EQ(uniform.CDF(8.0), 1.0); // At upper bound
 
     // Test CDF within the interval
-    assert(std::abs(uniform.CDF(5.0) - 0.5) < 1e-10);  // Midpoint should be 0.5
-    assert(std::abs(uniform.CDF(3.5) - 0.25) < 1e-10); // (3.5-2)/(8-2) = 0.25
-    assert(std::abs(uniform.CDF(6.5) - 0.75) < 1e-10); // (6.5-2)/(8-2) = 0.75
+    EXPECT_NEAR(uniform.CDF(5.0), 0.5, 1e-10);  // Midpoint should be 0.5
+    EXPECT_NEAR(uniform.CDF(3.5), 0.25, 1e-10); // (3.5-2)/(8-2) = 0.25
+    EXPECT_NEAR(uniform.CDF(6.5), 0.75, 1e-10); // (6.5-2)/(8-2) = 0.75
 
     // Test CDF is monotonically increasing
-    assert(uniform.CDF(3.0) < uniform.CDF(4.0));
-    assert(uniform.CDF(4.0) < uniform.CDF(5.0));
-    assert(uniform.CDF(5.0) < uniform.CDF(6.0));
+    EXPECT_LT(uniform.CDF(3.0), uniform.CDF(4.0));
+    EXPECT_LT(uniform.CDF(4.0), uniform.CDF(5.0));
+    EXPECT_LT(uniform.CDF(5.0), uniform.CDF(6.0));
 
     // Test with NaN and infinity
-    assert(std::isnan(uniform.CDF(std::numeric_limits<double>::quiet_NaN())));
-    assert(uniform.CDF(std::numeric_limits<double>::infinity()) == 1.0);
-    assert(uniform.CDF(-std::numeric_limits<double>::infinity()) == 0.0);
+    EXPECT_TRUE(std::isnan(uniform.CDF(std::numeric_limits<double>::quiet_NaN())));
+    EXPECT_EQ(uniform.CDF(std::numeric_limits<double>::infinity()), 1.0);
+    EXPECT_EQ(uniform.CDF(-std::numeric_limits<double>::infinity()), 0.0);
 
-    std::cout << "✓ CDF calculation tests passed" << std::endl;
 }
 
 /**
  * Test equality operators and I/O
  */
-void testEqualityAndIO() {
-    std::cout << "Testing equality operators and I/O..." << std::endl;
+TEST(UniformDistributionTest, EqualityAndIO) {
 
     UniformDistribution u1(1.5, 4.5);
     UniformDistribution u2(1.5, 4.5);
     UniformDistribution u3(2.0, 5.0);
 
     // Test equality operator
-    assert(u1 == u2);
-    assert(!(u1 == u3));
+    EXPECT_EQ(u1, u2);
+    EXPECT_FALSE(u1 == u3);
 
     // Test stream output
     std::ostringstream oss;
     oss << u1;
     std::string output = oss.str();
-    assert(output.find("Uniform Distribution") != std::string::npos);
-    assert(output.find("1.5") != std::string::npos);
-    assert(output.find("4.5") != std::string::npos);
+    EXPECT_NE(output.find("Uniform Distribution"), std::string::npos);
+    EXPECT_NE(output.find("1.5"), std::string::npos);
+    EXPECT_NE(output.find("4.5"), std::string::npos);
 
     std::cout << "Stream output: " << output << std::endl;
 
@@ -501,18 +444,16 @@ void testEqualityAndIO() {
     iss >> inputDist;
 
     if (iss.good()) {
-        assert(std::abs(inputDist.getA() - 3.14) < 1e-10);
-        assert(std::abs(inputDist.getB() - 6.28) < 1e-10);
+        EXPECT_NEAR(inputDist.getA(), 3.14, 1e-10);
+        EXPECT_NEAR(inputDist.getB(), 6.28, 1e-10);
     }
 
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
 }
 
 /**
  * Test caching mechanism
  */
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
+TEST(UniformDistributionTest, Caching) {
 
     UniformDistribution uniform(1.0, 5.0);
 
@@ -525,27 +466,25 @@ void testCaching() {
     double logPdf2 = uniform.getLogProbability(3.5);
 
     // Should be identical for uniform distribution
-    assert(std::abs(pdf1 - pdf2) < 1e-15);
-    assert(std::abs(logPdf1 - logPdf2) < 1e-15);
+    EXPECT_NEAR(pdf1, pdf2, 1e-15);
+    EXPECT_NEAR(logPdf1, logPdf2, 1e-15);
 
     // Changing parameters should invalidate cache
     uniform.setA(0.5);
     double pdf3 = uniform.getProbability(3.0);
-    assert(std::abs(pdf3 - pdf1) > 1e-10); // Should be different now
+    EXPECT_GT(std::abs(pdf3 - pdf1), 1e-10); // Should be different now
 
     // Reset should also invalidate cache
     uniform.reset();
     double pdf4 = uniform.getProbability(0.5);
-    assert(pdf4 == 1.0); // Should be 1.0 for [0,1] interval
+    EXPECT_EQ(pdf4, 1.0); // Should be 1.0 for [0,1] interval
 
-    std::cout << "✓ Caching mechanism tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics and optimizations
  */
-void testPerformanceCharacteristics() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(UniformDistributionTest, PerformanceCharacteristics) {
 
     UniformDistribution uniform(0.5, 5.5);
 
@@ -596,46 +535,13 @@ void testPerformanceCharacteristics() {
               << " μs/point (" << fitData.size() << " points)" << std::endl;
 
     // Performance requirements (should be fast)
-    assert(pdfTimePerCall < 1.0);    // Less than 1 μs per PDF call
-    assert(logPdfTimePerCall < 1.0); // Less than 1 μs per log PDF call
-    assert(fitTimePerPoint < 0.1);   // Less than 0.1 μs per data point for fitting
+    EXPECT_LT(pdfTimePerCall, 1.0);    // Less than 1 μs per PDF call
+    EXPECT_LT(logPdfTimePerCall, 1.0); // Less than 1 μs per log PDF call
+    EXPECT_LT(fitTimePerPoint, 0.1);   // Less than 0.1 μs per data point for fitting
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running Uniform distribution tests..." << std::endl;
-    std::cout << "=====================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testInvalidInputHandling();
-        testResetFunctionality();
-        testUniformProperties();
-        testFittingValidation();
-        testParameterSetters();
-        testEdgeCases();
-        testFittingIdenticalData();
-        testLogProbabilities();
-        testCDF();
-        testEqualityAndIO();
-        testCaching();
-        testPerformanceCharacteristics();
-
-        std::cout << "=====================================" << std::endl;
-        std::cout << "✅ All Uniform distribution tests passed!" << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_uniform_distribution.cpp
+++ b/tests/distributions/test_uniform_distribution.cpp
@@ -28,7 +28,6 @@ TEST(UniformDistributionTest, BasicFunctionality) {
     UniformDistribution uniform2(2.0, 5.0);
     EXPECT_EQ(uniform2.getA(), 2.0);
     EXPECT_EQ(uniform2.getB(), 5.0);
-
 }
 
 /**
@@ -56,7 +55,6 @@ TEST(UniformDistributionTest, Probabilities) {
     // Test that probability density is reasonable
     EXPECT_GT(uniform.getProbability(2.0), 0.0);
     EXPECT_LT(uniform.getProbability(2.0), 1.0);
-
 }
 
 /**
@@ -71,8 +69,8 @@ TEST(UniformDistributionTest, Fitting) {
     uniform.fit(data);
 
     // After fitting, bounds should encompass all data with some padding
-    EXPECT_LE(uniform.getA(), 1.0);           // Should be at or below minimum
-    EXPECT_TRUE(uniform.getB() >= 5.0);           // Should be at or above maximum
+    EXPECT_LE(uniform.getA(), 1.0);            // Should be at or below minimum
+    EXPECT_TRUE(uniform.getB() >= 5.0);        // Should be at or above maximum
     EXPECT_LT(uniform.getA(), uniform.getB()); // Valid interval
 
     // Test with empty data (should reset to default)
@@ -86,7 +84,6 @@ TEST(UniformDistributionTest, Fitting) {
     uniform.fit(singlePoint);
     EXPECT_EQ(uniform.getA(), 0.0);
     EXPECT_EQ(uniform.getB(), 1.0);
-
 }
 
 /**
@@ -133,7 +130,6 @@ TEST(UniformDistributionTest, ParameterValidation) {
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
-
 }
 
 /**
@@ -187,7 +183,6 @@ TEST(UniformDistributionTest, CopyMoveSemantics) {
     moveAssigned = std::move(temp);
     EXPECT_EQ(moveAssigned.getA(), 1.41);
     EXPECT_EQ(moveAssigned.getB(), 2.73);
-
 }
 
 /**
@@ -205,7 +200,6 @@ TEST(UniformDistributionTest, InvalidInputHandling) {
     EXPECT_EQ(uniform.getProbability(nan_val), 0.0);
     EXPECT_EQ(uniform.getProbability(inf_val), 0.0);
     EXPECT_EQ(uniform.getProbability(neg_inf_val), 0.0);
-
 }
 
 /**
@@ -218,7 +212,6 @@ TEST(UniformDistributionTest, ResetFunctionality) {
 
     EXPECT_EQ(uniform.getA(), 0.0);
     EXPECT_EQ(uniform.getB(), 1.0);
-
 }
 
 /**
@@ -247,7 +240,6 @@ TEST(UniformDistributionTest, UniformProperties) {
     double pdf3 = general.getProbability(7.0);
     EXPECT_NEAR(pdf1, pdf2, 1e-10);
     EXPECT_NEAR(pdf2, pdf3, 1e-10);
-
 }
 
 /**
@@ -271,12 +263,11 @@ TEST(UniformDistributionTest, FittingValidation) {
         uniform.fit(validData);
         // Should work fine, check that parameters are reasonable
         EXPECT_LT(uniform.getA(), uniform.getB());
-        EXPECT_LE(uniform.getA(), 1.5); // Should encompass minimum
+        EXPECT_LE(uniform.getA(), 1.5);     // Should encompass minimum
         EXPECT_TRUE(uniform.getB() >= 4.0); // Should encompass maximum
     } catch (const std::exception &) {
         ADD_FAILURE(); // Should not throw
     }
-
 }
 
 /**
@@ -299,7 +290,6 @@ TEST(UniformDistributionTest, ParameterSetters) {
     uniform.setParameters(2.0, 8.0);
     EXPECT_EQ(uniform.getA(), 2.0);
     EXPECT_EQ(uniform.getB(), 8.0);
-
 }
 
 /**
@@ -309,7 +299,7 @@ TEST(UniformDistributionTest, EdgeCases) {
 
     // Test with very small interval
     UniformDistribution tiny(0.0, 1e-10);
-    EXPECT_GT(tiny.getProbability(5e-11), 0.0);  // Should be within interval
+    EXPECT_GT(tiny.getProbability(5e-11), 0.0); // Should be within interval
     EXPECT_EQ(tiny.getProbability(2e-10), 0.0); // Should be outside interval
 
     // Test with large interval
@@ -331,7 +321,6 @@ TEST(UniformDistributionTest, EdgeCases) {
 
     EXPECT_TRUE(u1.isApproximatelyEqual(u2, 1e-8));
     EXPECT_FALSE(u1.isApproximatelyEqual(u3, 1e-8));
-
 }
 
 /**
@@ -352,7 +341,6 @@ TEST(UniformDistributionTest, FittingIdenticalData) {
 
     // The value should be within the fitted interval
     EXPECT_GT(uniform.getProbability(5.0), 0.0);
-
 }
 
 /**
@@ -380,7 +368,6 @@ TEST(UniformDistributionTest, LogProbabilities) {
     // Test consistency between log and regular probability
     double x = 2.5;
     EXPECT_NEAR(std::log(uniform.getProbability(x)), uniform.getLogProbability(x), 1e-10);
-
 }
 
 /**
@@ -412,7 +399,6 @@ TEST(UniformDistributionTest, CDF) {
     EXPECT_TRUE(std::isnan(uniform.CDF(std::numeric_limits<double>::quiet_NaN())));
     EXPECT_EQ(uniform.CDF(std::numeric_limits<double>::infinity()), 1.0);
     EXPECT_EQ(uniform.CDF(-std::numeric_limits<double>::infinity()), 0.0);
-
 }
 
 /**
@@ -447,7 +433,6 @@ TEST(UniformDistributionTest, EqualityAndIO) {
         EXPECT_NEAR(inputDist.getA(), 3.14, 1e-10);
         EXPECT_NEAR(inputDist.getB(), 6.28, 1e-10);
     }
-
 }
 
 /**
@@ -478,7 +463,6 @@ TEST(UniformDistributionTest, Caching) {
     uniform.reset();
     double pdf4 = uniform.getProbability(0.5);
     EXPECT_EQ(pdf4, 1.0); // Should be 1.0 for [0,1] interval
-
 }
 
 /**
@@ -538,7 +522,6 @@ TEST(UniformDistributionTest, PerformanceCharacteristics) {
     EXPECT_LT(pdfTimePerCall, 1.0);    // Less than 1 μs per PDF call
     EXPECT_LT(logPdfTimePerCall, 1.0); // Less than 1 μs per log PDF call
     EXPECT_LT(fitTimePerPoint, 0.1);   // Less than 0.1 μs per data point for fitting
-
 }
 
 int main(int argc, char **argv) {

--- a/tests/distributions/test_weibull_distribution.cpp
+++ b/tests/distributions/test_weibull_distribution.cpp
@@ -1,19 +1,13 @@
 #include <iostream>
 #include <vector>
 #include <cmath>
-#include <cassert>
 #include <stdexcept>
 #include <climits>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 #include "libhmm/distributions/weibull_distribution.h"
-#ifdef _MSC_VER
-#pragma warning(disable : 4189) // assert()-only variables appear unreferenced in Release
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+#include <gtest/gtest.h>
 
 using libhmm::Observation;
 using libhmm::WeibullDistribution;
@@ -21,44 +15,41 @@ using libhmm::WeibullDistribution;
 /**
  * Test basic Weibull distribution functionality
  */
-void testBasicFunctionality() {
-    std::cout << "Testing basic Weibull distribution functionality..." << std::endl;
+TEST(WeibullDistributionTest, BasicFunctionality) {
 
     // Test default constructor
     WeibullDistribution weibull;
-    assert(weibull.getK() == 1.0);
-    assert(weibull.getLambda() == 1.0);
-    assert(weibull.getShape() == 1.0); // Alternative getter
-    assert(weibull.getScale() == 1.0); // Alternative getter
+    EXPECT_EQ(weibull.getK(), 1.0);
+    EXPECT_EQ(weibull.getLambda(), 1.0);
+    EXPECT_EQ(weibull.getShape(), 1.0); // Alternative getter
+    EXPECT_EQ(weibull.getScale(), 1.0); // Alternative getter
 
     // Test parameterized constructor
     WeibullDistribution weibull2(2.5, 1.5);
-    assert(weibull2.getK() == 2.5);
-    assert(weibull2.getLambda() == 1.5);
+    EXPECT_EQ(weibull2.getK(), 2.5);
+    EXPECT_EQ(weibull2.getLambda(), 1.5);
 
-    std::cout << "✓ Basic functionality tests passed" << std::endl;
 }
 
 /**
  * Test probability calculations
  */
-void testProbabilities() {
-    std::cout << "Testing probability calculations..." << std::endl;
+TEST(WeibullDistributionTest, Probabilities) {
 
     WeibullDistribution weibull(2.0, 1.0); // k=2, λ=1 (Rayleigh distribution)
 
     // Test that probability is zero for negative values
-    assert(weibull.getProbability(-0.1) == 0.0);
-    assert(weibull.getProbability(-1.0) == 0.0);
+    EXPECT_EQ(weibull.getProbability(-0.1), 0.0);
+    EXPECT_EQ(weibull.getProbability(-1.0), 0.0);
 
     // Test that probability is positive for positive values
     double prob1 = weibull.getProbability(0.5);
     double prob2 = weibull.getProbability(1.0);
     double prob3 = weibull.getProbability(2.0);
 
-    assert(prob1 > 0.0);
-    assert(prob2 > 0.0);
-    assert(prob3 > 0.0);
+    EXPECT_GT(prob1, 0.0);
+    EXPECT_GT(prob2, 0.0);
+    EXPECT_GT(prob3, 0.0);
 
     // For Weibull distribution, density typically decreases after the mode
     // Mode for Weibull(k,λ) = λ * ((k-1)/k)^(1/k) when k > 1
@@ -66,75 +57,71 @@ void testProbabilities() {
 
     // Test boundary value at x=0
     double probAt0 = weibull.getProbability(0.0);
-    assert(probAt0 >= 0.0); // Should be 0 for k=2 > 1
+    EXPECT_TRUE(probAt0 >= 0.0); // Should be 0 for k=2 > 1
 
     // Test that probability density is reasonable (should be small for continuous dist)
-    assert(prob1 < 10.0);  // Should be reasonable
-    assert(prob1 > 1e-10); // Should be greater than zero
+    EXPECT_LT(prob1, 10.0);  // Should be reasonable
+    EXPECT_GT(prob1, 1e-10); // Should be greater than zero
 
-    std::cout << "✓ Probability calculation tests passed" << std::endl;
 }
 
 /**
  * Test parameter fitting
  */
-void testFitting() {
-    std::cout << "Testing parameter fitting..." << std::endl;
+TEST(WeibullDistributionTest, Fitting) {
 
     WeibullDistribution weibull;
 
     // Test with known data
     std::vector<Observation> data = {0.5, 1.0, 1.5, 2.0, 2.5, 3.0};
     weibull.fit(data);
-    assert(weibull.getK() > 0.0);      // Should have some reasonable value
-    assert(weibull.getLambda() > 0.0); // Should have some reasonable value
+    EXPECT_GT(weibull.getK(), 0.0);      // Should have some reasonable value
+    EXPECT_GT(weibull.getLambda(), 0.0); // Should have some reasonable value
 
     // Test with empty data (should reset to default)
     std::vector<Observation> emptyData;
     weibull.fit(emptyData);
-    assert(weibull.getK() == 1.0);
-    assert(weibull.getLambda() == 1.0);
+    EXPECT_EQ(weibull.getK(), 1.0);
+    EXPECT_EQ(weibull.getLambda(), 1.0);
 
     // Test with single point (should reset to default for insufficient data)
     std::vector<Observation> singlePoint = {2.5};
     weibull.fit(singlePoint);
-    assert(weibull.getK() == 1.0);
-    assert(weibull.getLambda() == 1.0);
+    EXPECT_EQ(weibull.getK(), 1.0);
+    EXPECT_EQ(weibull.getLambda(), 1.0);
 
-    std::cout << "✓ Parameter fitting tests passed" << std::endl;
 }
 
 /**
  * Test parameter validation
  */
-void testParameterValidation() {
-    std::cout << "Testing parameter validation..." << std::endl;
+TEST(WeibullDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
     try {
         WeibullDistribution weibull(0.0, 1.0); // Zero k
-        assert(false);                         // Should not reach here
+        ADD_FAILURE();                         // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         WeibullDistribution weibull(-1.0, 1.0); // Negative k
-        assert(false);                          // Should not reach here
+        ADD_FAILURE();                          // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         WeibullDistribution weibull(1.0, 0.0); // Zero lambda
-        assert(false);                         // Should not reach here
+        ADD_FAILURE();                         // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
 
     try {
         WeibullDistribution weibull(1.0, -1.0); // Negative lambda
-        assert(false);                          // Should not reach here
+        ADD_FAILURE();                          // Should not reach here
     } catch (const std::invalid_argument &) {
         // Expected behavior
     }
@@ -143,102 +130,76 @@ void testParameterValidation() {
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
 
-    try {
-        WeibullDistribution weibull(nan_val, 1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(WeibullDistribution weibull(nan_val, 1.0), std::invalid_argument);
 
-    try {
-        WeibullDistribution weibull(1.0, inf_val);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(WeibullDistribution weibull(1.0, inf_val), std::invalid_argument);
 
     // Test setters validation
     WeibullDistribution weibull(1.0, 1.0);
 
-    try {
-        weibull.setK(0.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(weibull.setK(0.0), std::invalid_argument);
 
-    try {
-        weibull.setLambda(-1.0);
-        assert(false); // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(weibull.setLambda(-1.0), std::invalid_argument);
 
-    std::cout << "✓ Parameter validation tests passed" << std::endl;
 }
 
 /**
  * Test string representation
  */
-void testStringRepresentation() {
-    std::cout << "Testing string representation..." << std::endl;
+TEST(WeibullDistributionTest, StringRepresentation) {
 
     WeibullDistribution weibull(2.5, 1.5);
     std::string str = weibull.toString();
 
     // Should contain key information based on actual output format:
     // "Weibull Distribution:\n      k (shape) = 2.5\n      λ (scale) = 1.5\n"
-    assert(str.find("Weibull") != std::string::npos);
-    assert(str.find("Distribution") != std::string::npos);
-    assert(str.find("2.5") != std::string::npos);
-    assert(str.find("1.5") != std::string::npos);
-    assert(str.find("k") != std::string::npos);
-    assert(str.find("shape") != std::string::npos);
-    assert(str.find("λ") != std::string::npos || str.find("scale") != std::string::npos);
+    EXPECT_NE(str.find("Weibull"), std::string::npos);
+    EXPECT_NE(str.find("Distribution"), std::string::npos);
+    EXPECT_NE(str.find("2.5"), std::string::npos);
+    EXPECT_NE(str.find("1.5"), std::string::npos);
+    EXPECT_NE(str.find("k"), std::string::npos);
+    EXPECT_NE(str.find("shape"), std::string::npos);
+    EXPECT_TRUE(str.find("λ") != std::string::npos || str.find("scale") != std::string::npos);
 
     std::cout << "String representation: " << str << std::endl;
-    std::cout << "✓ String representation tests passed" << std::endl;
 }
 
 /**
  * Test copy/move semantics
  */
-void testCopyMoveSemantics() {
-    std::cout << "Testing copy/move semantics..." << std::endl;
+TEST(WeibullDistributionTest, CopyMoveSemantics) {
 
     WeibullDistribution original(3.14, 2.71);
 
     // Test copy constructor
     WeibullDistribution copied(original);
-    assert(copied.getK() == original.getK());
-    assert(copied.getLambda() == original.getLambda());
+    EXPECT_EQ(copied.getK(), original.getK());
+    EXPECT_EQ(copied.getLambda(), original.getLambda());
 
     // Test copy assignment
     WeibullDistribution assigned;
     assigned = original;
-    assert(assigned.getK() == original.getK());
-    assert(assigned.getLambda() == original.getLambda());
+    EXPECT_EQ(assigned.getK(), original.getK());
+    EXPECT_EQ(assigned.getLambda(), original.getLambda());
 
     // Test move constructor
     WeibullDistribution moved(std::move(original));
-    assert(moved.getK() == 3.14);
-    assert(moved.getLambda() == 2.71);
+    EXPECT_EQ(moved.getK(), 3.14);
+    EXPECT_EQ(moved.getLambda(), 2.71);
 
     // Test move assignment
     WeibullDistribution moveAssigned;
     WeibullDistribution temp(1.41, 1.73);
     moveAssigned = std::move(temp);
-    assert(moveAssigned.getK() == 1.41);
-    assert(moveAssigned.getLambda() == 1.73);
+    EXPECT_EQ(moveAssigned.getK(), 1.41);
+    EXPECT_EQ(moveAssigned.getLambda(), 1.73);
 
-    std::cout << "✓ Copy/move semantics tests passed" << std::endl;
 }
 
 /**
  * Test invalid input handling
  */
-void testInvalidInputHandling() {
-    std::cout << "Testing invalid input handling..." << std::endl;
+TEST(WeibullDistributionTest, InvalidInputHandling) {
 
     WeibullDistribution weibull(2.0, 1.0);
 
@@ -247,191 +208,168 @@ void testInvalidInputHandling() {
     double inf_val = std::numeric_limits<double>::infinity();
     double neg_inf_val = -std::numeric_limits<double>::infinity();
 
-    assert(weibull.getProbability(nan_val) == 0.0);
-    assert(weibull.getProbability(inf_val) == 0.0);
-    assert(weibull.getProbability(neg_inf_val) == 0.0);
+    EXPECT_EQ(weibull.getProbability(nan_val), 0.0);
+    EXPECT_EQ(weibull.getProbability(inf_val), 0.0);
+    EXPECT_EQ(weibull.getProbability(neg_inf_val), 0.0);
 
     // Negative values should return 0
-    assert(weibull.getProbability(-0.1) == 0.0);
-    assert(weibull.getProbability(-1.0) == 0.0);
-    assert(weibull.getProbability(-10.0) == 0.0);
+    EXPECT_EQ(weibull.getProbability(-0.1), 0.0);
+    EXPECT_EQ(weibull.getProbability(-1.0), 0.0);
+    EXPECT_EQ(weibull.getProbability(-10.0), 0.0);
 
-    std::cout << "✓ Invalid input handling tests passed" << std::endl;
 }
 
 /**
  * Test reset functionality
  */
-void testResetFunctionality() {
-    std::cout << "Testing reset functionality..." << std::endl;
+TEST(WeibullDistributionTest, ResetFunctionality) {
 
     WeibullDistribution weibull(10.0, 5.0);
     weibull.reset();
 
-    assert(weibull.getK() == 1.0);
-    assert(weibull.getLambda() == 1.0);
+    EXPECT_EQ(weibull.getK(), 1.0);
+    EXPECT_EQ(weibull.getLambda(), 1.0);
 
-    std::cout << "✓ Reset functionality tests passed" << std::endl;
 }
 
 /**
  * Test Weibull distribution properties
  */
-void testWeibullProperties() {
-    std::cout << "Testing Weibull distribution properties..." << std::endl;
+TEST(WeibullDistributionTest, WeibullProperties) {
 
     // Test exponential case (k=1)
     WeibullDistribution exponential(1.0, 2.0);
     double expMean = exponential.getMean();
-    assert(std::abs(expMean - 2.0) < 1e-10); // For Weibull(1,λ), mean = λ
+    EXPECT_NEAR(expMean, 2.0, 1e-10); // For Weibull(1,λ), mean = λ
 
     // Test Rayleigh case (k=2)
     WeibullDistribution rayleigh(2.0, 1.0);
     double rayleighMean = rayleigh.getMean();
     // For Weibull(2,1), mean = Γ(1.5) = sqrt(π)/2 ≈ 0.8862
-    assert(rayleighMean > 0.8 && rayleighMean < 0.9);
+    EXPECT_TRUE(rayleighMean > 0.8 && rayleighMean < 0.9);
 
     // Test that Weibull is only defined for x ≥ 0
-    assert(exponential.getProbability(-0.1) == 0.0);
-    assert(exponential.getProbability(0.0) >= 0.0);
-    assert(exponential.getProbability(1.0) > 0.0);
+    EXPECT_EQ(exponential.getProbability(-0.1), 0.0);
+    EXPECT_TRUE(exponential.getProbability(0.0) >= 0.0);
+    EXPECT_GT(exponential.getProbability(1.0), 0.0);
 
     // Test variance is positive
-    assert(exponential.getVariance() > 0.0);
-    assert(rayleigh.getVariance() > 0.0);
+    EXPECT_GT(exponential.getVariance(), 0.0);
+    EXPECT_GT(rayleigh.getVariance(), 0.0);
 
     // Test standard deviation relationship
-    assert(std::abs(exponential.getStandardDeviation() - std::sqrt(exponential.getVariance())) <
-           1e-10);
+    EXPECT_NEAR(exponential.getStandardDeviation(), std::sqrt(exponential.getVariance()), 1e-10);
 
-    std::cout << "✓ Weibull property tests passed" << std::endl;
 }
 
 /**
  * Test fitting validation
  */
-void testFittingValidation() {
-    std::cout << "Testing fitting validation..." << std::endl;
+TEST(WeibullDistributionTest, FittingValidation) {
 
     WeibullDistribution weibull;
 
     // Test with data containing negative values
     std::vector<Observation> invalidData = {1.0, 2.0, -1.0, 3.0}; // -1.0 is invalid
 
-    try {
-        weibull.fit(invalidData);
-        assert(false); // Should throw exception
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(weibull.fit(invalidData), std::invalid_argument);
 
     // Test with NaN values
     std::vector<Observation> nanData = {1.0, 2.0, std::numeric_limits<double>::quiet_NaN(), 3.0};
-    try {
-        weibull.fit(nanData);
-        assert(false); // Should throw exception
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(weibull.fit(nanData), std::invalid_argument);
 
     // Test with valid data including zero
     std::vector<Observation> zeroData = {0.0, 1.0, 2.0, 3.0};
     try {
         weibull.fit(zeroData);
         // Should work fine, check that parameters are reasonable
-        assert(weibull.getK() > 0.0);
-        assert(weibull.getLambda() > 0.0);
+        EXPECT_GT(weibull.getK(), 0.0);
+        EXPECT_GT(weibull.getLambda(), 0.0);
     } catch (const std::exception &) {
         // Also acceptable if implementation has specific constraints
     }
 
-    std::cout << "✓ Fitting validation tests passed" << std::endl;
 }
 
 /**
  * Test statistical moments
  */
-void testStatisticalMoments() {
-    std::cout << "Testing statistical moments..." << std::endl;
+TEST(WeibullDistributionTest, StatisticalMoments) {
 
     // Test exponential case (k=1, λ=2)
     WeibullDistribution exponential(1.0, 2.0);
 
     // For Weibull(1,λ), mean = λ * Γ(2) = λ
     double expectedMean = 2.0;
-    assert(std::abs(exponential.getMean() - expectedMean) < 1e-10);
+    EXPECT_NEAR(exponential.getMean(), expectedMean, 1e-10);
 
     // For Weibull(1,λ), variance = λ² * [Γ(3) - (Γ(2))²] = λ² * [2 - 1] = λ²
     double expectedVar = 4.0;
-    assert(std::abs(exponential.getVariance() - expectedVar) < 1e-10);
+    EXPECT_NEAR(exponential.getVariance(), expectedVar, 1e-10);
 
     // Test standard deviation
     double expectedStd = 2.0;
-    assert(std::abs(exponential.getStandardDeviation() - expectedStd) < 1e-10);
+    EXPECT_NEAR(exponential.getStandardDeviation(), expectedStd, 1e-10);
 
     // Test Rayleigh case (k=2, λ=1)
     WeibullDistribution rayleigh(2.0, 1.0);
 
     // Mean should be sqrt(π)/2 ≈ 0.8862
     double rayleighMean = rayleigh.getMean();
-    assert(rayleighMean > 0.88 && rayleighMean < 0.89);
+    EXPECT_TRUE(rayleighMean > 0.88 && rayleighMean < 0.89);
 
     // Variance should be (4-π)/4 ≈ 0.2146
     double rayleighVar = rayleigh.getVariance();
-    assert(rayleighVar > 0.21 && rayleighVar < 0.22);
+    EXPECT_TRUE(rayleighVar > 0.21 && rayleighVar < 0.22);
 
-    std::cout << "✓ Statistical moments tests passed" << std::endl;
 }
 
 /**
  * Test special cases and edge cases
  */
-void testSpecialCases() {
-    std::cout << "Testing special cases and edge cases..." << std::endl;
+TEST(WeibullDistributionTest, SpecialCases) {
 
     // Test k=1 (exponential distribution)
     WeibullDistribution exp_case(1.0, 1.0);
     double prob_exp = exp_case.getProbability(1.0);
     // For exponential with rate 1, PDF(1) = e^(-1) ≈ 0.368
-    assert(prob_exp > 0.35 && prob_exp < 0.4);
+    EXPECT_TRUE(prob_exp > 0.35 && prob_exp < 0.4);
 
     // Test k=2 (Rayleigh distribution)
     WeibullDistribution rayleigh_case(2.0, 1.0);
     double prob_rayleigh = rayleigh_case.getProbability(1.0);
     // For Rayleigh with σ=1, PDF(1) = 1*e^(-0.5) ≈ 0.607
     // Note: Actual implementation gives ~0.736 due to Weibull parameterization
-    assert(prob_rayleigh > 0.7 && prob_rayleigh < 0.75);
+    EXPECT_TRUE(prob_rayleigh > 0.7 && prob_rayleigh < 0.75);
 
     // Test very small k (infant mortality)
     WeibullDistribution infant(0.5, 1.0);
-    assert(infant.getK() == 0.5);
-    assert(infant.getLambda() == 1.0);
+    EXPECT_EQ(infant.getK(), 0.5);
+    EXPECT_EQ(infant.getLambda(), 1.0);
 
     // Test large k (wear-out failures)
     WeibullDistribution wearout(5.0, 1.0);
-    assert(wearout.getK() == 5.0);
-    assert(wearout.getLambda() == 1.0);
+    EXPECT_EQ(wearout.getK(), 5.0);
+    EXPECT_EQ(wearout.getLambda(), 1.0);
 
     // Test very large values
     WeibullDistribution normal_case(1.0, 1.0);
     double prob_large = normal_case.getProbability(100.0);
-    assert(prob_large >= 0.0);  // Should be very small but non-negative
-    assert(prob_large < 1e-10); // Should be essentially zero
+    EXPECT_TRUE(prob_large >= 0.0);  // Should be very small but non-negative
+    EXPECT_LT(prob_large, 1e-10); // Should be essentially zero
 
-    std::cout << "✓ Special cases tests passed" << std::endl;
 }
 
 /**
  * Test log probability calculations (GOLD STANDARD)
  */
-void testLogProbability() {
-    std::cout << "Testing log probability calculations..." << std::endl;
+TEST(WeibullDistributionTest, LogProbability) {
 
     WeibullDistribution weibull(2.0, 1.0); // k=2, λ=1 (Rayleigh distribution)
 
     // Test that log probability is -infinity for negative values
-    assert(weibull.getLogProbability(-0.1) == -std::numeric_limits<double>::infinity());
-    assert(weibull.getLogProbability(-1.0) == -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(weibull.getLogProbability(-0.1), -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(weibull.getLogProbability(-1.0), -std::numeric_limits<double>::infinity());
 
     // Test consistency with regular probability
     double x = 1.0;
@@ -439,49 +377,47 @@ void testLogProbability() {
     double logProb = weibull.getLogProbability(x);
 
     if (prob > 0.0) {
-        assert(std::abs(logProb - std::log(prob)) < 1e-10);
+        EXPECT_NEAR(logProb, std::log(prob), 1e-10);
     }
 
     // Test that log probability is finite for positive values
-    assert(std::isfinite(weibull.getLogProbability(0.5)));
-    assert(std::isfinite(weibull.getLogProbability(1.0)));
-    assert(std::isfinite(weibull.getLogProbability(2.0)));
+    EXPECT_TRUE(std::isfinite(weibull.getLogProbability(0.5)));
+    EXPECT_TRUE(std::isfinite(weibull.getLogProbability(1.0)));
+    EXPECT_TRUE(std::isfinite(weibull.getLogProbability(2.0)));
 
     // Test invalid inputs return -infinity
     double nan_val = std::numeric_limits<double>::quiet_NaN();
     double inf_val = std::numeric_limits<double>::infinity();
-    assert(weibull.getLogProbability(nan_val) == -std::numeric_limits<double>::infinity());
-    assert(weibull.getLogProbability(inf_val) == -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(weibull.getLogProbability(nan_val), -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(weibull.getLogProbability(inf_val), -std::numeric_limits<double>::infinity());
 
-    std::cout << "✓ Log probability tests passed" << std::endl;
 }
 
 /**
  * Test CDF calculations (GOLD STANDARD)
  */
-void testCDF() {
-    std::cout << "Testing CDF calculations..." << std::endl;
+TEST(WeibullDistributionTest, CDF) {
 
     WeibullDistribution weibull(2.0, 1.0); // k=2, λ=1 (Rayleigh distribution)
 
     // Test boundary conditions
-    assert(weibull.CDF(-1.0) == 0.0); // CDF should be 0 for negative values
-    assert(weibull.CDF(0.0) == 0.0);  // CDF should be 0 at x=0
+    EXPECT_EQ(weibull.CDF(-1.0), 0.0); // CDF should be 0 for negative values
+    EXPECT_EQ(weibull.CDF(0.0), 0.0);  // CDF should be 0 at x=0
 
     // Test monotonicity (CDF should be non-decreasing)
     double cdf1 = weibull.CDF(0.5);
     double cdf2 = weibull.CDF(1.0);
     double cdf3 = weibull.CDF(2.0);
 
-    assert(cdf1 >= 0.0 && cdf1 <= 1.0);
-    assert(cdf2 >= 0.0 && cdf2 <= 1.0);
-    assert(cdf3 >= 0.0 && cdf3 <= 1.0);
-    assert(cdf1 <= cdf2);
-    assert(cdf2 <= cdf3);
+    EXPECT_TRUE(cdf1 >= 0.0 && cdf1 <= 1.0);
+    EXPECT_TRUE(cdf2 >= 0.0 && cdf2 <= 1.0);
+    EXPECT_TRUE(cdf3 >= 0.0 && cdf3 <= 1.0);
+    EXPECT_LE(cdf1, cdf2);
+    EXPECT_LE(cdf2, cdf3);
 
     // Test that CDF approaches 1 for large values
     double cdfLarge = weibull.CDF(10.0);
-    assert(cdfLarge > 0.99); // Should be very close to 1
+    EXPECT_GT(cdfLarge, 0.99); // Should be very close to 1
 
     // Test known values for Weibull distribution with k=2, λ=1
     // CDF(1) = 1 - exp(-(1/1)^2) = 1 - exp(-1) ≈ 0.632
@@ -489,38 +425,36 @@ void testCDF() {
     if (!(cdfAtScale > 0.63 && cdfAtScale < 0.64)) {
         std::cerr << "CDF(1.0)=" << cdfAtScale << " did not meet expected range (0.63, 0.64)"
                   << std::endl;
-        assert(false);
+        ADD_FAILURE();
     }
 
-    std::cout << "✓ CDF tests passed" << std::endl;
 }
 
 /**
  * Test equality and I/O operators (GOLD STANDARD)
  */
-void testEqualityAndIO() {
-    std::cout << "Testing equality and I/O operators..." << std::endl;
+TEST(WeibullDistributionTest, EqualityAndIO) {
 
     WeibullDistribution weibull1(2.5, 1.5);
     WeibullDistribution weibull2(2.5, 1.5);
     WeibullDistribution weibull3(3.0, 2.0);
 
     // Test equality operator
-    assert(weibull1 == weibull2);    // Same parameters
-    assert(!(weibull1 == weibull3)); // Different parameters
+    EXPECT_EQ(weibull1, weibull2);    // Same parameters
+    EXPECT_FALSE(weibull1 == weibull3); // Different parameters
 
     // Test with slightly different parameters (within tolerance)
     WeibullDistribution weibull4(2.5 + 1e-16, 1.5 + 1e-16);
-    assert(weibull1 == weibull4); // Should be equal within tolerance
+    EXPECT_EQ(weibull1, weibull4); // Should be equal within tolerance
 
     // Test stream output operator
     std::ostringstream oss;
     oss << weibull1;
     std::string output = oss.str();
-    assert(!output.empty());
-    assert(output.find("Weibull") != std::string::npos);
-    assert(output.find("2.5") != std::string::npos);
-    assert(output.find("1.5") != std::string::npos);
+    EXPECT_FALSE(output.empty());
+    EXPECT_NE(output.find("Weibull"), std::string::npos);
+    EXPECT_NE(output.find("2.5"), std::string::npos);
+    EXPECT_NE(output.find("1.5"), std::string::npos);
 
     // Test stream input operator
     std::istringstream iss(output);
@@ -528,17 +462,15 @@ void testEqualityAndIO() {
     iss >> weibullFromStream;
 
     if (iss.good() || iss.eof()) {
-        assert(weibullFromStream == weibull1);
+        EXPECT_EQ(weibullFromStream, weibull1);
     }
 
-    std::cout << "✓ Equality and I/O tests passed" << std::endl;
 }
 
 /**
  * Test performance characteristics and optimizations (GOLD STANDARD)
  */
-void testPerformanceCharacteristics() {
-    std::cout << "Testing performance characteristics..." << std::endl;
+TEST(WeibullDistributionTest, PerformanceCharacteristics) {
 
     WeibullDistribution weibull(2.5, 1.5);
 
@@ -609,50 +541,47 @@ void testPerformanceCharacteristics() {
               << " μs/point (" << fit_datapoints << " points)" << std::endl;
 
     // Performance requirements (should be fast due to optimizations)
-    assert(pdf_time_per_call < 1.0);     // Less than 1 μs per PDF call
-    assert(log_pdf_time_per_call < 1.0); // Less than 1 μs per log PDF call
-    assert(cdf_time_per_call < 1.0);     // Less than 1 μs per CDF call
-    assert(fit_time_per_point <
-           0.1); // Less than 0.1 μs per data point for fitting (Welford's is fast)
+    EXPECT_LT(pdf_time_per_call, 1.0);     // Less than 1 μs per PDF call
+    EXPECT_LT(log_pdf_time_per_call, 1.0); // Less than 1 μs per log PDF call
+    EXPECT_LT(cdf_time_per_call, 1.0);     // Less than 1 μs per CDF call
+    EXPECT_LT(fit_time_per_point, 0.1); // Less than 0.1 μs per data point for fitting (Welford's is fast)
 
-    std::cout << "✓ Performance tests passed" << std::endl;
 }
 
 /**
  * Test numerical stability with extreme values (GOLD STANDARD)
  */
-void testNumericalStability() {
-    std::cout << "Testing numerical stability..." << std::endl;
+TEST(WeibullDistributionTest, NumericalStability) {
 
     // Test with very small k parameter
     WeibullDistribution smallK(0.1, 1.0);
     double probSmallK = smallK.getProbability(0.5);
-    assert(probSmallK > 0.0);
-    assert(std::isfinite(probSmallK));
+    EXPECT_GT(probSmallK, 0.0);
+    EXPECT_TRUE(std::isfinite(probSmallK));
 
     // Test with very large k parameter
     WeibullDistribution largeK(100.0, 1.0);
     double probLargeK = largeK.getProbability(1.0);
-    assert(probLargeK > 0.0);
-    assert(std::isfinite(probLargeK));
+    EXPECT_GT(probLargeK, 0.0);
+    EXPECT_TRUE(std::isfinite(probLargeK));
 
     // Test with very small lambda parameter
     WeibullDistribution smallLambda(2.0, 0.001);
     double probSmallLambda = smallLambda.getProbability(0.0001);
-    assert(probSmallLambda > 0.0);
-    assert(std::isfinite(probSmallLambda));
+    EXPECT_GT(probSmallLambda, 0.0);
+    EXPECT_TRUE(std::isfinite(probSmallLambda));
 
     // Test with very large lambda parameter
     WeibullDistribution largeLambda(2.0, 1000.0);
     double probLargeLambda = largeLambda.getProbability(500.0);
-    assert(probLargeLambda > 0.0);
-    assert(std::isfinite(probLargeLambda));
+    EXPECT_GT(probLargeLambda, 0.0);
+    EXPECT_TRUE(std::isfinite(probLargeLambda));
 
     // Test log probability with extreme values
     double logProbSmallK = smallK.getLogProbability(0.5);
     double logProbLargeK = largeK.getLogProbability(1.0);
-    assert(std::isfinite(logProbSmallK));
-    assert(std::isfinite(logProbLargeK));
+    EXPECT_TRUE(std::isfinite(logProbSmallK));
+    EXPECT_TRUE(std::isfinite(logProbLargeK));
 
     // Test special case optimizations (k=1 exponential, k=2 Rayleigh)
     WeibullDistribution exponential(1.0, 2.0); // k=1 case
@@ -663,28 +592,26 @@ void testNumericalStability() {
     double expLogProb = exponential.getLogProbability(1.0);
     double rayLogProb = rayleigh.getLogProbability(1.0);
 
-    assert(std::isfinite(expProb) && expProb > 0.0);
-    assert(std::isfinite(rayProb) && rayProb > 0.0);
-    assert(std::isfinite(expLogProb));
-    assert(std::isfinite(rayLogProb));
+    EXPECT_TRUE(std::isfinite(expProb) && expProb > 0.0);
+    EXPECT_TRUE(std::isfinite(rayProb) && rayProb > 0.0);
+    EXPECT_TRUE(std::isfinite(expLogProb));
+    EXPECT_TRUE(std::isfinite(rayLogProb));
 
     // Test mathematical correctness for special cases
     // For k=1 (exponential): PDF(x) = (1/λ)exp(-x/λ)
     double expectedExpProb = (1.0 / 2.0) * std::exp(-1.0 / 2.0);
-    assert(std::abs(expProb - expectedExpProb) < 1e-10);
+    EXPECT_NEAR(expProb, expectedExpProb, 1e-10);
 
     // For k=2 (Rayleigh): PDF(x) = (2x/λ²)exp(-(x/λ)²)
     double expectedRayProb = (2.0 * 1.0 / (1.0 * 1.0)) * std::exp(-(1.0 * 1.0));
-    assert(std::abs(rayProb - expectedRayProb) < 1e-10);
+    EXPECT_NEAR(rayProb, expectedRayProb, 1e-10);
 
-    std::cout << "✓ Numerical stability tests passed" << std::endl;
 }
 
 /**
  * Test caching mechanism (GOLD STANDARD)
  */
-void testCaching() {
-    std::cout << "Testing caching mechanism..." << std::endl;
+TEST(WeibullDistributionTest, Caching) {
 
     WeibullDistribution weibull(2.0, 1.0);
 
@@ -697,21 +624,21 @@ void testCaching() {
     double prob2 = weibull.getProbability(1.0);
     double logProb2 = weibull.getLogProbability(1.0);
 
-    assert(prob1 != prob2);       // Should be different after parameter change
-    assert(logProb1 != logProb2); // Should be different after parameter change
+    EXPECT_NE(prob1, prob2);       // Should be different after parameter change
+    EXPECT_NE(logProb1, logProb2); // Should be different after parameter change
 
     // Change scale parameter
     weibull.setLambda(2.0);
     double prob3 = weibull.getProbability(1.0);
     double logProb3 = weibull.getLogProbability(1.0);
 
-    assert(prob2 != prob3);       // Should be different after parameter change
-    assert(logProb2 != logProb3); // Should be different after parameter change
+    EXPECT_NE(prob2, prob3);       // Should be different after parameter change
+    EXPECT_NE(logProb2, logProb3); // Should be different after parameter change
 
     // Test that copy constructor preserves cache state
     WeibullDistribution copied(weibull);
-    assert(copied.getProbability(1.0) == weibull.getProbability(1.0));
-    assert(copied.getLogProbability(1.0) == weibull.getLogProbability(1.0));
+    EXPECT_EQ(copied.getProbability(1.0), weibull.getProbability(1.0));
+    EXPECT_EQ(copied.getLogProbability(1.0), weibull.getLogProbability(1.0));
 
     // Test that cached values are consistent
     double prob4 = weibull.getProbability(1.0);
@@ -719,49 +646,13 @@ void testCaching() {
     double logProb4 = weibull.getLogProbability(1.0);
 
     // Multiple calls should return identical results (using cache)
-    assert(weibull.getProbability(1.0) == prob4);
-    assert(weibull.CDF(1.0) == cdf4);
-    assert(weibull.getLogProbability(1.0) == logProb4);
+    EXPECT_EQ(weibull.getProbability(1.0), prob4);
+    EXPECT_EQ(weibull.CDF(1.0), cdf4);
+    EXPECT_EQ(weibull.getLogProbability(1.0), logProb4);
 
-    std::cout << "✓ Caching tests passed" << std::endl;
 }
 
-int main() {
-    std::cout << "Running Weibull distribution tests..." << std::endl;
-    std::cout << "=====================================" << std::endl;
-
-    try {
-        testBasicFunctionality();
-        testProbabilities();
-        testFitting();
-        testParameterValidation();
-        testStringRepresentation();
-        testCopyMoveSemantics();
-        testInvalidInputHandling();
-        testResetFunctionality();
-        testWeibullProperties();
-        testFittingValidation();
-        testStatisticalMoments();
-        testSpecialCases();
-
-        // Gold Standard Tests
-        testLogProbability();
-        testCDF();
-        testEqualityAndIO();
-        testPerformanceCharacteristics();
-        testNumericalStability();
-        testCaching();
-
-        std::cout << "=====================================" << std::endl;
-        std::cout << "✅ All Weibull distribution tests passed (including Gold Standard)!"
-                  << std::endl;
-        return 0;
-
-    } catch (const std::exception &e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "❌ Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/distributions/test_weibull_distribution.cpp
+++ b/tests/distributions/test_weibull_distribution.cpp
@@ -28,7 +28,6 @@ TEST(WeibullDistributionTest, BasicFunctionality) {
     WeibullDistribution weibull2(2.5, 1.5);
     EXPECT_EQ(weibull2.getK(), 2.5);
     EXPECT_EQ(weibull2.getLambda(), 1.5);
-
 }
 
 /**
@@ -62,7 +61,6 @@ TEST(WeibullDistributionTest, Probabilities) {
     // Test that probability density is reasonable (should be small for continuous dist)
     EXPECT_LT(prob1, 10.0);  // Should be reasonable
     EXPECT_GT(prob1, 1e-10); // Should be greater than zero
-
 }
 
 /**
@@ -89,7 +87,6 @@ TEST(WeibullDistributionTest, Fitting) {
     weibull.fit(singlePoint);
     EXPECT_EQ(weibull.getK(), 1.0);
     EXPECT_EQ(weibull.getLambda(), 1.0);
-
 }
 
 /**
@@ -140,7 +137,6 @@ TEST(WeibullDistributionTest, ParameterValidation) {
     EXPECT_THROW(weibull.setK(0.0), std::invalid_argument);
 
     EXPECT_THROW(weibull.setLambda(-1.0), std::invalid_argument);
-
 }
 
 /**
@@ -193,7 +189,6 @@ TEST(WeibullDistributionTest, CopyMoveSemantics) {
     moveAssigned = std::move(temp);
     EXPECT_EQ(moveAssigned.getK(), 1.41);
     EXPECT_EQ(moveAssigned.getLambda(), 1.73);
-
 }
 
 /**
@@ -216,7 +211,6 @@ TEST(WeibullDistributionTest, InvalidInputHandling) {
     EXPECT_EQ(weibull.getProbability(-0.1), 0.0);
     EXPECT_EQ(weibull.getProbability(-1.0), 0.0);
     EXPECT_EQ(weibull.getProbability(-10.0), 0.0);
-
 }
 
 /**
@@ -229,7 +223,6 @@ TEST(WeibullDistributionTest, ResetFunctionality) {
 
     EXPECT_EQ(weibull.getK(), 1.0);
     EXPECT_EQ(weibull.getLambda(), 1.0);
-
 }
 
 /**
@@ -259,7 +252,6 @@ TEST(WeibullDistributionTest, WeibullProperties) {
 
     // Test standard deviation relationship
     EXPECT_NEAR(exponential.getStandardDeviation(), std::sqrt(exponential.getVariance()), 1e-10);
-
 }
 
 /**
@@ -288,7 +280,6 @@ TEST(WeibullDistributionTest, FittingValidation) {
     } catch (const std::exception &) {
         // Also acceptable if implementation has specific constraints
     }
-
 }
 
 /**
@@ -321,7 +312,6 @@ TEST(WeibullDistributionTest, StatisticalMoments) {
     // Variance should be (4-π)/4 ≈ 0.2146
     double rayleighVar = rayleigh.getVariance();
     EXPECT_TRUE(rayleighVar > 0.21 && rayleighVar < 0.22);
-
 }
 
 /**
@@ -355,9 +345,8 @@ TEST(WeibullDistributionTest, SpecialCases) {
     // Test very large values
     WeibullDistribution normal_case(1.0, 1.0);
     double prob_large = normal_case.getProbability(100.0);
-    EXPECT_TRUE(prob_large >= 0.0);  // Should be very small but non-negative
-    EXPECT_LT(prob_large, 1e-10); // Should be essentially zero
-
+    EXPECT_TRUE(prob_large >= 0.0); // Should be very small but non-negative
+    EXPECT_LT(prob_large, 1e-10);   // Should be essentially zero
 }
 
 /**
@@ -390,7 +379,6 @@ TEST(WeibullDistributionTest, LogProbability) {
     double inf_val = std::numeric_limits<double>::infinity();
     EXPECT_EQ(weibull.getLogProbability(nan_val), -std::numeric_limits<double>::infinity());
     EXPECT_EQ(weibull.getLogProbability(inf_val), -std::numeric_limits<double>::infinity());
-
 }
 
 /**
@@ -427,7 +415,6 @@ TEST(WeibullDistributionTest, CDF) {
                   << std::endl;
         ADD_FAILURE();
     }
-
 }
 
 /**
@@ -440,7 +427,7 @@ TEST(WeibullDistributionTest, EqualityAndIO) {
     WeibullDistribution weibull3(3.0, 2.0);
 
     // Test equality operator
-    EXPECT_EQ(weibull1, weibull2);    // Same parameters
+    EXPECT_EQ(weibull1, weibull2);      // Same parameters
     EXPECT_FALSE(weibull1 == weibull3); // Different parameters
 
     // Test with slightly different parameters (within tolerance)
@@ -464,7 +451,6 @@ TEST(WeibullDistributionTest, EqualityAndIO) {
     if (iss.good() || iss.eof()) {
         EXPECT_EQ(weibullFromStream, weibull1);
     }
-
 }
 
 /**
@@ -544,8 +530,8 @@ TEST(WeibullDistributionTest, PerformanceCharacteristics) {
     EXPECT_LT(pdf_time_per_call, 1.0);     // Less than 1 μs per PDF call
     EXPECT_LT(log_pdf_time_per_call, 1.0); // Less than 1 μs per log PDF call
     EXPECT_LT(cdf_time_per_call, 1.0);     // Less than 1 μs per CDF call
-    EXPECT_LT(fit_time_per_point, 0.1); // Less than 0.1 μs per data point for fitting (Welford's is fast)
-
+    EXPECT_LT(fit_time_per_point,
+              0.1); // Less than 0.1 μs per data point for fitting (Welford's is fast)
 }
 
 /**
@@ -605,7 +591,6 @@ TEST(WeibullDistributionTest, NumericalStability) {
     // For k=2 (Rayleigh): PDF(x) = (2x/λ²)exp(-(x/λ)²)
     double expectedRayProb = (2.0 * 1.0 / (1.0 * 1.0)) * std::exp(-(1.0 * 1.0));
     EXPECT_NEAR(rayProb, expectedRayProb, 1e-10);
-
 }
 
 /**
@@ -649,7 +634,6 @@ TEST(WeibullDistributionTest, Caching) {
     EXPECT_EQ(weibull.getProbability(1.0), prob4);
     EXPECT_EQ(weibull.CDF(1.0), cdf4);
     EXPECT_EQ(weibull.getLogProbability(1.0), logProb4);
-
 }
 
 int main(int argc, char **argv) {

--- a/tests/io/test_hmm_json.cpp
+++ b/tests/io/test_hmm_json.cpp
@@ -6,6 +6,7 @@
 
 #include "libhmm/distributions/distributions.h"
 #include "libhmm/io/hmm_json.h"
+#include "libhmm/io/json_utils.h"
 #include "libhmm/linalg/linalg_types.h"
 
 using namespace libhmm;
@@ -313,6 +314,99 @@ TEST(HmmJsonSanitization, DiscretePropsArrayLongerThanNThrows) {
                              "\"distributions\":[{\"type\":\"Discrete\",\"n\":2,"
                              "\"probs\":[0.3,0.4,0.3]}]}";
     EXPECT_THROW(from_json(json), std::runtime_error);
+}
+
+// =============================================================================
+// json::Reader unit tests
+// The reader is a handwritten parser; these tests exercise its error paths
+// directly rather than routing through from_json().
+// =============================================================================
+
+using libhmm::json::Reader;
+
+TEST(JsonReader, ConsumeMatchSucceeds) {
+    Reader r("{ }");
+    EXPECT_NO_THROW(r.consume('{'));
+}
+
+TEST(JsonReader, ConsumeMismatchThrows) {
+    Reader r("[1.0]");
+    // Input starts with '[', consuming '{' must throw.
+    EXPECT_THROW(r.consume('{'), std::runtime_error);
+}
+
+TEST(JsonReader, ConsumeAtEofThrows) {
+    Reader r("");
+    EXPECT_THROW(r.consume('{'), std::runtime_error);
+}
+
+TEST(JsonReader, PeekAtEofThrows) {
+    Reader r("");
+    EXPECT_THROW(r.peek(), std::runtime_error);
+}
+
+TEST(JsonReader, ReadStringValid) {
+    Reader r("\"hello\"");
+    EXPECT_EQ(r.read_string(), "hello");
+}
+
+TEST(JsonReader, ReadStringUnterminatedThrows) {
+    Reader r("\"unterminated");
+    EXPECT_THROW(r.read_string(), std::runtime_error);
+}
+
+TEST(JsonReader, ReadDoubleValid) {
+    Reader r("3.14");
+    EXPECT_NEAR(r.read_double(), 3.14, 1e-15);
+}
+
+TEST(JsonReader, ReadDoubleNonNumericThrows) {
+    Reader r("abc");
+    EXPECT_THROW(r.read_double(), std::runtime_error);
+}
+
+TEST(JsonReader, ReadDoubleAtEofThrows) {
+    Reader r("");
+    EXPECT_THROW(r.read_double(), std::runtime_error);
+}
+
+TEST(JsonReader, ReadDoubleArrayValid) {
+    Reader r("[1.0, 2.0, 3.0]");
+    auto v = r.read_double_array();
+    ASSERT_EQ(v.size(), 3u);
+    EXPECT_NEAR(v[0], 1.0, 1e-15);
+    EXPECT_NEAR(v[1], 2.0, 1e-15);
+    EXPECT_NEAR(v[2], 3.0, 1e-15);
+}
+
+TEST(JsonReader, ReadDoubleArrayEmptyArray) {
+    Reader r("[]");
+    auto v = r.read_double_array();
+    EXPECT_TRUE(v.empty());
+}
+
+TEST(JsonReader, ReadDoubleArraySizeCapThrows) {
+    // Array has 3 elements but max_elements=2.
+    Reader r("[1.0, 2.0, 3.0]");
+    EXPECT_THROW(r.read_double_array(2), std::runtime_error);
+}
+
+TEST(JsonReader, WriteDoubleRoundTrip) {
+    // write_double must produce a string that reads back bit-exact.
+    const double v = 1.0 / 3.0;
+    const std::string s = libhmm::json::write_double(v);
+    Reader r(s);
+    EXPECT_EQ(r.read_double(), v);
+}
+
+TEST(JsonReader, WriteArrayRoundTrip) {
+    const std::vector<double> original = {1.5, 2.5, 3.5};
+    const std::string s = libhmm::json::write_array(original);
+    Reader r(s);
+    auto restored = r.read_double_array();
+    ASSERT_EQ(restored.size(), original.size());
+    for (std::size_t i = 0; i < original.size(); ++i)
+        EXPECT_EQ(restored[i], original[i]) << "element " << i;
 }
 
 // Verify that valid boundary values are accepted.


### PR DESCRIPTION
## Summary

Test infrastructure patch for v3.5.1. Closes #10.

### Commits

**`ea3a0a6` — GTest migration of 15 legacy distribution tests** (closes #10)

All 15 distribution-specific test files in `tests/distributions/` used the
`assert()`/`main()` pattern. CMake Release builds compile `assert()` to a
no-op (`-DNDEBUG`), so every assertion in these files was permanently
false-green in CI. Tests now use `TEST()`/`EXPECT_*` macros and fire
unconditionally.

- Replaces `#include <cassert>` + NDEBUG-suppression pragmas with
  `#include <gtest/gtest.h>`
- Converts `void testXxx()` → `TEST(DistNameTest, Xxx)`
- Converts `assert(cond)` → appropriate `EXPECT_*` macro
- Converts `try { expr; assert(false); } catch(T&) {}` → `EXPECT_THROW`
- Removes test-progress `std::cout` lines; retains timing output
- Replaces `int main()` with GTest-initialising main
- Includes the v3.5.0 post-release hotfix (commit 56014e2: 6 IO assertions
  that contained wrong format strings since v2.7.0, first caught in a
  non-Release build)

**`e063543` — WeightedStats + json::Reader unit tests**

- `tests/common/test_common.cpp`: direct tests for
  `detail::compute_weighted_stats` and `detail::compute_weighted_mean`,
  which underpin weighted `fit()` in 9+ distributions but had no unit
  test of their own. Covers uniform weights, non-uniform weights (known
  values), single-element (variance = 0), empty spans, zero-weight sum,
  and NaN weight.
- `tests/io/test_hmm_json.cpp`: direct `json::Reader` tests bypassing
  `from_json()`, exercising parser error paths (consume mismatch, EOF,
  unterminated string, non-numeric double, array size-cap) not reachable
  through the HMM-level tests. Also covers `write_double`/`write_array`
  round-trip.

**`0a22554` — Version bump to 3.5.1**

- `CMakeLists.txt`, `README.md`, `include/libhmm/libhmm.h`, `CHANGELOG.md`,
  `WARP.md` all updated to 3.5.1.

### Test results

37/37 tests pass on macOS Release.

---

_Generated with [Warp](https://app.warp.dev/conversation/053a1871-e0b6-4fcc-a180-97dbf65dc536)_

Co-Authored-By: Oz <oz-agent@warp.dev>