### PR TITLE
refactor: dead code removal, tool exception safety, and lizard triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.2] - 2026-05-09
+
+Code quality patch: dead code removal, tool exception safety, lizard triage. 37/37 tests pass.
+
+### Removed
+
+- **`GammaDistribution::ligamma`** (`include/libhmm/distributions/gamma_distribution.h`,
+  `src/distributions/gamma_distribution.cpp`): private static method declared and
+  implemented but never called. `getCumulativeProbability()` calls `gammap()` directly;
+  `ligamma` was a redundant wrapper left over from an earlier draft. Closes #9.
+- **`ParetoDistribution::CDF`** (`include/libhmm/distributions/pareto_distribution.h`,
+  `src/distributions/pareto_distribution.cpp`): private method that forwarded directly
+  to `getCumulativeProbability()`; zero callers (tests use the public method). Also
+  removes the `negK_` cached field, which was computed in `updateCache()` solely for
+  `CDF`'s use and never read by any other code path. Closes #9.
+
+### Fixed
+
+- **Tool exception safety** (`tools/bw_hotspot.cpp`, `tools/fb_contour_sweep.cpp`,
+  `tools/hotspot_breakdown.cpp`): each tool had a `try/catch` covering only the
+  argument-parsing section; the main profiling loop was unprotected. Exceptions during
+  model construction or benchmarking (e.g. `std::bad_alloc`) now produce a clean
+  error message on stderr and exit 1 instead of terminating without output. Closes #8.
+
 ## [3.5.1] - 2026-05-09
 
 Test infrastructure patch. 37 test executables / 37 passing.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if(APPLE AND NOT CMAKE_CXX_COMPILER)
 endif()
 
 project(libhmm
-    VERSION 3.5.1
+    VERSION 3.5.2
     DESCRIPTION "Modern C++20 Hidden Markov Model Library"
     LANGUAGES CXX
 )

--- a/WARP.md
+++ b/WARP.md
@@ -6,9 +6,9 @@ This file provides guidance to Warp (warp.dev) when working in this repository.
 
 ## Current Status
 
-**Version**: v3.5.1 — pending release on `fix/gtest-migration`; v3.5.0 is the latest published tag on `main`.
+**Version**: v3.5.2 — pending merge on `refactor/code-quality-phase6` (PR #14); v3.5.1 is the latest published tag on `main`.
 **Tests**: 37/37 passing on all four CI platforms (Linux/GCC, Linux/Clang, macOS/AppleClang, Windows/MSVC).
-**Active phase**: Complete. All phases through Post-Phase 5 (CI/tooling, benchmarks) are done.
+**Active phase**: Code quality roadmap complete. All lizard warnings triaged; Tier 6 (SIMD boilerplate) is the only deferred structural item.
 
 ---
 

--- a/include/libhmm/distributions/gamma_distribution.h
+++ b/include/libhmm/distributions/gamma_distribution.h
@@ -85,12 +85,6 @@ private:
         }
     }
 
-    /**
-     * Evaluates the LOWER INCOMPLETE gamma function at x
-     * Uses numerical approximation for computational efficiency
-     */
-    static double ligamma(double a, double x) noexcept;
-
 public:
     /**
      * Constructs a Gamma distribution with given parameters.

--- a/include/libhmm/distributions/pareto_distribution.h
+++ b/include/libhmm/distributions/pareto_distribution.h
@@ -63,11 +63,6 @@ private:
     mutable double kXmPowK_{1.0};
 
     /**
-     * Cached value of -k for efficiency in CDF calculations
-     */
-    mutable double negK_{-1.0};
-
-    /**
      * Cached value of log(x_m) for efficiency in log probability calculations
      */
     mutable double logXm_{0.0};
@@ -78,7 +73,6 @@ private:
         kLogXm_ = k_ * logXm_;
         kPlus1_ = k_ + constants::math::ONE;
         kXmPowK_ = k_ * std::pow(xm_, k_);
-        negK_ = -k_;
         markCacheValid();
     }
 
@@ -96,11 +90,6 @@ private:
             throw std::invalid_argument("Scale parameter xm must be a positive finite number");
         }
     }
-
-    /**
-     * Evaluates the CDF at x using the standard Pareto CDF formula
-     */
-    double CDF(double x) const noexcept;
 
     friend std::istream &operator>>(std::istream &is, libhmm::ParetoDistribution &distribution);
 

--- a/include/libhmm/libhmm.h
+++ b/include/libhmm/libhmm.h
@@ -28,7 +28,7 @@
  * For large projects or when compilation time is critical, consider including
  * only the specific headers you need instead of this master header.
  *
- * @version 3.5.1
+ * @version 3.5.2
  * @author libhmm development team
  */
 

--- a/src/distributions/gamma_distribution.cpp
+++ b/src/distributions/gamma_distribution.cpp
@@ -81,13 +81,6 @@ double GammaDistribution::getCumulativeProbability(double x) const noexcept {
 }
 
 /**
- * Returns the value of the LOWER INCOMPLETE gamma function given a and x.
- */
-double GammaDistribution::ligamma(double a, double x) noexcept {
-    return std::exp(std::log(gammap(a, x)) + std::lgamma(a));
-}
-
-/**
  * Fits the distribution parameters to the given data using method of moments estimation.
  *
  * Method of moments uses:

--- a/src/distributions/pareto_distribution.cpp
+++ b/src/distributions/pareto_distribution.cpp
@@ -66,19 +66,7 @@ double ParetoDistribution::getCumulativeProbability(double value) const noexcept
 }
 
 /**
- * Evaluates the CDF for the Pareto distribution at x.
- *
- * Formula: F(x) = 1 - (x_m/x)^k for x ≥ x_m
- *
- * @param x The value at which to evaluate the CDF
- * @return Cumulative probability P(X ≤ x)
- */
-double ParetoDistribution::CDF(double x) const noexcept {
-    return getCumulativeProbability(x);
-}
-
-/**
- * Fits the distribution parameters to the given data using maximum likelihood estimation.
+ * Fits the distribution parameters
  *
  * For Pareto distribution, the MLE estimators are:
  * x_m = min(x_i) for all i

--- a/tools/bw_hotspot.cpp
+++ b/tools/bw_hotspot.cpp
@@ -276,52 +276,57 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    std::cout << "libhmm BW Hotspot Breakdown  (median of " << runs << " runs, " << warmup
-              << " warmup)\n";
-    std::cout << std::string(66, '=') << "\n\n";
-    std::cout << std::fixed << std::setprecision(3);
+    try {
+        std::cout << "libhmm BW Hotspot Breakdown  (median of " << runs << " runs, " << warmup
+                  << " warmup)\n";
+        std::cout << std::string(66, '=') << "\n\n";
+        std::cout << std::fixed << std::setprecision(3);
 
-    for (const auto &cfg : configs) {
-        auto hmm = make_hmm(cfg.n);
-        auto obs = make_obs(cfg.t, cfg.n);
-        const auto bw = profile_bw(*hmm, obs, warmup, runs);
+        for (const auto &cfg : configs) {
+            auto hmm = make_hmm(cfg.n);
+            auto obs = make_obs(cfg.t, cfg.n);
+            const auto bw = profile_bw(*hmm, obs, warmup, runs);
 
-        const double total = bw.fb_ms + bw.gamma_ms + bw.xi_ms;
-        auto pct = [&](double v) {
-            return (total > 0.0) ? 100.0 * v / total : 0.0;
-        };
+            const double total = bw.fb_ms + bw.gamma_ms + bw.xi_ms;
+            auto pct = [&](double v) {
+                return (total > 0.0) ? 100.0 * v / total : 0.0;
+            };
 
-        std::cout << "N=" << cfg.n << "  T=" << cfg.t << "\n";
-        std::cout << "  exp() call volume:  gamma=" << static_cast<double>(bw.gamma_exp_calls) / 1e3
-                  << "K"
-                  << "  xi=" << static_cast<double>(bw.xi_exp_calls) / 1e6 << "M"
-                  << "  ratio xi/gamma="
-                  << (bw.gamma_exp_calls > 0 ? static_cast<double>(bw.xi_exp_calls) /
-                                                   static_cast<double>(bw.gamma_exp_calls)
-                                             : 0.0)
-                  << "x\n";
+            std::cout << "N=" << cfg.n << "  T=" << cfg.t << "\n";
+            std::cout << "  exp() call volume:  gamma="
+                      << static_cast<double>(bw.gamma_exp_calls) / 1e3 << "K"
+                      << "  xi=" << static_cast<double>(bw.xi_exp_calls) / 1e6 << "M"
+                      << "  ratio xi/gamma="
+                      << (bw.gamma_exp_calls > 0 ? static_cast<double>(bw.xi_exp_calls) /
+                                                       static_cast<double>(bw.gamma_exp_calls)
+                                                 : 0.0)
+                      << "x\n";
 
-        auto row = [&](const char *label, double ms, std::uint64_t calls) {
-            std::cout << "  " << std::left << std::setw(24) << label << std::right << std::setw(8)
-                      << ms << " ms"
-                      << "  " << std::setw(6) << std::setprecision(1) << pct(ms) << "%";
-            if (calls > 0) {
-                const double ns_per = (ms * 1e6) / static_cast<double>(calls);
-                std::cout << "  " << std::setprecision(1) << ns_per << " ns/exp()";
-            }
+            auto row = [&](const char *label, double ms, std::uint64_t calls) {
+                std::cout << "  " << std::left << std::setw(24) << label << std::right
+                          << std::setw(8) << ms << " ms"
+                          << "  " << std::setw(6) << std::setprecision(1) << pct(ms) << "%";
+                if (calls > 0) {
+                    const double ns_per = (ms * 1e6) / static_cast<double>(calls);
+                    std::cout << "  " << std::setprecision(1) << ns_per << " ns/exp()";
+                }
+                std::cout << "\n";
+                std::cout << std::setprecision(3);
+            };
+
+            row("FB (fwd+bwd)", bw.fb_ms, 0);
+            row("Gamma accum", bw.gamma_ms, bw.gamma_exp_calls);
+            row("Xi accum", bw.xi_ms, bw.xi_exp_calls);
+            std::cout << "  " << std::left << std::setw(24) << "TOTAL (1 BW iter)" << std::right
+                      << std::setw(8) << total << " ms\n";
             std::cout << "\n";
-            std::cout << std::setprecision(3);
-        };
+        }
 
-        row("FB (fwd+bwd)", bw.fb_ms, 0);
-        row("Gamma accum", bw.gamma_ms, bw.gamma_exp_calls);
-        row("Xi accum", bw.xi_ms, bw.xi_exp_calls);
-        std::cout << "  " << std::left << std::setw(24) << "TOTAL (1 BW iter)" << std::right
-                  << std::setw(8) << total << " ms\n";
-        std::cout << "\n";
+        if (g_sink == 1.23456789)
+            std::cout << "sink=" << g_sink << "\n";
+    } catch (const std::exception &e) {
+        std::cerr << "Error: " << e.what() << "\n";
+        return 1;
     }
-
-    if (g_sink == 1.23456789)
-        std::cout << "sink=" << g_sink << "\n";
     return 0;
 }

--- a/tools/fb_contour_sweep.cpp
+++ b/tools/fb_contour_sweep.cpp
@@ -360,61 +360,66 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    const std::vector<Config> configs = {
-        {2, 1000},   {2, 10000}, {2, 100000}, {2, 1000000}, {4, 1000},  {4, 10000},
-        {4, 100000}, {8, 1000},  {8, 5000},   {8, 10000},   {16, 1000}, {16, 2000},
-        {16, 5000},  {32, 500},  {32, 1000},  {32, 2000},   {64, 200},  {64, 500},
-        {64, 1000},  {128, 100}, {128, 250},  {128, 500},
-    };
+    try {
+        const std::vector<Config> configs = {
+            {2, 1000},   {2, 10000}, {2, 100000}, {2, 1000000}, {4, 1000},  {4, 10000},
+            {4, 100000}, {8, 1000},  {8, 5000},   {8, 10000},   {16, 1000}, {16, 2000},
+            {16, 5000},  {32, 500},  {32, 1000},  {32, 2000},   {64, 200},  {64, 500},
+            {64, 1000},  {128, 100}, {128, 250},  {128, 500},
+        };
 
-    const fs::path output_dir = output_path.parent_path();
-    if (!output_dir.empty()) {
-        fs::create_directories(output_dir);
-    }
-    std::ofstream csv(output_path);
-    if (!csv) {
-        std::cerr << "Failed to open output file: " << output_path << "\n";
+        const fs::path output_dir = output_path.parent_path();
+        if (!output_dir.empty()) {
+            fs::create_directories(output_dir);
+        }
+        std::ofstream csv(output_path);
+        if (!csv) {
+            std::cerr << "Failed to open output file: " << output_path << "\n";
+            return 1;
+        }
+
+        csv << "mode,n,t,runs,warmup,recurrence_work,emission_work,transition_ms,obs_copy_ms,"
+               "emission_ms,alloc_ms,forward_ms,backward_ms,reduction_ms,total_ms\n";
+
+        std::cout << "libhmm FB contour sweep\n";
+        std::cout << "Mode: " << mode_name() << "\n";
+        std::cout << "Runs: " << runs << " (warmup " << warmup << ")\n";
+        std::cout << "Output: " << output_path << "\n\n";
+        std::cout << std::fixed << std::setprecision(3);
+
+        for (const auto &cfg : configs) {
+            auto hmm = make_hmm(cfg.n);
+            auto obs = make_obs(cfg.t, cfg.n);
+            const Timings timed = profile_config(*hmm, obs, runs, warmup);
+
+            const std::uint64_t recurrence_work =
+                static_cast<std::uint64_t>(cfg.n) * cfg.n * static_cast<std::uint64_t>(cfg.t - 1);
+            const std::uint64_t emission_work =
+                static_cast<std::uint64_t>(cfg.n) * static_cast<std::uint64_t>(cfg.t);
+
+            csv << mode_name() << "," << cfg.n << "," << cfg.t << "," << runs << "," << warmup
+                << "," << recurrence_work << "," << emission_work << "," << timed.transition_ms
+                << "," << timed.obs_copy_ms << "," << timed.emission_ms << "," << timed.alloc_ms
+                << "," << timed.forward_ms << "," << timed.backward_ms << "," << timed.reduction_ms
+                << "," << timed.total_ms << "\n";
+
+            const double recurrence_pct =
+                (timed.total_ms > 0.0)
+                    ? ((timed.forward_ms + timed.backward_ms) * 100.0 / timed.total_ms)
+                    : 0.0;
+            std::cout << "N=" << std::setw(3) << cfg.n << " T=" << std::setw(8) << cfg.t
+                      << " total=" << std::setw(9) << timed.total_ms << " ms"
+                      << " recur=" << std::setw(6) << recurrence_pct << "%\n";
+        }
+
+        csv.close();
+        if (g_sink_double == 42.0) {
+            std::cout << "sink=" << g_sink_double << "\n";
+        }
+        std::cout << "\nDone.\n";
+    } catch (const std::exception &e) {
+        std::cerr << "Error: " << e.what() << "\n";
         return 1;
     }
-
-    csv << "mode,n,t,runs,warmup,recurrence_work,emission_work,transition_ms,obs_copy_ms,"
-           "emission_ms,alloc_ms,forward_ms,backward_ms,reduction_ms,total_ms\n";
-
-    std::cout << "libhmm FB contour sweep\n";
-    std::cout << "Mode: " << mode_name() << "\n";
-    std::cout << "Runs: " << runs << " (warmup " << warmup << ")\n";
-    std::cout << "Output: " << output_path << "\n\n";
-    std::cout << std::fixed << std::setprecision(3);
-
-    for (const auto &cfg : configs) {
-        auto hmm = make_hmm(cfg.n);
-        auto obs = make_obs(cfg.t, cfg.n);
-        const Timings timed = profile_config(*hmm, obs, runs, warmup);
-
-        const std::uint64_t recurrence_work =
-            static_cast<std::uint64_t>(cfg.n) * cfg.n * static_cast<std::uint64_t>(cfg.t - 1);
-        const std::uint64_t emission_work =
-            static_cast<std::uint64_t>(cfg.n) * static_cast<std::uint64_t>(cfg.t);
-
-        csv << mode_name() << "," << cfg.n << "," << cfg.t << "," << runs << "," << warmup << ","
-            << recurrence_work << "," << emission_work << "," << timed.transition_ms << ","
-            << timed.obs_copy_ms << "," << timed.emission_ms << "," << timed.alloc_ms << ","
-            << timed.forward_ms << "," << timed.backward_ms << "," << timed.reduction_ms << ","
-            << timed.total_ms << "\n";
-
-        const double recurrence_pct =
-            (timed.total_ms > 0.0)
-                ? ((timed.forward_ms + timed.backward_ms) * 100.0 / timed.total_ms)
-                : 0.0;
-        std::cout << "N=" << std::setw(3) << cfg.n << " T=" << std::setw(8) << cfg.t
-                  << " total=" << std::setw(9) << timed.total_ms << " ms"
-                  << " recur=" << std::setw(6) << recurrence_pct << "%\n";
-    }
-
-    csv.close();
-    if (g_sink_double == 42.0) {
-        std::cout << "sink=" << g_sink_double << "\n";
-    }
-    std::cout << "\nDone.\n";
     return 0;
 }

--- a/tools/hotspot_breakdown.cpp
+++ b/tools/hotspot_breakdown.cpp
@@ -489,76 +489,80 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    std::cout << "libhmm Hotspot Breakdown Tool\n";
-    std::cout << "============================\n";
-    std::cout << "Median of " << runs << " timed runs (" << warmup << " warmup).\n\n";
+    try {
+        std::cout << "libhmm Hotspot Breakdown Tool\n";
+        std::cout << "============================\n";
+        std::cout << "Median of " << runs << " timed runs (" << warmup << " warmup).\n\n";
 #if defined(LIBHMM_EXPERIMENT_FB_MAX_REDUCE)
-    std::cout << "Forward-Backward accumulation mode: max-then-reduce (experimental)\n\n";
+        std::cout << "Forward-Backward accumulation mode: max-then-reduce (experimental)\n\n";
 #elif defined(LIBHMM_EXPERIMENT_FB_ADAPTIVE_SELECTOR)
-    std::cout << "Forward-Backward accumulation mode: static adaptive selector (stage-1)\n\n";
+        std::cout << "Forward-Backward accumulation mode: static adaptive selector (stage-1)\n\n";
 #else
-    std::cout << "Forward-Backward accumulation mode: pairwise logSumExp (control)\n\n";
+        std::cout << "Forward-Backward accumulation mode: pairwise logSumExp (control)\n\n";
 #endif
 
-    std::cout << std::fixed << std::setprecision(3);
+        std::cout << std::fixed << std::setprecision(3);
 
-    for (const auto &cfg : configs) {
-        auto hmm = make_hmm(cfg.num_states);
-        auto obs = make_obs(cfg.sequence_length, cfg.num_states);
+        for (const auto &cfg : configs) {
+            auto hmm = make_hmm(cfg.num_states);
+            auto obs = make_obs(cfg.sequence_length, cfg.num_states);
 
-        const auto fb = profile_forward_backward(*hmm, obs, warmup, runs);
-        const auto vt = profile_viterbi(*hmm, obs, warmup, runs);
+            const auto fb = profile_forward_backward(*hmm, obs, warmup, runs);
+            const auto vt = profile_viterbi(*hmm, obs, warmup, runs);
 
-        const double fb_total = fb.transition_ms + fb.obs_copy_ms + fb.emission_ms +
-                                fb.buffer_alloc_ms + fb.forward_ms + fb.backward_ms +
-                                fb.reduction_ms;
-        const double vt_total = vt.transition_ms + vt.emission_ms + vt.emission_relayout_ms +
-                                vt.buffer_alloc_ms + vt.recursion_ms + vt.backtrack_ms;
+            const double fb_total = fb.transition_ms + fb.obs_copy_ms + fb.emission_ms +
+                                    fb.buffer_alloc_ms + fb.forward_ms + fb.backward_ms +
+                                    fb.reduction_ms;
+            const double vt_total = vt.transition_ms + vt.emission_ms + vt.emission_relayout_ms +
+                                    vt.buffer_alloc_ms + vt.recursion_ms + vt.backtrack_ms;
 
-        const std::size_t n = static_cast<std::size_t>(cfg.num_states);
-        const std::size_t t = static_cast<std::size_t>(cfg.sequence_length);
-        const std::uint64_t emission_work = static_cast<std::uint64_t>(n) * t;
-        const std::uint64_t recurrence_work =
-            (t > 0) ? static_cast<std::uint64_t>(n) * n * (t - 1) : 0ULL;
+            const std::size_t n = static_cast<std::size_t>(cfg.num_states);
+            const std::size_t t = static_cast<std::size_t>(cfg.sequence_length);
+            const std::uint64_t emission_work = static_cast<std::uint64_t>(n) * t;
+            const std::uint64_t recurrence_work =
+                (t > 0) ? static_cast<std::uint64_t>(n) * n * (t - 1) : 0ULL;
 
-        std::cout << "Config: N=" << cfg.num_states << ", T=" << cfg.sequence_length << "\n";
-        std::cout << "  Estimated recurrence work per pass: "
-                  << static_cast<double>(recurrence_work) / 1.0e6 << " M (N^2*(T-1))\n";
-        std::cout << "  Emission evaluations per pass:      "
-                  << static_cast<double>(emission_work) / 1.0e6 << " M (N*T)\n";
+            std::cout << "Config: N=" << cfg.num_states << ", T=" << cfg.sequence_length << "\n";
+            std::cout << "  Estimated recurrence work per pass: "
+                      << static_cast<double>(recurrence_work) / 1.0e6 << " M (N^2*(T-1))\n";
+            std::cout << "  Emission evaluations per pass:      "
+                      << static_cast<double>(emission_work) / 1.0e6 << " M (N*T)\n";
 
-        std::cout << "\nForward-Backward phase breakdown:\n";
-        print_phase("Transition log precompute", fb.transition_ms, fb_total);
-        print_phase("Observation copy", fb.obs_copy_ms, fb_total);
-        print_phase("Emission batch eval", fb.emission_ms, fb_total);
-        print_phase("Alpha/Beta buffer alloc", fb.buffer_alloc_ms, fb_total);
-        print_phase("Forward recursion", fb.forward_ms, fb_total);
-        print_phase("Backward recursion", fb.backward_ms, fb_total);
-        print_phase("Final log-sum-exp reduce", fb.reduction_ms, fb_total);
-        std::cout << "  " << std::left << std::setw(28) << "TOTAL" << std::right << std::setw(10)
-                  << fb_total << " ms\n";
+            std::cout << "\nForward-Backward phase breakdown:\n";
+            print_phase("Transition log precompute", fb.transition_ms, fb_total);
+            print_phase("Observation copy", fb.obs_copy_ms, fb_total);
+            print_phase("Emission batch eval", fb.emission_ms, fb_total);
+            print_phase("Alpha/Beta buffer alloc", fb.buffer_alloc_ms, fb_total);
+            print_phase("Forward recursion", fb.forward_ms, fb_total);
+            print_phase("Backward recursion", fb.backward_ms, fb_total);
+            print_phase("Final log-sum-exp reduce", fb.reduction_ms, fb_total);
+            std::cout << "  " << std::left << std::setw(28) << "TOTAL" << std::right
+                      << std::setw(10) << fb_total << " ms\n";
 
-        std::cout << "  Estimated FB working set: "
-                  << bytes_to_mib(estimate_forward_working_set_bytes(n, t)) << " MiB\n";
+            std::cout << "  Estimated FB working set: "
+                      << bytes_to_mib(estimate_forward_working_set_bytes(n, t)) << " MiB\n";
 
-        std::cout << "\nViterbi phase breakdown:\n";
-        print_phase("Transition log precompute", vt.transition_ms, vt_total);
-        print_phase("Emission batch eval", vt.emission_ms, vt_total);
-        print_phase("Emission relayout (T-major)", vt.emission_relayout_ms, vt_total);
-        print_phase("Delta/Psi buffer alloc", vt.buffer_alloc_ms, vt_total);
-        print_phase("Viterbi recursion", vt.recursion_ms, vt_total);
-        print_phase("Backtrack", vt.backtrack_ms, vt_total);
-        std::cout << "  " << std::left << std::setw(28) << "TOTAL" << std::right << std::setw(10)
-                  << vt_total << " ms\n";
+            std::cout << "\nViterbi phase breakdown:\n";
+            print_phase("Transition log precompute", vt.transition_ms, vt_total);
+            print_phase("Emission batch eval", vt.emission_ms, vt_total);
+            print_phase("Emission relayout (T-major)", vt.emission_relayout_ms, vt_total);
+            print_phase("Delta/Psi buffer alloc", vt.buffer_alloc_ms, vt_total);
+            print_phase("Viterbi recursion", vt.recursion_ms, vt_total);
+            print_phase("Backtrack", vt.backtrack_ms, vt_total);
+            std::cout << "  " << std::left << std::setw(28) << "TOTAL" << std::right
+                      << std::setw(10) << vt_total << " ms\n";
 
-        std::cout << "  Estimated Viterbi working set: "
-                  << bytes_to_mib(estimate_viterbi_working_set_bytes(n, t)) << " MiB\n";
-        std::cout << "\n------------------------------------------------------------\n\n";
+            std::cout << "  Estimated Viterbi working set: "
+                      << bytes_to_mib(estimate_viterbi_working_set_bytes(n, t)) << " MiB\n";
+            std::cout << "\n------------------------------------------------------------\n\n";
+        }
+
+        if (g_sink_int == 42) {
+            std::cout << "sink=" << g_sink_double << "\n";
+        }
+    } catch (const std::exception &e) {
+        std::cerr << "Error: " << e.what() << "\n";
+        return 1;
     }
-
-    if (g_sink_int == 42) {
-        std::cout << "sink=" << g_sink_double << "\n";
-    }
-
     return 0;
 }


### PR DESCRIPTION
## Summary

Three focused changes from the code-quality roadmap, all lizard warnings now triaged.

## Changes

### Remove dead private helpers (closes #9)

`GammaDistribution::ligamma` — declared in the header, implemented in the `.cpp`, zero callers anywhere in `src/`, `include/`, `tests/`, or `tools/`. It wrapped `gammap()` but `getCumulativeProbability()` calls `gammap()` directly.

`ParetoDistribution::CDF` — private method that forwarded to `getCumulativeProbability()`; zero direct callers (tests use the public `getCumulativeProbability()`). Also removes the `negK_` cached field, which was computed in `updateCache()` solely for `CDF`'s use and never read elsewhere.

Net: 37 deletions across 4 files. All 37 tests pass.

### Fix incomplete throwInEntryPoint in 3 profiling tools (closes #8)

`bw_hotspot`, `fb_contour_sweep`, and `hotspot_breakdown` each had a `try/catch` covering only argument parsing. The main profiling loop was unprotected — any exception during model construction or the benchmark loop (e.g. `std::bad_alloc`) would terminate without a useful error message.

Wraps the full execution body (after argument validation) in `try/catch(const std::exception &)` that prints to stderr and returns 1.

### Triage remaining lizard warnings (closes #11, closes #12)

No code changes. Both issues resolved by inspection:

- `from_json` (CC 14, 67 lines): sequential JSON parser with security-motivated bounds-checking. Distribution dispatch already abstracted via `kFactory` + `read_distribution`. No structural decomposition warranted.
- `NegativeBinomialDistribution::fit` (CC 19), `ParetoDistribution::fit` (CC 17), `BetaDistribution::fit` (CC 16): all are closed-form MOM/MLE estimators wrapped in defense-in-depth guard chains. Same category as the previously acknowledged Beta algorithmic functions.

All lizard warnings are now triaged. Tier 6 (SIMD boilerplate in `transcendental_kernels.cpp`) is the only remaining structural item in the roadmap.

---

Conversation: https://app.warp.dev/conversation/f6feafc0-6026-4e5a-a973-7b0f175cc9a1

Co-Authored-By: Oz <oz-agent@warp.dev>