### PR TITLE
refactor: complete FB calculator loop extraction, BasicMatrix3D delegation, STL algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.3] - 2026-05-10
+
+Code quality patch: CPD reduction, STL algorithm improvements. 37/37 tests pass.
+
+### Changed
+
+- **`ForwardBackwardCalculator` pairwise/max-reduce extraction** (completes Tier 2,
+  `src/calculators/forward_backward_calculator.cpp`): the pointer-setup block and
+  outer time-loop were still duplicated between the Pairwise and MaxReduce forward and
+  backward passes. Extracted `compute_forward<Fn>` and `compute_backward<Fn>`
+  anonymous-namespace templates; the four concrete methods are now single-call wrappers
+  passing lambdas for the inner computation. Eliminates the two CPD blocks previously
+  found at lines 136/163 and 206/236.
+- **`BasicMatrix3D` constructor delegation** (`include/libhmm/linalg/basic_matrix3d.h`):
+  the zero-fill constructor now delegates to the init-value constructor in one line,
+  removing duplicated dimension-validation and allocation code.
+- **STL algorithm improvements** (10 distribution files + `src/common/weighted_stats.cpp`):
+  replace unconditional `for (w : weights) sumW += w;` accumulator loops with
+  `const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);` across
+  all weighted `fit()` overloads in binomial, discrete, gamma, log_normal,
+  negative_binomial, pareto, rayleigh, student_t, and weibull distributions, and in
+  `weighted_stats.cpp`. The `const` qualifier is the primary gain. Also replaces
+  the Weibull data-validation loop with `std::any_of`. Adds explicit `#include <numeric>`
+  where previously relying on transitive inclusion.
+
 ## [3.5.2] - 2026-05-09
 
 Code quality patch: dead code removal, tool exception safety, lizard triage. 37/37 tests pass.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if(APPLE AND NOT CMAKE_CXX_COMPILER)
 endif()
 
 project(libhmm
-    VERSION 3.5.2
+    VERSION 3.5.3
     DESCRIPTION "Modern C++20 Hidden Markov Model Library"
     LANGUAGES CXX
 )

--- a/WARP.md
+++ b/WARP.md
@@ -6,9 +6,9 @@ This file provides guidance to Warp (warp.dev) when working in this repository.
 
 ## Current Status
 
-**Version**: v3.5.2 — pending merge on `refactor/code-quality-phase6` (PR #14); v3.5.1 is the latest published tag on `main`.
+**Version**: v3.5.3 — pending merge on `refactor/code-quality-phase7`; v3.5.2 is the latest published tag on `main`.
 **Tests**: 37/37 passing on all four CI platforms (Linux/GCC, Linux/Clang, macOS/AppleClang, Windows/MSVC).
-**Active phase**: Code quality roadmap complete. All lizard warnings triaged; Tier 6 (SIMD boilerplate) is the only deferred structural item.
+**Active phase**: Code quality roadmap complete. All lizard warnings triaged; Tier 6 (SIMD boilerplate in `transcendental_kernels.cpp`) is the only deferred structural item.
 
 ---
 

--- a/include/libhmm/libhmm.h
+++ b/include/libhmm/libhmm.h
@@ -28,7 +28,7 @@
  * For large projects or when compilation time is critical, consider including
  * only the specific headers you need instead of this master header.
  *
- * @version 3.5.2
+ * @version 3.5.3
  * @author libhmm development team
  */
 

--- a/include/libhmm/linalg/basic_matrix3d.h
+++ b/include/libhmm/linalg/basic_matrix3d.h
@@ -28,37 +28,13 @@ private:
     }
 
 public:
-    /// Constructor with dimensions
-    /// @param x First dimension size
-    /// @param y Second dimension size
-    /// @param z Third dimension size
-    /// @throws std::invalid_argument if any dimension is zero
-    BasicMatrix3D(std::size_t x, std::size_t y, std::size_t z)
-        : x_{x}, y_{y}, z_{z}, yz_stride_{y * z} {
-        if (x == 0 || y == 0 || z == 0) {
-            throw std::invalid_argument("BasicMatrix3D dimensions must be greater than zero");
-        }
+    /// Constructor with dimensions; initialises all elements to zero.
+    /// @throws std::invalid_argument if any dimension is zero or the total size overflows.
+    BasicMatrix3D(std::size_t x, std::size_t y, std::size_t z) : BasicMatrix3D(x, y, z, T{0}) {}
 
-        // Check for potential overflow
-        if (yz_stride_ < y || yz_stride_ < z) {
-            throw std::invalid_argument("BasicMatrix3D dimensions too large (overflow)");
-        }
-
-        std::size_t total_size = x * yz_stride_;
-        if (total_size < x || total_size < yz_stride_) {
-            throw std::invalid_argument("BasicMatrix3D total size too large (overflow)");
-        }
-
-        // Initialize contiguous storage with zero-fill
-        data_.resize(total_size, T{0});
-    }
-
-    /// Constructor with dimensions and initial value
-    /// @param x First dimension size
-    /// @param y Second dimension size
-    /// @param z Third dimension size
-    /// @param init_value Initial value for all elements
-    /// @throws std::invalid_argument if any dimension is zero
+    /// Constructor with dimensions and initial value.
+    /// @param init_value Value written to every element.
+    /// @throws std::invalid_argument if any dimension is zero or the total size overflows.
     BasicMatrix3D(std::size_t x, std::size_t y, std::size_t z, const T &init_value)
         : x_{x}, y_{y}, z_{z}, yz_stride_{y * z} {
         if (x == 0 || y == 0 || z == 0) {

--- a/src/calculators/forward_backward_calculator.cpp
+++ b/src/calculators/forward_backward_calculator.cpp
@@ -24,6 +24,54 @@ void init_log_backward(double *betaData, std::size_t T, std::size_t N) noexcept 
     for (std::size_t i = 0; i < N; ++i)
         finalRow[i] = 0.0;
 }
+
+/// Shared forward-pass loop. Sets up pointers, calls init_log_forward, then
+/// iterates t=1..T-1. The per-j inner computation is delegated to @p inner,
+/// which receives (prevAlphaRow, transCol, N) and returns the log-sum term.
+///
+/// This template is instantiated twice — once for Pairwise, once for
+/// MaxReduce — in the same translation unit, so no explicit instantiation
+/// or header declaration is required.
+template <typename InnerFn>
+void compute_forward(const Hmm &hmm, std::size_t N, const ObservationSet &observations,
+                     const double *logTransT, const double *emitByTime, Matrix &logAlpha,
+                     InnerFn inner) {
+    const Vector &pi = hmm.getPi();
+    const std::size_t T = observations.size();
+    double *alphaData = logAlpha.data();
+    init_log_forward(alphaData, pi, emitByTime, N);
+    for (std::size_t t = 1; t < T; ++t) {
+        const double *prevRow = alphaData + (t - 1) * N;
+        double *row = alphaData + t * N;
+        const double *emitRow = emitByTime + t * N;
+        for (std::size_t j = 0; j < N; ++j)
+            row[j] = emitRow[j] + inner(prevRow, logTransT + j * N, N);
+    }
+}
+
+/// Shared backward-pass loop. Sets up pointers, calls init_log_backward,
+/// then iterates t=T-2..0. The per-i inner computation is delegated to
+/// @p inner, which receives (transRow, emitNextRow, nextBetaRow, N) and
+/// returns the log-sum term.
+template <typename InnerFn>
+void compute_backward(std::size_t N, const ObservationSet &observations, const double *logTrans,
+                      const double *emitByTime, Matrix &logBeta, InnerFn inner) {
+    const std::size_t T = observations.size();
+    double *betaData = logBeta.data();
+    init_log_backward(betaData, T, N);
+    if (T > 1) {
+        for (std::size_t t = T - 2;; --t) {
+            double *betaRow = betaData + t * N;
+            const double *nextBetaRow = betaData + (t + 1) * N;
+            const double *emitNextRow = emitByTime + (t + 1) * N;
+            for (std::size_t i = 0; i < N; ++i)
+                betaRow[i] = inner(logTrans + i * N, emitNextRow, nextBetaRow, N);
+            if (t == 0)
+                break;
+        }
+    }
+}
+
 } // namespace
 
 FbRecurrenceMode
@@ -134,65 +182,27 @@ void ForwardBackwardCalculator::computeLogForward() {
 }
 
 void ForwardBackwardCalculator::computeLogForwardPairwise() {
-    const Hmm &hmm = getHmmRef();
-    const Vector &pi = hmm.getPi();
-    const std::size_t T = observations_.size();
-    const std::size_t N = numStates_;
-    const double *logTransTData = logTransT_.data();
-    const double *emitByTimeData = logEmitByTime_.data();
-    double *alphaData = logAlpha_.data();
-
-    init_log_forward(alphaData, pi, emitByTimeData, N);
-
-    // t > 0.
-    for (std::size_t t = 1; t < T; ++t) {
-        const double *prevAlphaRow = alphaData + (t - 1) * N;
-        double *alphaRow = alphaData + t * N;
-        const double *emitRow = emitByTimeData + t * N;
-        for (std::size_t j = 0; j < N; ++j) {
-            const double *transCol = logTransTData + j * N;
-            double logSum = LOG_ZERO;
-            for (std::size_t i = 0; i < N; ++i) {
-                logSum = logSumExp(logSum, prevAlphaRow[i] + transCol[i]);
-            }
-            alphaRow[j] = emitRow[j] + logSum;
-        }
-    }
+    compute_forward(getHmmRef(), numStates_, observations_, logTransT_.data(),
+                    logEmitByTime_.data(), logAlpha_,
+                    [](const double *prev, const double *transCol, std::size_t n) {
+                        double s = LOG_ZERO;
+                        for (std::size_t i = 0; i < n; ++i)
+                            s = logSumExp(s, prev[i] + transCol[i]);
+                        return s;
+                    });
 }
 
 void ForwardBackwardCalculator::computeLogForwardMaxReduce() {
-    const Hmm &hmm = getHmmRef();
-    const Vector &pi = hmm.getPi();
-    const std::size_t T = observations_.size();
-    const std::size_t N = numStates_;
-    const double *logTransTData = logTransT_.data();
-    const double *emitByTimeData = logEmitByTime_.data();
-    double *alphaData = logAlpha_.data();
-
-    init_log_forward(alphaData, pi, emitByTimeData, N);
-
-    // t > 0.
-    for (std::size_t t = 1; t < T; ++t) {
-        const double *prevAlphaRow = alphaData + (t - 1) * N;
-        double *alphaRow = alphaData + t * N;
-        const double *emitRow = emitByTimeData + t * N;
-        for (std::size_t j = 0; j < N; ++j) {
-            const double *transCol = logTransTData + j * N;
-            const double maxTerm = performance::detail::TranscendentalKernels::reduce_max_sum2(
-                prevAlphaRow, transCol, N);
-
-            double logSum = LOG_ZERO;
-            if (std::isfinite(maxTerm)) {
-                const double scaledSum =
-                    performance::detail::TranscendentalKernels::sum_exp_sum2_minus_max(
-                        prevAlphaRow, transCol, N, maxTerm);
-                if (scaledSum > 0.0) {
-                    logSum = maxTerm + std::log(scaledSum);
-                }
-            }
-            alphaRow[j] = emitRow[j] + logSum;
-        }
-    }
+    using TK = performance::detail::TranscendentalKernels;
+    compute_forward(getHmmRef(), numStates_, observations_, logTransT_.data(),
+                    logEmitByTime_.data(), logAlpha_,
+                    [](const double *prev, const double *transCol, std::size_t n) {
+                        const double m = TK::reduce_max_sum2(prev, transCol, n);
+                        if (!std::isfinite(m))
+                            return LOG_ZERO;
+                        const double s = TK::sum_exp_sum2_minus_max(prev, transCol, n, m);
+                        return (s > 0.0) ? m + std::log(s) : LOG_ZERO;
+                    });
 }
 
 void ForwardBackwardCalculator::computeLogBackward() {
@@ -204,71 +214,27 @@ void ForwardBackwardCalculator::computeLogBackward() {
 }
 
 void ForwardBackwardCalculator::computeLogBackwardPairwise() {
-    const std::size_t T = observations_.size();
-    const std::size_t N = numStates_;
-    const double *logTransData = logTrans_.data();
-    const double *emitByTimeData = logEmitByTime_.data();
-    double *betaData = logBeta_.data();
-
-    init_log_backward(betaData, T, N);
-
-    // t < T - 1.
-    if (T > 1) {
-        for (std::size_t t = T - 2;; --t) {
-            double *betaRow = betaData + t * N;
-            const double *nextBetaRow = betaData + (t + 1) * N;
-            const double *emitNextRow = emitByTimeData + (t + 1) * N;
-            for (std::size_t i = 0; i < N; ++i) {
-                const double *transRow = logTransData + i * N;
-                double logSum = LOG_ZERO;
-                for (std::size_t j = 0; j < N; ++j) {
-                    logSum = logSumExp(logSum, transRow[j] + emitNextRow[j] + nextBetaRow[j]);
-                }
-                betaRow[i] = logSum;
-            }
-            if (t == 0) {
-                break;
-            }
-        }
-    }
+    compute_backward(
+        numStates_, observations_, logTrans_.data(), logEmitByTime_.data(), logBeta_,
+        [](const double *transRow, const double *emitNext, const double *nextBeta, std::size_t n) {
+            double s = LOG_ZERO;
+            for (std::size_t j = 0; j < n; ++j)
+                s = logSumExp(s, transRow[j] + emitNext[j] + nextBeta[j]);
+            return s;
+        });
 }
 
 void ForwardBackwardCalculator::computeLogBackwardMaxReduce() {
-    const std::size_t T = observations_.size();
-    const std::size_t N = numStates_;
-    const double *logTransData = logTrans_.data();
-    const double *emitByTimeData = logEmitByTime_.data();
-    double *betaData = logBeta_.data();
-
-    init_log_backward(betaData, T, N);
-
-    // t < T - 1.
-    if (T > 1) {
-        for (std::size_t t = T - 2;; --t) {
-            double *betaRow = betaData + t * N;
-            const double *nextBetaRow = betaData + (t + 1) * N;
-            const double *emitNextRow = emitByTimeData + (t + 1) * N;
-            for (std::size_t i = 0; i < N; ++i) {
-                const double *transRow = logTransData + i * N;
-                const double maxTerm = performance::detail::TranscendentalKernels::reduce_max_sum3(
-                    transRow, emitNextRow, nextBetaRow, N);
-
-                double logSum = LOG_ZERO;
-                if (std::isfinite(maxTerm)) {
-                    const double scaledSum =
-                        performance::detail::TranscendentalKernels::sum_exp_sum3_minus_max(
-                            transRow, emitNextRow, nextBetaRow, N, maxTerm);
-                    if (scaledSum > 0.0) {
-                        logSum = maxTerm + std::log(scaledSum);
-                    }
-                }
-                betaRow[i] = logSum;
-            }
-            if (t == 0) {
-                break;
-            }
-        }
-    }
+    using TK = performance::detail::TranscendentalKernels;
+    compute_backward(
+        numStates_, observations_, logTrans_.data(), logEmitByTime_.data(), logBeta_,
+        [](const double *transRow, const double *emitNext, const double *nextBeta, std::size_t n) {
+            const double m = TK::reduce_max_sum3(transRow, emitNext, nextBeta, n);
+            if (!std::isfinite(m))
+                return LOG_ZERO;
+            const double s = TK::sum_exp_sum3_minus_max(transRow, emitNext, nextBeta, n, m);
+            return (s > 0.0) ? m + std::log(s) : LOG_ZERO;
+        });
 }
 
 // Numerically stable log(exp(a) + exp(b)).

--- a/src/common/weighted_stats.cpp
+++ b/src/common/weighted_stats.cpp
@@ -1,5 +1,6 @@
 #include "libhmm/math/weighted_stats.h"
 #include "libhmm/math/constants.h"
+#include <numeric>
 
 using namespace libhmm::constants;
 
@@ -7,9 +8,7 @@ namespace libhmm::detail {
 
 std::optional<WeightedStats> compute_weighted_stats(std::span<const double> data,
                                                     std::span<const double> weights) noexcept {
-    double sumW = 0.0;
-    for (const double w : weights)
-        sumW += w;
+    const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);
     if (sumW < precision::ZERO || std::isnan(sumW))
         return std::nullopt;
 

--- a/src/distributions/binomial_distribution.cpp
+++ b/src/distributions/binomial_distribution.cpp
@@ -93,9 +93,7 @@ void BinomialDistribution::fit(std::span<const double> data) {
 }
 
 void BinomialDistribution::fit(std::span<const double> data, std::span<const double> weights) {
-    double sumW = 0.0;
-    for (const double w : weights)
-        sumW += w;
+    const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);
     if (sumW < precision::ZERO || std::isnan(sumW)) {
         reset();
         return;

--- a/src/distributions/discrete_distribution.cpp
+++ b/src/distributions/discrete_distribution.cpp
@@ -1,5 +1,6 @@
 #include "libhmm/distributions/discrete_distribution.h"
 #include "libhmm/io/json_utils.h"
+#include <numeric>
 #include <span>
 
 using namespace libhmm::constants;
@@ -58,9 +59,7 @@ void DiscreteDistribution::fit(std::span<const double> data) {
 
 void DiscreteDistribution::fit(std::span<const double> data, std::span<const double> weights) {
     // Weighted empirical probabilities: P(X=k) = Σ(w_i for x_i=k) / Σ(w_i)
-    double sumW = 0.0;
-    for (const double w : weights)
-        sumW += w;
+    const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);
     if (sumW < precision::ZERO || std::isnan(sumW)) {
         reset();
         return;

--- a/src/distributions/gamma_distribution.cpp
+++ b/src/distributions/gamma_distribution.cpp
@@ -1,5 +1,6 @@
 #include "libhmm/distributions/gamma_distribution.h"
 #include "libhmm/io/json_utils.h"
+#include <numeric>
 #include <span>
 
 using namespace libhmm::constants;
@@ -131,9 +132,7 @@ void GammaDistribution::fit(std::span<const double> data) {
 }
 
 void GammaDistribution::fit(std::span<const double> data, std::span<const double> weights) {
-    double sumW = 0.0;
-    for (const double w : weights)
-        sumW += w;
+    const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);
     if (sumW < precision::ZERO || std::isnan(sumW)) {
         reset();
         return;

--- a/src/distributions/log_normal_distribution.cpp
+++ b/src/distributions/log_normal_distribution.cpp
@@ -126,9 +126,7 @@ void LogNormalDistribution::fit(std::span<const double> data) {
 }
 
 void LogNormalDistribution::fit(std::span<const double> data, std::span<const double> weights) {
-    double sumW = 0.0;
-    for (const double w : weights)
-        sumW += w;
+    const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);
     if (sumW < precision::ZERO || std::isnan(sumW)) {
         reset();
         return;

--- a/src/distributions/negative_binomial_distribution.cpp
+++ b/src/distributions/negative_binomial_distribution.cpp
@@ -94,9 +94,7 @@ void NegativeBinomialDistribution::fit(std::span<const double> data) {
 
 void NegativeBinomialDistribution::fit(std::span<const double> data,
                                        std::span<const double> weights) {
-    double sumW = 0.0;
-    for (const double w : weights)
-        sumW += w;
+    const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);
     if (sumW < precision::ZERO || std::isnan(sumW)) {
         reset();
         return;

--- a/src/distributions/pareto_distribution.cpp
+++ b/src/distributions/pareto_distribution.cpp
@@ -102,9 +102,7 @@ void ParetoDistribution::fit(std::span<const double> data) {
 }
 
 void ParetoDistribution::fit(std::span<const double> data, std::span<const double> weights) {
-    double sumW = 0.0;
-    for (const double w : weights)
-        sumW += w;
+    const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);
     if (sumW < precision::ZERO || std::isnan(sumW)) {
         reset();
         return;

--- a/src/distributions/rayleigh_distribution.cpp
+++ b/src/distributions/rayleigh_distribution.cpp
@@ -1,7 +1,8 @@
 #include "libhmm/distributions/rayleigh_distribution.h"
 #include "libhmm/io/json_utils.h"
 // Header already includes: <iostream>, <cmath>, <cassert>, <stdexcept>, <sstream>, <iomanip> via common.h
-#include <limits> // For std::numeric_limits (not in common.h)
+#include <limits>  // For std::numeric_limits (not in common.h)
+#include <numeric> // For std::accumulate
 
 namespace libhmm {
 
@@ -76,9 +77,7 @@ void RayleighDistribution::fit(std::span<const double> data) {
 }
 
 void RayleighDistribution::fit(std::span<const double> data, std::span<const double> weights) {
-    double sumW = 0.0;
-    for (const double w : weights)
-        sumW += w;
+    const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);
     if (sumW < constants::precision::ZERO || std::isnan(sumW)) {
         reset();
         return;

--- a/src/distributions/student_t_distribution.cpp
+++ b/src/distributions/student_t_distribution.cpp
@@ -2,6 +2,7 @@
 #include "libhmm/io/json_utils.h"
 #include <algorithm>
 #include <limits>
+#include <numeric>
 #include <span>
 
 using namespace libhmm::constants;
@@ -154,9 +155,7 @@ void StudentTDistribution::fit(std::span<const double> data) {
 }
 
 void StudentTDistribution::fit(std::span<const double> data, std::span<const double> weights) {
-    double sumW = 0.0;
-    for (const double w : weights)
-        sumW += w;
+    const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);
     if (sumW < precision::ZERO || std::isnan(sumW)) {
         reset();
         return;

--- a/src/distributions/weibull_distribution.cpp
+++ b/src/distributions/weibull_distribution.cpp
@@ -101,9 +101,10 @@ void WeibullDistribution::fit(std::span<const double> data) {
         reset();
         return;
     }
-    for (const double val : data)
-        if (val < math::ZERO_DOUBLE || std::isnan(val) || std::isinf(val))
-            throw std::invalid_argument("Weibull fitting requires non-negative values");
+    if (std::any_of(data.begin(), data.end(), [](double v) {
+            return v < math::ZERO_DOUBLE || std::isnan(v) || std::isinf(v);
+        }))
+        throw std::invalid_argument("Weibull fitting requires non-negative values");
     const auto n = static_cast<double>(data.size());
     double mean = 0.0, m2 = 0.0;
     std::size_t count = 0;
@@ -117,9 +118,7 @@ void WeibullDistribution::fit(std::span<const double> data) {
 }
 
 void WeibullDistribution::fit(std::span<const double> data, std::span<const double> weights) {
-    double sumW = 0.0;
-    for (const double w : weights)
-        sumW += w;
+    const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);
     if (sumW < precision::ZERO || std::isnan(sumW)) {
         reset();
         return;


### PR DESCRIPTION
## Summary

Code quality patch addressing residual CPD duplication, STL algorithm improvements, and a linalg constructor fix. No public API changes. 37/37 tests pass.

## Changes

### Forward-Backward calculator pairwise/max-reduce extraction (completes Tier 2)

The Tier 2 plan item "ForwardBackwardCalculator pairwise/non-pairwise setup extraction" was marked complete but the pointer-setup block and outer time-loop were still duplicated between the Pairwise and MaxReduce forward and backward passes — confirmed by CPD at lines 136/163 and 206/236.

Extracted `compute_forward<Fn>` and `compute_backward<Fn>` free-function templates into the anonymous namespace. The four concrete methods (`computeLogForwardPairwise`, `computeLogForwardMaxReduce`, `computeLogBackwardPairwise`, `computeLogBackwardMaxReduce`) are now single-call wrappers passing lambdas for the inner computation. The templates are instantiated twice each within the same TU — no header changes required.

### `BasicMatrix3D` constructor delegation

The zero-fill constructor and the init-value constructor shared identical dimension-validation and allocation code. The zero-fill constructor now delegates to the init-value constructor in one line, removing the duplicated body.

### STL algorithm improvements (10 distribution files + `weighted_stats.cpp`)

Replaces unconditional `for (w : weights) sumW += w;` accumulator loops with `const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);` across all weighted `fit()` overloads in binomial, discrete, gamma, log_normal, negative_binomial, pareto, rayleigh, student_t, and weibull distributions, and in `weighted_stats.cpp`. The primary gain is `const` — the value cannot be reassigned after the guard check. Also replaces the Weibull data-validation loop with `std::any_of`. Adds explicit `#include <numeric>` where the include was previously relied on transitively.

## Not addressed (both confirmed not actionable)

- Minor `.cpp` weighted-fit CPD clusters (gamma/studentT, lognormal/weibull, 8–9 lines each): shared Welford preamble — structural algorithmic similarity with no clean extraction boundary, same category as distribution header interface boilerplate.
- `basic_matrix.h` vs `basic_vector.h` accessor block: STL-compatible interface boilerplate inherent to the template class pattern.

---

Conversation: https://app.warp.dev/conversation/f6feafc0-6026-4e5a-a973-7b0f175cc9a1

Co-Authored-By: Oz <oz-agent@warp.dev>