### PR TITLE
feat: v3.6.0 — posterior decoding, model selection, MAP Baum-Welch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,6 +541,7 @@ set(LIBHMM_SOURCES
     src/calculators/viterbi_calculator.cpp
     # Canonical trainers (Phase 4)
     src/training/baum_welch_trainer.cpp
+    src/training/map_baum_welch_trainer.cpp
     src/training/viterbi_trainer.cpp
     src/training/segmental_kmeans_trainer.cpp
     src/io/file_io_manager.cpp

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://isocpp.org/std/the-standard)
 [![CMake](https://img.shields.io/badge/CMake-3.20%2B-blue.svg)](https://cmake.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-3.5.1-brightgreen.svg)](https://github.com/OldCrow/libhmm/releases)
-[![Tests](https://img.shields.io/badge/Tests-37%2F37_Passing-success.svg)](tests/)
+[![Version](https://img.shields.io/badge/Version-3.6.0-brightgreen.svg)](https://github.com/OldCrow/libhmm/releases)
+[![Tests](https://img.shields.io/badge/Tests-40%2F40_Passing-success.svg)](tests/)
 [![SIMD](https://img.shields.io/badge/SIMD-AVX--512%2FAVX2%2FSSE2%2FNEON-blue.svg)](src/distributions/)
 [![CI](https://github.com/OldCrow/libhmm/actions/workflows/ci.yml/badge.svg)](https://github.com/OldCrow/libhmm/actions)
 
@@ -18,16 +18,36 @@ canonical log-space algorithms, and compile-time SIMD acceleration.
 ### Training Algorithms
 
 - **Baum-Welch** — canonical log-space EM; works with any `EmissionDistribution` via weighted `fit()`
+- **MAP Baum-Welch** — adds symmetric Dirichlet priors on A, π, and discrete emissions; prevents
+  degenerate zero-probability transitions on sparse data. `c = 0` recovers standard MLE exactly.
+  Use `computeLogPrior()` for the correct convergence criterion (likelihood alone is not monotone
+  when `c > 0`).
 - **Viterbi Training** — hard-assignment with `TrainingConfig` presets (`fast`, `balanced`, `precise`)
 - **Segmental K-Means** — for discrete HMMs; useful as initialiser before EM
 
 ### Inference
 
-- **ForwardBackward** — canonical log-space calculator; returns `probability()` and `getLogProbability()`
-- **Viterbi** — canonical log-space decoder; returns the MAP state sequence
+- **ForwardBackward** — canonical log-space calculator; returns `probability()`, `getLogProbability()`,
+  and `decodePosterior()` (per-step argmax-γ decoding, minimising per-step state error rate)
+- **Viterbi** — canonical log-space decoder; returns the MAP joint state sequence
+
+Use `decodePosterior()` when per-step annotation accuracy matters (e.g. gene prediction).
+Use Viterbi when whole-sequence structural coherence is required (e.g. speech alignment).
 
 Both calculators call `getBatchLogProbabilities()` per state per time step, enabling
 SIMD acceleration directly at the distribution layer.
+
+### Model Selection
+
+- `count_free_parameters(hmm)` — free parameters = N*(N-1) transitions + (N-1) initial + sum of emission params
+- `compute_aic(logL, k)`, `compute_bic(logL, k, n)`, `compute_aicc(logL, k, n)` — lower is better
+- `evaluate_model(hmm, logL, n)` — returns `HmmModelCriteria{aic, bic, aicc}` in one call
+
+```cpp
+ForwardBackwardCalculator fbc(hmm, obs);
+HmmModelCriteria mc = evaluate_model(hmm, fbc.getLogProbability(), obs.size());
+std::cout << "AIC: " << mc.aic << "  BIC: " << mc.bic << "\n";
+```
 
 ### Probability Distributions (15)
 
@@ -116,9 +136,27 @@ trainer.train();
 ForwardBackwardCalculator fbc(hmm, obs[0]);
 double log_p = fbc.getLogProbability();
 
-// Decode
+// Decode - two strategies:
 ViterbiCalculator vc(hmm, obs[0]);
-StateSequence path = vc.decode();
+StateSequence map_path      = vc.decode();           // MAP joint path
+StateSequence marginal_path = fbc.decodePosterior(); // per-step argmax-gamma
+```
+
+### MAP Baum-Welch
+
+```cpp
+// c=1 (Laplace smoothing) prevents zero transitions on sparse data.
+MapBaumWelchTrainer map_trainer(&hmm, obs, /*pseudo_count=*/1.0);
+
+double prev = -std::numeric_limits<double>::infinity();
+for (int i = 0; i < 50; ++i) {
+    map_trainer.train();
+    // Correct MAP convergence criterion: logL + log P(lambda|c)
+    double logL   = ForwardBackwardCalculator(hmm, obs[0]).getLogProbability();
+    double mapObj = logL + map_trainer.computeLogPrior();
+    if (mapObj - prev < 1e-6) break;
+    prev = mapObj;
+}
 ```
 
 ### ViterbiTrainer Presets
@@ -145,11 +183,11 @@ libhmm/
 │   ├── distributions/ # Layer 3: 15 distributions + base
 │   ├── hmm.h          # Core HMM class
 │   ├── calculators/   # Layer 4: ForwardBackward, Viterbi
-│   ├── training/      # Layer 4: BaumWelch, Viterbi, SegmentalKMeans
+│   ├── training/      # Layer 4: BaumWelch, MapBaumWelch, Viterbi, SegmentalKMeans
 │   └── io/            # JSON (hmm_json.h) + legacy XML I/O
 ├── src/               # Implementation (mirrors include/)
-├── tests/             # 37-test GTest suite
-├── examples/          # 12 usage demonstrations
+├── tests/             # 40-test GTest suite
+├── examples/          # 15 usage demonstrations
 ├── tools/             # simd_inspection, batch_performance, hmm_validator (.json/.xml)
 ├── samples/           # Reference HMM files (two_state_gaussian, casino) in JSON and XML
 ├── benchmarks/        # Comparative benchmarks (requires external libraries)
@@ -175,6 +213,8 @@ See [examples/](examples/) for demonstrations:
 | `queuing_theory_hmm_example` | Poisson, Exponential, Gamma | Viterbi |
 | `statistical_process_control_hmm_example` | ChiSquared | Viterbi |
 | `swarm_coordination_example` | Discrete (243 symbols) | — |
+| `posterior_decoding_example` | Discrete | ForwardBackward (`decodePosterior` vs Viterbi) |
+| `map_baum_welch_example` | Discrete | MAP Baum-Welch (c=0 vs c=1, MAP convergence table) |
 
 ## Requirements
 

--- a/WARP.md
+++ b/WARP.md
@@ -6,9 +6,9 @@ This file provides guidance to Warp (warp.dev) when working in this repository.
 
 ## Current Status
 
-**Version**: v3.5.4 — pending merge on `refactor/cpp20-modernisation`; v3.5.3 is the latest published tag on `main`.
-**Tests**: 39/39 passing on all four CI platforms (Linux/GCC, Linux/Clang, macOS/AppleClang, Windows/MSVC).
-**Active phase**: C++20 modernisation patch (string_view, noexcept, STL algorithms, loop preservation comments). Feature branch `feature/v3.6.0-posterior-model-selection` (posterior decoding, AIC/BIC/AICc, `getNumParameters()`) ready for PR after this lands.
+**Version**: v3.6.0 — pending merge on `feature/v3.6.0-posterior-model-selection`; v3.5.4 is the latest published tag on `main`.
+**Tests**: 40/40 passing on all four CI platforms (Linux/GCC, Linux/Clang, macOS/AppleClang, Windows/MSVC).
+**Active phase**: v3.6.0 feature branch complete: `decodePosterior()`, `getNumParameters()` / model selection (AIC/BIC/AICc), `MapBaumWelchTrainer`. Awaiting rebase onto v3.5.4 main and PR.
 
 ---
 
@@ -32,12 +32,13 @@ include/libhmm/
 │   └── viterbi_calculator.h           # Canonical log-space Viterbi
 ├── training/       # Layer 4 — parameter estimation
 │   ├── baum_welch_trainer.h           # Log-space EM; weighted fit()
+│   ├── map_baum_welch_trainer.h       # MAP-EM with Dirichlet priors; computeLogPrior()
 │   ├── viterbi_trainer.h              # Hard-assignment with TrainingConfig presets
 │   └── segmental_kmeans_trainer.h     # Discrete-state initialisation
 └── io/             # XML I/O
 src/                # Implementation (mirrors include/)
 tests/              # GTest suite — semantic groups (see tests/CMakeLists.txt)
-examples/           # 13 usage demonstrations (all canonical API)
+examples/           # 15 usage demonstrations (all canonical API)
 tools/              # Standalone diagnostic/benchmarking executables
 benchmarks/         # Comparative benchmarks
 │   ├── src/        #   libhmm vs HMMLib / LAMP / JAHMM (Windows+Unix)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -80,6 +80,9 @@ add_hmm_example(swarm_coordination_example swarm_coordination_example.cpp)
 # Posterior decoding vs Viterbi (casino HMM)
 add_hmm_example(posterior_decoding_example posterior_decoding_example.cpp)
 
+# MAP-EM Baum-Welch with Dirichlet priors
+add_hmm_example(map_baum_welch_example map_baum_welch_example.cpp)
+
 # Install all examples
 install(TARGETS
     basic_hmm_example
@@ -96,5 +99,6 @@ install(TARGETS
     student_t_hmm_example
     swarm_coordination_example
     posterior_decoding_example
+    map_baum_welch_example
     RUNTIME DESTINATION bin/examples
 )

--- a/examples/map_baum_welch_example.cpp
+++ b/examples/map_baum_welch_example.cpp
@@ -1,0 +1,132 @@
+/**
+ * map_baum_welch_example — MAP-EM Baum-Welch with Dirichlet priors.
+ *
+ * Demonstrates MapBaumWelchTrainer on the dishonest casino HMM:
+ *
+ *   c = 0  → standard MLE (identical to BaumWelchTrainer)
+ *   c = 1  → Laplace smoothing: adds one virtual observation per outcome
+ *
+ * Key points illustrated:
+ *   1. c = 0 and BaumWelchTrainer produce identical updates.
+ *   2. c > 0 keeps all transitions and emission probabilities strictly
+ *      positive, preventing degenerate sparse solutions.
+ *   3. The correct convergence criterion is the full MAP objective
+ *      log P(O|λ) + log P(λ|c), not the likelihood alone.
+ *   4. Discrete emissions are Dirichlet-smoothed; continuous distributions
+ *      are fitted by MLE and unaffected by c.
+ */
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include "libhmm/libhmm.h"
+
+using namespace libhmm;
+
+// Build a 2-state, 6-symbol casino HMM from uniform starting parameters.
+static std::unique_ptr<Hmm> make_casino_hmm() {
+    auto hmm = std::make_unique<Hmm>(2);
+    Matrix trans(2, 2);
+    trans(0, 0) = 0.6;
+    trans(0, 1) = 0.4;
+    trans(1, 0) = 0.4;
+    trans(1, 1) = 0.6;
+    hmm->setTrans(trans);
+    Vector pi(2);
+    pi(0) = 0.5;
+    pi(1) = 0.5;
+    hmm->setPi(pi);
+    for (int s = 0; s < 2; ++s)
+        hmm->setDistribution(s, std::make_unique<DiscreteDistribution>(6));
+    return hmm;
+}
+
+// Total log-likelihood across all sequences.
+static double total_logL(const Hmm &hmm, const ObservationLists &obs) {
+    double ll = 0.0;
+    for (const auto &seq : obs)
+        ll += ForwardBackwardCalculator(hmm, seq).getLogProbability();
+    return ll;
+}
+
+int main() {
+    std::cout << "MAP Baum-Welch Example\n";
+    std::cout << "======================\n\n";
+
+    // -------------------------------------------------------------------------
+    // Training data: structured to produce a clear two-state pattern.
+    // First half of each sequence: symbols 0-3 (fair-looking).
+    // Second half: symbol 5 (six, loaded-looking).
+    // -------------------------------------------------------------------------
+    ObservationLists obs;
+    for (int s = 0; s < 8; ++s) {
+        ObservationSet seq(30);
+        for (int t = 0; t < 15; ++t)
+            seq(t) = static_cast<double>(t % 4);
+        for (int t = 15; t < 30; ++t)
+            seq(t) = 5.0;
+        obs.push_back(seq);
+    }
+
+    // -------------------------------------------------------------------------
+    // Compare: c = 0 (standard MLE) vs c = 1 (Laplace smoothing)
+    // -------------------------------------------------------------------------
+    std::cout << std::fixed << std::setprecision(4);
+
+    for (double c : {0.0, 1.0}) {
+        auto hmm = make_casino_hmm();
+        MapBaumWelchTrainer trainer(*hmm, obs, c);
+
+        std::cout << "--- c = " << c
+                  << (c == 0.0 ? " (standard MLE, identical to BaumWelchTrainer)" : " (Laplace)")
+                  << " ---\n";
+        std::cout << std::setw(6) << "iter" << std::setw(14) << "log P(O|λ)" << std::setw(14)
+                  << "log P(λ|c)" << std::setw(14) << "MAP objective"
+                  << "\n";
+        std::cout << std::string(48, '-') << "\n";
+
+        for (int iter = 1; iter <= 10; ++iter) {
+            trainer.train();
+            const double logL = total_logL(*hmm, obs);
+            const double logPr = trainer.computeLogPrior();
+            const double mapObj = logL + logPr;
+            std::cout << std::setw(6) << iter << std::setw(14) << logL << std::setw(14) << logPr
+                      << std::setw(14) << mapObj << "\n";
+        }
+
+        // Print final transition matrix.
+        std::cout << "\nFinal transition matrix:\n";
+        const Matrix &A = hmm->getTrans();
+        for (int i = 0; i < 2; ++i) {
+            std::cout << "  [";
+            for (int j = 0; j < 2; ++j)
+                std::cout << std::setw(8) << A(i, j);
+            std::cout << "  ]\n";
+        }
+
+        // Print final emission probabilities for each state.
+        std::cout << "Final emission probabilities (symbols 1-6):\n";
+        for (int s = 0; s < 2; ++s) {
+            const auto &dd = static_cast<const DiscreteDistribution &>(hmm->getDistribution(s));
+            std::cout << "  State " << s << ":";
+            for (std::size_t k = 0; k < dd.getNumSymbols(); ++k)
+                std::cout << std::setw(8) << dd.getSymbolProbability(k);
+            std::cout << "\n";
+        }
+        std::cout << "\n";
+    }
+
+    // -------------------------------------------------------------------------
+    // Note on convergence criterion
+    // -------------------------------------------------------------------------
+    std::cout << "Notes on convergence:\n";
+    std::cout << "  With c > 0, log P(O|λ) alone is NOT guaranteed to be monotone.\n";
+    std::cout << "  Use  logL + trainer.computeLogPrior()  as the convergence signal.\n";
+    std::cout << "  With c = 0, log P(λ|c) = 0 and the MAP objective equals logL.\n\n";
+
+    std::cout << "Notes on scope:\n";
+    std::cout << "  Dirichlet priors apply to transitions, π, and DiscreteDistribution\n";
+    std::cout << "  emissions. Continuous distributions (Gaussian, etc.) use MLE\n";
+    std::cout << "  regardless of c — conjugate priors for them are not implemented.\n";
+
+    return 0;
+}

--- a/include/libhmm/training/map_baum_welch_trainer.h
+++ b/include/libhmm/training/map_baum_welch_trainer.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "libhmm/training/trainer.h"
+#include <vector>
+
+namespace libhmm {
+
+/**
+ * @brief MAP-EM Baum-Welch trainer with symmetric Dirichlet priors.
+ *
+ * Extends standard Baum-Welch (see BaumWelchTrainer) by placing symmetric
+ * Dirichlet priors on the transition matrix rows, the initial distribution,
+ * and — for DiscreteDistribution emissions — the per-state emission vectors.
+ * All other emission distributions are fitted by MLE.
+ *
+ * Parameterisation
+ * ----------------
+ * The prior is expressed as a pseudo-count c ≥ 0, related to the Dirichlet
+ * concentration parameter α by c = α − 1.  In the MAP M-step:
+ *
+ *   A(i,j) = (ξ(i,j) + c) / (Σ_k ξ(i,k) + N·c)
+ *   π_i    = (γ₀(i)  + c) / (Σ_k γ₀(k) + N·c)
+ *
+ * For DiscreteDistribution with K symbols per state, the same c is added to
+ * each symbol's expected count before normalising:
+ *
+ *   B(i,k) = (Σ_t γ_t(i)·I[x_t=k] + c) / (Σ_t γ_t(i) + K·c)
+ *
+ * c = 0  → standard MLE, identical to BaumWelchTrainer.
+ * c = 1  → Laplace smoothing (one virtual observation per outcome).
+ *
+ * Sparse-inducing priors (α < 1, i.e. c < 0) are not supported; the MAP
+ * estimate is undefined when adjusted numerators go negative on short
+ * sequences.  Users requiring sparsity should use Variational Bayes.
+ *
+ * Convergence
+ * -----------
+ * MAP-EM guarantees monotonic increase of the full MAP objective:
+ *
+ *   log P(O | λ) + log P(λ | c)
+ *
+ * The likelihood term log P(O | λ) alone is NOT guaranteed to be monotone.
+ * On short sequences with non-zero c the likelihood can decrease while the
+ * MAP objective increases.  Use computeLogPrior() to form the correct
+ * convergence criterion:
+ *
+ *   ForwardBackwardCalculator(hmm, obs).getLogProbability()
+ *     + trainer.computeLogPrior()
+ *
+ * Known limitations
+ * -----------------
+ * - Sparse-inducing priors (c < 0) unsupported; use VB for that regime.
+ * - A single c is applied uniformly; per-row asymmetric priors unsupported.
+ * - No conjugate priors on continuous distributions; they use MLE regardless.
+ * - No state pruning during training.  To identify near-zero-occupancy states
+ *   after training, compute posterior marginals via ForwardBackwardCalculator
+ *   and remove states manually if desired.
+ * - No hyperparameter optimisation; c is fixed at construction time.
+ */
+class MapBaumWelchTrainer : public Trainer {
+public:
+    /**
+     * @brief Construct with an HMM reference, observation sequences, and pseudo-count.
+     * @param hmm          HMM to train in place (non-owning reference).
+     * @param obsLists     One or more observation sequences (must be non-empty).
+     * @param pseudo_count Dirichlet pseudo-count c ≥ 0.  c = 0 → standard MLE.
+     * @throws std::invalid_argument if obsLists is empty or pseudo_count < 0.
+     */
+    MapBaumWelchTrainer(Hmm &hmm, const ObservationLists &obsLists, double pseudo_count = 1.0);
+
+    /** Legacy pointer constructor. @throws std::invalid_argument if hmm is null. */
+    MapBaumWelchTrainer(Hmm *hmm, const ObservationLists &obsLists, double pseudo_count = 1.0);
+
+    ~MapBaumWelchTrainer() override = default;
+
+    MapBaumWelchTrainer(const MapBaumWelchTrainer &) = delete;
+    MapBaumWelchTrainer &operator=(const MapBaumWelchTrainer &) = delete;
+    MapBaumWelchTrainer(MapBaumWelchTrainer &&) = default;
+    MapBaumWelchTrainer &operator=(MapBaumWelchTrainer &&) = default;
+
+    /**
+     * @brief Execute one MAP-EM pass (E-step + MAP M-step).
+     * @throws std::runtime_error if no sequence has finite log-probability
+     *         under the current model.
+     */
+    void train() override;
+
+    /**
+     * @brief Set the pseudo-count c for subsequent train() calls.
+     * @throws std::invalid_argument if c < 0.
+     */
+    void setPseudoCount(double c);
+
+    /** @return Current pseudo-count c. */
+    [[nodiscard]] double getPseudoCount() const noexcept { return pseudo_count_; }
+
+    /**
+     * @brief Unnormalised log-prior of the current HMM parameters.
+     *
+     * Returns the parameter-dependent part of log P(λ | c):
+     *
+     *   c · (Σ_i Σ_j log A(i,j) + Σ_i log π_i)
+     *     + c · Σ_{discrete states i} Σ_k log B(i,k)
+     *
+     * The Dirichlet normalising constants are omitted; they are invariant to
+     * the HMM parameters and cancel when checking convergence.
+     *
+     * For the correct MAP convergence criterion combine this with
+     * ForwardBackwardCalculator::getLogProbability():
+     *
+     *   mapObjective = logLikelihood + trainer.computeLogPrior()
+     *
+     * If c = 0 this returns 0.0.
+     * Transitions or π entries equal to 0 contribute −∞ to the sum.
+     */
+    [[nodiscard]] double computeLogPrior() const;
+
+private:
+    double pseudo_count_;
+
+    /// MAP M-step for π: add c to each numerator; normalise by piSum + N·c.
+    static void m_step_pi_map(Hmm &hmm, std::size_t N, const std::vector<double> &piNum, double c);
+
+    /// MAP M-step for A: add c to each xi count; normalise by transDen[i] + N·c.
+    static void m_step_transitions_map(Hmm &hmm, std::size_t N,
+                                       const std::vector<double> &transNumT,
+                                       const std::vector<double> &transDen, double c);
+
+    /// MAP M-step for emissions: MLE for continuous; Dirichlet-smoothed for discrete.
+    static void apply_emission_fits_map(Hmm &hmm, std::size_t N,
+                                        const std::vector<std::vector<double>> &emisData,
+                                        const std::vector<std::vector<double>> &emisWts, double c);
+};
+
+} // namespace libhmm

--- a/include/libhmm/training/trainers.h
+++ b/include/libhmm/training/trainers.h
@@ -2,5 +2,6 @@
 
 #include "libhmm/training/trainer.h"
 #include "libhmm/training/baum_welch_trainer.h"
+#include "libhmm/training/map_baum_welch_trainer.h"
 #include "libhmm/training/viterbi_trainer.h"
 #include "libhmm/training/segmental_kmeans_trainer.h"

--- a/src/training/map_baum_welch_trainer.cpp
+++ b/src/training/map_baum_welch_trainer.cpp
@@ -1,0 +1,307 @@
+#include "libhmm/training/map_baum_welch_trainer.h"
+#include "libhmm/calculators/forward_backward_calculator.h"
+#include "libhmm/distributions/discrete_distribution.h"
+#include "libhmm/hmm.h"
+#include "libhmm/performance/transcendental_kernels.h"
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace libhmm {
+
+namespace {
+// Per-TU sentinel — same convention as baum_welch_trainer.cpp,
+// forward_backward_calculator.cpp, and viterbi_calculator.cpp.
+constexpr double LOG_ZERO = -std::numeric_limits<double>::infinity();
+
+// ---------------------------------------------------------------------------
+// E-step helpers
+//
+// Identical in structure to the private statics in BaumWelchTrainer.
+// Duplicated here to avoid coupling to BaumWelchTrainer's private interface;
+// a future refactor could promote them to Trainer as protected statics.
+// ---------------------------------------------------------------------------
+
+/// Accumulates γ statistics for one observation sequence.
+void accumulate_gamma(const Matrix &logAlpha, const Matrix &logBeta, const ObservationSet &obs,
+                      double logP, std::size_t N, std::vector<std::vector<double>> &emisData,
+                      std::vector<std::vector<double>> &emisWts, std::vector<double> &piNum,
+                      std::vector<double> &transDen) noexcept {
+    const std::size_t T = obs.size();
+    const double *logAlphaData = logAlpha.data();
+    const double *logBetaData = logBeta.data();
+    for (std::size_t t = 0; t < T; ++t) {
+        const double *alphaRow = logAlphaData + t * N;
+        const double *betaRow = logBetaData + t * N;
+        const double obsVal = obs(t);
+        for (std::size_t i = 0; i < N; ++i) {
+            const double g = std::exp(alphaRow[i] + betaRow[i] - logP);
+            emisData[i].push_back(obsVal);
+            emisWts[i].push_back(g);
+            if (t == 0)
+                piNum[i] += g;
+            if (t < T - 1)
+                transDen[i] += g;
+        }
+    }
+}
+
+/// Accumulates ξ statistics (expected transition counts) for one sequence.
+void accumulate_xi(const double *logAlphaData, const double *logBetaData,
+                   const std::vector<double> &logEmitByTime, const std::vector<double> &logTransT,
+                   double logP, std::size_t T, std::size_t N, bool hasZeroTransitions,
+                   std::vector<double> &transNumT) noexcept {
+    if (hasZeroTransitions) {
+        for (std::size_t t = 0; t + 1 < T; ++t) {
+            const double *alphaRow = logAlphaData + t * N;
+            const double *betaNextRow = logBetaData + (t + 1) * N;
+            const double *emitNextRow = logEmitByTime.data() + (t + 1) * N;
+            for (std::size_t j = 0; j < N; ++j) {
+                const double emitBetaNext = emitNextRow[j] + betaNextRow[j] - logP;
+                const double *transCol = logTransT.data() + j * N;
+                double *transNumCol = transNumT.data() + j * N;
+                for (std::size_t i = 0; i < N; ++i) {
+                    if (transCol[i] == LOG_ZERO)
+                        continue;
+                    transNumCol[i] += std::exp(alphaRow[i] + transCol[i] + emitBetaNext);
+                }
+            }
+        }
+    } else {
+        for (std::size_t t = 0; t + 1 < T; ++t) {
+            const double *alphaRow = logAlphaData + t * N;
+            const double *betaNextRow = logBetaData + (t + 1) * N;
+            const double *emitNextRow = logEmitByTime.data() + (t + 1) * N;
+            for (std::size_t j = 0; j < N; ++j) {
+                const double emitBetaNext = emitNextRow[j] + betaNextRow[j] - logP;
+                const double *transCol = logTransT.data() + j * N;
+                double *transNumCol = transNumT.data() + j * N;
+                performance::detail::TranscendentalKernels::accumulate_exp_sum2_bias(
+                    transNumCol, alphaRow, transCol, N, emitBetaNext);
+            }
+        }
+    }
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+MapBaumWelchTrainer::MapBaumWelchTrainer(Hmm &hmm, const ObservationLists &obsLists,
+                                         double pseudo_count)
+    : Trainer(hmm, obsLists), pseudo_count_(pseudo_count) {
+    if (pseudo_count < 0.0) {
+        throw std::invalid_argument("MapBaumWelchTrainer: pseudo_count must be >= 0 "
+                                    "(sparse-inducing priors require Variational Bayes)");
+    }
+}
+
+MapBaumWelchTrainer::MapBaumWelchTrainer(Hmm *hmm, const ObservationLists &obsLists,
+                                         double pseudo_count)
+    : MapBaumWelchTrainer(hmm ? *hmm : throw std::invalid_argument("HMM pointer cannot be null"),
+                          obsLists, pseudo_count) {}
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+void MapBaumWelchTrainer::setPseudoCount(double c) {
+    if (c < 0.0)
+        throw std::invalid_argument("MapBaumWelchTrainer: pseudo_count must be >= 0");
+    pseudo_count_ = c;
+}
+
+double MapBaumWelchTrainer::computeLogPrior() const {
+    if (pseudo_count_ == 0.0)
+        return 0.0;
+
+    const Hmm &hmm = hmm_ref_.get();
+    const std::size_t N = static_cast<std::size_t>(hmm.getNumStates());
+    const double c = pseudo_count_;
+    double lp = 0.0;
+
+    // c · Σ_i Σ_j log A(i,j)
+    const Matrix &A = hmm.getTrans();
+    for (std::size_t i = 0; i < N; ++i)
+        for (std::size_t j = 0; j < N; ++j)
+            lp += c * (A(i, j) > 0.0 ? std::log(A(i, j)) : LOG_ZERO);
+
+    // c · Σ_i log π_i
+    const Vector &pi = hmm.getPi();
+    for (std::size_t i = 0; i < N; ++i)
+        lp += c * (pi(i) > 0.0 ? std::log(pi(i)) : LOG_ZERO);
+
+    // c · Σ_{discrete i} Σ_k log B(i,k)
+    for (std::size_t i = 0; i < N; ++i) {
+        const EmissionDistribution &dist = hmm.getDistribution(i);
+        if (!dist.isDiscrete())
+            continue;
+        const auto &dd = static_cast<const DiscreteDistribution &>(dist);
+        const std::size_t K = dd.getNumSymbols();
+        for (std::size_t k = 0; k < K; ++k) {
+            const double bk = dd.getSymbolProbability(k);
+            lp += c * (bk > 0.0 ? std::log(bk) : LOG_ZERO);
+        }
+    }
+
+    return lp;
+}
+
+// ---------------------------------------------------------------------------
+// train() — one full MAP-EM pass
+// ---------------------------------------------------------------------------
+
+void MapBaumWelchTrainer::train() {
+    Hmm &hmm = hmm_ref_.get();
+    const std::size_t N = static_cast<std::size_t>(hmm.getNumStates());
+    const double c = pseudo_count_;
+
+    std::size_t totalExpectedLength = 0;
+    for (const auto &obs : obsLists_)
+        totalExpectedLength += obs.size();
+
+    // Accumulators (linear space, summed across all sequences)
+    std::vector<double> piNum(N, 0.0);
+    std::vector<double> transDen(N, 0.0);
+    // Column-major: transNumT[j*N+i] = ξ(i→j)
+    std::vector<double> transNumT(N * N, 0.0);
+
+    std::vector<std::vector<double>> emisData(N);
+    std::vector<std::vector<double>> emisWts(N);
+    for (std::size_t i = 0; i < N; ++i) {
+        emisData[i].reserve(totalExpectedLength);
+        emisWts[i].reserve(totalExpectedLength);
+    }
+
+    // Precompute transposed log-transition matrix
+    const Matrix &curTrans = hmm.getTrans();
+    std::vector<double> logTransT(N * N);
+    bool hasZeroTransitions = false;
+    for (std::size_t i = 0; i < N; ++i) {
+        for (std::size_t j = 0; j < N; ++j) {
+            const double a = curTrans(i, j);
+            if (a > 0.0) {
+                logTransT[j * N + i] = std::log(a);
+            } else {
+                logTransT[j * N + i] = LOG_ZERO;
+                hasZeroTransitions = true;
+            }
+        }
+    }
+
+    std::size_t validSeqs = 0;
+
+    for (const auto &obs : obsLists_) {
+        const std::size_t T = obs.size();
+        if (T == 0)
+            continue;
+
+        ForwardBackwardCalculator fbc(hmm, obs);
+        const double logP = fbc.getLogProbability();
+        if (!std::isfinite(logP))
+            continue;
+
+        const Matrix &logAlpha = fbc.getLogForwardVariables();
+        const Matrix &logBeta = fbc.getLogBackwardVariables();
+        const double *logAlphaData = logAlpha.data();
+        const double *logBetaData = logBeta.data();
+
+        // Time-major log-emission buffer
+        std::vector<double> logEmitStateMajor(N * T);
+        std::vector<double> logEmitByTime(N * T);
+        const std::span<const double> obsSpan(obs.data(), T);
+        for (std::size_t i = 0; i < N; ++i) {
+            hmm.getDistribution(i).getBatchLogProbabilities(
+                obsSpan, std::span<double>(logEmitStateMajor.data() + i * T, T));
+        }
+        for (std::size_t i = 0; i < N; ++i) {
+            const double *stateRow = logEmitStateMajor.data() + i * T;
+            for (std::size_t t = 0; t < T; ++t)
+                logEmitByTime[t * N + i] = stateRow[t];
+        }
+
+        accumulate_gamma(logAlpha, logBeta, obs, logP, N, emisData, emisWts, piNum, transDen);
+        accumulate_xi(logAlphaData, logBetaData, logEmitByTime, logTransT, logP, T, N,
+                      hasZeroTransitions, transNumT);
+        ++validSeqs;
+    }
+
+    if (validSeqs == 0) {
+        throw std::runtime_error("MapBaumWelchTrainer: no valid observation sequences "
+                                 "(all had zero probability under the current model)");
+    }
+
+    m_step_pi_map(hmm, N, piNum, c);
+    m_step_transitions_map(hmm, N, transNumT, transDen, c);
+    apply_emission_fits_map(hmm, N, emisData, emisWts, c);
+}
+
+// ---------------------------------------------------------------------------
+// MAP M-step helpers
+// ---------------------------------------------------------------------------
+
+void MapBaumWelchTrainer::m_step_pi_map(Hmm &hmm, std::size_t N, const std::vector<double> &piNum,
+                                        double c) {
+    const double piSum = std::accumulate(piNum.begin(), piNum.end(), 0.0);
+    const double denom = piSum + static_cast<double>(N) * c;
+    Vector pi(N);
+    for (std::size_t i = 0; i < N; ++i)
+        pi(i) = (denom > 0.0) ? (piNum[i] + c) / denom : 1.0 / static_cast<double>(N);
+    hmm.setPi(pi);
+}
+
+void MapBaumWelchTrainer::m_step_transitions_map(Hmm &hmm, std::size_t N,
+                                                 const std::vector<double> &transNumT,
+                                                 const std::vector<double> &transDen, double c) {
+    const double Nc = static_cast<double>(N) * c;
+    Matrix newTrans(N, N);
+    for (std::size_t i = 0; i < N; ++i) {
+        const double denom = transDen[i] + Nc;
+        for (std::size_t j = 0; j < N; ++j) {
+            newTrans(i, j) =
+                (denom > 0.0) ? (transNumT[j * N + i] + c) / denom : 1.0 / static_cast<double>(N);
+        }
+    }
+    hmm.setTrans(newTrans);
+}
+
+void MapBaumWelchTrainer::apply_emission_fits_map(Hmm &hmm, std::size_t N,
+                                                  const std::vector<std::vector<double>> &emisData,
+                                                  const std::vector<std::vector<double>> &emisWts,
+                                                  double c) {
+    for (std::size_t i = 0; i < N; ++i) {
+        const std::size_t M = emisData[i].size();
+        EmissionDistribution &dist = hmm.getDistribution(i);
+
+        if (M == 0) {
+            dist.reset();
+            continue;
+        }
+
+        // Weighted MLE fit for all distribution types.
+        dist.fit(std::span<const double>(emisData[i].data(), M),
+                 std::span<const double>(emisWts[i].data(), M));
+
+        // For discrete distributions, apply Dirichlet smoothing on top of MLE.
+        // B_map(i,k) = (B_mle(i,k)·sumW + c) / (sumW + K·c)
+        if (c > 0.0 && dist.isDiscrete()) {
+            auto &dd = static_cast<DiscreteDistribution &>(dist);
+            const std::size_t K = dd.getNumSymbols();
+            const double sumW = std::accumulate(emisWts[i].begin(), emisWts[i].end(), 0.0);
+            if (sumW > 0.0) {
+                const double denom = sumW + static_cast<double>(K) * c;
+                for (std::size_t k = 0; k < K; ++k) {
+                    dd.setProbability(static_cast<double>(k),
+                                      (dd.getSymbolProbability(k) * sumW + c) / denom);
+                }
+            }
+        }
+    }
+}
+
+} // namespace libhmm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -210,6 +210,7 @@ if(GTest_FOUND OR TARGET gtest)
     add_hmm_test(test_training_edge_cases    training/test_training_edge_cases.cpp)
     add_hmm_test(test_baum_welch_convergence training/test_baum_welch_convergence.cpp)
     add_hmm_test(test_bw_parity              training/test_bw_parity.cpp)
+    add_hmm_test(test_map_baum_welch         training/test_map_baum_welch.cpp)
 
     # =========================================================================
     # IO & Integration

--- a/tests/training/test_map_baum_welch.cpp
+++ b/tests/training/test_map_baum_welch.cpp
@@ -1,0 +1,242 @@
+#include <gtest/gtest.h>
+#include "libhmm/training/map_baum_welch_trainer.h"
+#include "libhmm/training/baum_welch_trainer.h"
+#include "libhmm/calculators/forward_backward_calculator.h"
+#include "libhmm/distributions/discrete_distribution.h"
+#include "libhmm/distributions/gaussian_distribution.h"
+#include <cmath>
+#include <memory>
+
+using namespace libhmm;
+
+namespace {
+
+/// 2-state, 6-symbol casino HMM with uniform initial parameters.
+std::unique_ptr<Hmm> make_uniform_hmm() {
+    auto hmm = std::make_unique<Hmm>(2);
+    Matrix trans(2, 2);
+    trans(0, 0) = 0.5;
+    trans(0, 1) = 0.5;
+    trans(1, 0) = 0.5;
+    trans(1, 1) = 0.5;
+    hmm->setTrans(trans);
+    Vector pi(2);
+    pi(0) = 0.5;
+    pi(1) = 0.5;
+    hmm->setPi(pi);
+    for (int s = 0; s < 2; ++s)
+        hmm->setDistribution(s, std::make_unique<DiscreteDistribution>(6));
+    return hmm;
+}
+
+/// Observation sequences: first half low symbols (fair), second half sixes (loaded).
+ObservationLists make_casino_obs() {
+    ObservationLists obs;
+    for (int s = 0; s < 5; ++s) {
+        ObservationSet seq(20);
+        for (int t = 0; t < 10; ++t)
+            seq(t) = static_cast<double>(t % 4); // 0-3, fair-like
+        for (int t = 10; t < 20; ++t)
+            seq(t) = 5.0; // all sixes, loaded-like
+        obs.push_back(seq);
+    }
+    return obs;
+}
+
+/// Total log-likelihood across all sequences.
+double total_logL(const Hmm &hmm, const ObservationLists &seqs) {
+    double ll = 0.0;
+    for (const auto &seq : seqs)
+        ll += ForwardBackwardCalculator(hmm, seq).getLogProbability();
+    return ll;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Construction and validation
+// ---------------------------------------------------------------------------
+
+TEST(MapBaumWelchTest, NegativePseudoCountThrows) {
+    auto hmm = make_uniform_hmm();
+    auto obs = make_casino_obs();
+    EXPECT_THROW(MapBaumWelchTrainer(*hmm, obs, -0.1), std::invalid_argument);
+}
+
+TEST(MapBaumWelchTest, NullHmmThrows) {
+    auto obs = make_casino_obs();
+    EXPECT_THROW(MapBaumWelchTrainer(nullptr, obs, 1.0), std::invalid_argument);
+}
+
+TEST(MapBaumWelchTest, EmptyObsThrows) {
+    auto hmm = make_uniform_hmm();
+    EXPECT_THROW(MapBaumWelchTrainer(*hmm, {}, 1.0), std::invalid_argument);
+}
+
+TEST(MapBaumWelchTest, SetPseudoCountNegativeThrows) {
+    auto hmm = make_uniform_hmm();
+    MapBaumWelchTrainer trainer(*hmm, make_casino_obs(), 1.0);
+    EXPECT_THROW(trainer.setPseudoCount(-0.5), std::invalid_argument);
+}
+
+TEST(MapBaumWelchTest, GetPseudoCount) {
+    auto hmm = make_uniform_hmm();
+    MapBaumWelchTrainer trainer(*hmm, make_casino_obs(), 2.5);
+    EXPECT_DOUBLE_EQ(trainer.getPseudoCount(), 2.5);
+    trainer.setPseudoCount(0.0);
+    EXPECT_DOUBLE_EQ(trainer.getPseudoCount(), 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// c = 0 recovers standard Baum-Welch exactly
+// ---------------------------------------------------------------------------
+
+TEST(MapBaumWelchTest, ZeroPseudoCountMatchesBaumWelch) {
+    auto obs = make_casino_obs();
+
+    auto hmmBW = make_uniform_hmm();
+    auto hmmMAP = make_uniform_hmm();
+
+    BaumWelchTrainer bw(*hmmBW, obs);
+    MapBaumWelchTrainer map(*hmmMAP, obs, 0.0);
+
+    bw.train();
+    map.train();
+
+    // Transitions must match to floating-point precision.
+    const Matrix &tbw = hmmBW->getTrans();
+    const Matrix &tmap = hmmMAP->getTrans();
+    for (int i = 0; i < 2; ++i)
+        for (int j = 0; j < 2; ++j)
+            EXPECT_NEAR(tbw(i, j), tmap(i, j), 1e-12)
+                << "A(" << i << "," << j << ") mismatch at c=0";
+
+    // Pi must match.
+    const Vector &pbw = hmmBW->getPi();
+    const Vector &pmap = hmmMAP->getPi();
+    for (int i = 0; i < 2; ++i)
+        EXPECT_NEAR(pbw(i), pmap(i), 1e-12) << "pi(" << i << ") mismatch at c=0";
+}
+
+// ---------------------------------------------------------------------------
+// c > 0 produces strictly positive transitions and smoothed emissions
+// ---------------------------------------------------------------------------
+
+TEST(MapBaumWelchTest, PositivePseudoCountSmooths) {
+    auto hmm = make_uniform_hmm();
+    auto obs = make_casino_obs();
+    MapBaumWelchTrainer trainer(*hmm, obs, 1.0);
+    trainer.train();
+
+    const Matrix &A = hmm->getTrans();
+    for (int i = 0; i < 2; ++i)
+        for (int j = 0; j < 2; ++j)
+            EXPECT_GT(A(i, j), 0.0) << "A(" << i << "," << j << ") should be > 0 with c=1";
+
+    const Vector &pi = hmm->getPi();
+    for (int i = 0; i < 2; ++i)
+        EXPECT_GT(pi(i), 0.0) << "pi(" << i << ") should be > 0 with c=1";
+}
+
+TEST(MapBaumWelchTest, DiscreteEmissionsSmoothed) {
+    auto hmm = make_uniform_hmm();
+    auto obs = make_casino_obs();
+    MapBaumWelchTrainer trainer(*hmm, obs, 1.0);
+    trainer.train();
+
+    // After smoothing with c=1 and K=6, every symbol should have positive probability.
+    for (int s = 0; s < 2; ++s) {
+        const auto &dd = static_cast<const DiscreteDistribution &>(hmm->getDistribution(s));
+        for (std::size_t k = 0; k < dd.getNumSymbols(); ++k)
+            EXPECT_GT(dd.getSymbolProbability(k), 0.0)
+                << "B(" << s << "," << k << ") should be > 0 with c=1";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// computeLogPrior
+// ---------------------------------------------------------------------------
+
+TEST(MapBaumWelchTest, LogPriorZeroWhenCIsZero) {
+    auto hmm = make_uniform_hmm();
+    MapBaumWelchTrainer trainer(*hmm, make_casino_obs(), 0.0);
+    EXPECT_DOUBLE_EQ(trainer.computeLogPrior(), 0.0);
+}
+
+TEST(MapBaumWelchTest, LogPriorFiniteAndNonPositive) {
+    auto hmm = make_uniform_hmm();
+    MapBaumWelchTrainer trainer(*hmm, make_casino_obs(), 1.0);
+    trainer.train();
+    const double lp = trainer.computeLogPrior();
+    EXPECT_TRUE(std::isfinite(lp));
+    EXPECT_LE(lp, 0.0); // log of probabilities ≤ 1, scaled by c > 0
+}
+
+// ---------------------------------------------------------------------------
+// MAP objective is monotone over multiple iterations
+// ---------------------------------------------------------------------------
+
+TEST(MapBaumWelchTest, MapObjectiveMonotone) {
+    auto hmm = make_uniform_hmm();
+    auto obs = make_casino_obs();
+    MapBaumWelchTrainer trainer(*hmm, obs, 1.0);
+
+    double prevObjective = -std::numeric_limits<double>::infinity();
+    for (int iter = 0; iter < 8; ++iter) {
+        trainer.train();
+        const double logL = total_logL(*hmm, obs);
+        const double logPr = trainer.computeLogPrior();
+        const double mapObj = logL + logPr;
+        EXPECT_GE(mapObj, prevObjective - 1e-6) // allow tiny floating-point slack
+            << "MAP objective decreased at iteration " << iter;
+        prevObjective = mapObj;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Continuous emissions use MLE (unaffected by pseudo-count)
+// ---------------------------------------------------------------------------
+
+TEST(MapBaumWelchTest, ContinuousEmissionsUnchangedByPseudoCount) {
+    // Build a 2-state Gaussian HMM.
+    auto hmmMLE = std::make_unique<Hmm>(2);
+    auto hmmMAP = std::make_unique<Hmm>(2);
+    for (auto *h : {hmmMLE.get(), hmmMAP.get()}) {
+        Matrix trans(2, 2);
+        trans(0, 0) = 0.8;
+        trans(0, 1) = 0.2;
+        trans(1, 0) = 0.3;
+        trans(1, 1) = 0.7;
+        h->setTrans(trans);
+        Vector pi(2);
+        pi(0) = 0.5;
+        pi(1) = 0.5;
+        h->setPi(pi);
+        h->setDistribution(0, std::make_unique<GaussianDistribution>(-2.0, 1.0));
+        h->setDistribution(1, std::make_unique<GaussianDistribution>(2.0, 1.0));
+    }
+
+    ObservationLists obs;
+    ObservationSet seq(20);
+    for (int t = 0; t < 10; ++t)
+        seq(t) = -2.0 + 0.1 * (t % 3);
+    for (int t = 10; t < 20; ++t)
+        seq(t) = 2.0 + 0.1 * (t % 3);
+    obs.push_back(seq);
+
+    BaumWelchTrainer bw(*hmmMLE, obs);
+    MapBaumWelchTrainer map(*hmmMAP, obs, 2.0);
+    bw.train();
+    map.train();
+
+    // Gaussian means should be equal — c only affects transitions and π.
+    const auto &g0mle = static_cast<const GaussianDistribution &>(hmmMLE->getDistribution(0));
+    const auto &g0map = static_cast<const GaussianDistribution &>(hmmMAP->getDistribution(0));
+    EXPECT_NEAR(g0mle.getMean(), g0map.getMean(), 1e-10);
+    EXPECT_NEAR(g0mle.getStandardDeviation(), g0map.getStandardDeviation(), 1e-10);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Three new features for v3.6.0. No breaking API changes; pure additive release. 40/40 tests pass.

---

## Feature 1 — Posterior (marginal) decoding

`ForwardBackwardCalculator::decodePosterior()` returns the per-step argmax-γ state sequence. Minimises per-step state error rate; differs from Viterbi (joint path). Reuses existing logAlpha/logBeta — no extra FB pass.

Use posterior decoding when per-step annotation accuracy matters (gene prediction, sequence labelling). Use Viterbi when whole-sequence structural coherence is required (speech alignment).

---

## Feature 2 — Parameter count API and model selection

`EmissionDistribution::getNumParameters()` — new pure virtual, implemented on all 15 distributions.

`include/libhmm/model_selection.h`:
- `count_free_parameters(hmm)` — N*(N-1) + (N-1) + Σ emission params
- `compute_aic / compute_bic / compute_aicc`
- `evaluate_model(hmm, logL, n)` — returns `HmmModelCriteria{aic, bic, aicc}`

---

## Feature 3 — MAP Baum-Welch trainer

`MapBaumWelchTrainer` with symmetric Dirichlet priors on A, π, and discrete emissions.

Design decisions (recorded in [v3.6.0 plan](https://app.warp.dev/drive/notebook/YSCndY9XUTbjDqO4BNjT97)):
- Pseudo-count `c ≥ 0`; `c = 0` recovers standard BW exactly
- MAP M-step: `A(i,j) = (ξ(i,j)+c)/(Σ_k ξ(i,k)+N·c)`; same for π
- `DiscreteDistribution` emissions smoothed: `B_map(i,k) = (B_mle·sumW+c)/(sumW+K·c)`
- Continuous distributions fitted by MLE
- `computeLogPrior()` — combine with `getLogProbability()` for correct MAP convergence criterion (likelihood alone is not monotone under MAP-EM when `c > 0`)
- Sparse-inducing priors (`c < 0`) unsupported; constructor throws

---

## Tests
- `test_posterior_decoding` — 6 cases
- `test_model_selection` — 18 cases
- `test_map_baum_welch` — 11 cases (c=0 matches BaumWelchTrainer exactly; MAP objective monotone)

## Examples
- `posterior_decoding_example` — casino HMM, posterior vs Viterbi, model criteria
- `map_baum_welch_example` — c=0 vs c=1, MAP convergence table

---

_Generated with [Warp](https://app.warp.dev/conversation/f6feafc0-6026-4e5a-a973-7b0f175cc9a1)_

Co-Authored-By: Oz <oz-agent@warp.dev>