### PR TITLE
refactor: arch-review cleanup (v4.0.2 target)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,7 @@ benchmarks/CMakeFiles/
 # Apache Ant (build tool for JAHMM)
 benchmarks/apache-ant-*
 apache-ant-*/
+
+# IDE caches and generated index files
+.cache/
+*.synctex.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,7 +271,7 @@ set(LIBHMM_SIMD_SOURCES
     src/distributions/von_mises_distribution.cpp
 )
 
-# Additional TUs that include simd_kernels_internal.h or transcendental_kernels.h
+# Additional TUs that include detail/simd_kernels_internal.h or transcendental_kernels.h
 # and therefore need LIBHMM_BEST_SIMD_FLAGS to activate the #if LIBHMM_HAS_* cascade.
 # (log_normal and pareto are already in LIBHMM_SIMD_SOURCES above.)
 # Both scalar and MV explicit-instantiation TUs are compiled with SIMD flags so the
@@ -484,7 +484,8 @@ install(TARGETS hmm hmm_static
     PUBLIC_HEADER DESTINATION include/libhmm
 )
 
-install(DIRECTORY include/libhmm DESTINATION include)
+install(DIRECTORY include/libhmm DESTINATION include
+    PATTERN "detail" EXCLUDE)
 
 # Examples
 if(BUILD_EXAMPLES)

--- a/examples/mv_gaussian_example.cpp
+++ b/examples/mv_gaussian_example.cpp
@@ -70,7 +70,7 @@ HmmMV make_true_hmm() {
 
 /// Sample one observation sequence of length T from @p true_hmm.
 ObservationMatrix sample_sequence(const HmmMV &true_hmm, std::size_t T, std::mt19937_64 &rng) {
-    const std::size_t N = static_cast<std::size_t>(true_hmm.getNumStates());
+    const std::size_t N = true_hmm.getNumStatesModern();
     const auto &pi = true_hmm.getPi();
     const auto &trans = true_hmm.getTrans();
 
@@ -109,7 +109,7 @@ double total_log_prob(HmmMV &hmm, const MultiObservationLists &lists) {
 
 /// Print the mean and variance for each state.
 void print_emissions(const HmmMV &hmm) {
-    const std::size_t N = static_cast<std::size_t>(hmm.getNumStates());
+    const std::size_t N = hmm.getNumStatesModern();
     for (std::size_t i = 0; i < N; ++i) {
         const auto &d = static_cast<const DiagonalGaussianDistribution &>(hmm.getDistribution(i));
         std::cout << "  State " << i << ": μ=[" << std::fixed << std::setprecision(3)

--- a/examples/segmental_kmeans_example.cpp
+++ b/examples/segmental_kmeans_example.cpp
@@ -66,7 +66,7 @@ static std::unique_ptr<Hmm> make_die_hmm() {
 
 static void print_emissions(const Hmm &hmm, const char *label) {
     std::cout << "  " << label << "\n";
-    for (int s = 0; s < hmm.getNumStates(); ++s) {
+    for (std::size_t s = 0; s < hmm.getNumStatesModern(); ++s) {
         const auto &d = static_cast<const DiscreteDistribution &>(hmm.getDistribution(s));
         std::cout << "    State " << s << ": ";
         for (std::size_t sym = 0; sym < d.getNumSymbols(); ++sym) {

--- a/examples/support/two_state_hmm.h
+++ b/examples/support/two_state_hmm.h
@@ -24,7 +24,7 @@ inline constexpr double loaded_biased_prob = 0.375;
 } // namespace dishonest_casino
 
 inline void prepare_two_state_hmm(Hmm &hmm) {
-    if (static_cast<std::size_t>(hmm.getNumStates()) != dishonest_casino::num_states) {
+    if (hmm.getNumStatesModern() != dishonest_casino::num_states) {
         throw std::invalid_argument("Dishonest casino helper expects a 2-state HMM");
     }
 

--- a/examples/swarm_coordination_example.cpp
+++ b/examples/swarm_coordination_example.cpp
@@ -552,7 +552,7 @@ public:
     void printSystemDiagnostics() {
         std::cout << "\n🔧 System Diagnostics\n";
         std::cout << "=" << std::string(30, '=') << "\n";
-        std::cout << "HMM States: " << formationHMM_->getNumStates() << "\n";
+        std::cout << "HMM States: " << formationHMM_->getNumStatesModern() << "\n";
         std::cout << "Observation Space: " << SwarmObservation::getMaxValue() << " combinations\n";
         std::cout << "State History: " << stateHistory_.size() << " entries\n";
         std::cout << "Observation History: " << observationHistory_.size() << " entries\n";

--- a/include/libhmm/basic_hmm.h
+++ b/include/libhmm/basic_hmm.h
@@ -190,7 +190,9 @@ public:
     [[nodiscard]] const Vector &getPi() const noexcept { return pi_; }
 
     /// Gets the number of states (legacy int interface for backward compatibility).
-    [[nodiscard]] int getNumStates() const noexcept { return static_cast<int>(states_); }
+    /// @deprecated Use getNumStatesModern() which returns std::size_t.
+    [[nodiscard, deprecated("Use getNumStatesModern() which returns std::size_t")]]
+    int getNumStates() const noexcept { return static_cast<int>(states_); }
 
     /// Gets the number of states.
     [[nodiscard]] std::size_t getNumStatesModern() const noexcept { return states_; }

--- a/include/libhmm/basic_hmm.h
+++ b/include/libhmm/basic_hmm.h
@@ -192,7 +192,9 @@ public:
     /// Gets the number of states (legacy int interface for backward compatibility).
     /// @deprecated Use getNumStatesModern() which returns std::size_t.
     [[nodiscard, deprecated("Use getNumStatesModern() which returns std::size_t")]]
-    int getNumStates() const noexcept { return static_cast<int>(states_); }
+    int getNumStates() const noexcept {
+        return static_cast<int>(states_);
+    }
 
     /// Gets the number of states.
     [[nodiscard]] std::size_t getNumStatesModern() const noexcept { return states_; }

--- a/include/libhmm/calculators/basic_forward_backward_calculator.h
+++ b/include/libhmm/calculators/basic_forward_backward_calculator.h
@@ -9,9 +9,10 @@
 #include <vector>
 
 #include "libhmm/calculators/basic_calculator.h"
+#include "libhmm/detail/log_utils.h"
 #include "libhmm/linalg/linalg_types.h"
-#include "libhmm/performance/fb_recurrence_policy.h"
 #include "libhmm/performance/transcendental_kernels.h"
+#include "libhmm/performance/fb_recurrence_policy.h"
 
 namespace libhmm {
 
@@ -129,7 +130,7 @@ public:
     [[nodiscard]] FbRecurrenceMode getRecurrenceMode() const noexcept { return currentMode_; }
 
 private:
-    static constexpr double LOG_ZERO = -std::numeric_limits<double>::infinity();
+    static constexpr double LOG_ZERO = detail::LOG_ZERO;
 
     std::size_t numStates_{0};
 
@@ -210,7 +211,7 @@ private:
 template <typename Obs>
 BasicForwardBackwardCalculator<Obs>::BasicForwardBackwardCalculator(const HmmType &hmm,
                                                                     const SeqType &observations)
-    : Base(hmm, observations), numStates_(static_cast<std::size_t>(hmm.getNumStates())) {
+    : Base(hmm, observations), numStates_(hmm.getNumStatesModern()) {
     if (ObsSeqTraits<Obs>::sequence_length(observations) == 0) {
         throw std::invalid_argument("Observation sequence cannot be empty");
     }
@@ -460,13 +461,7 @@ StateSequence BasicForwardBackwardCalculator<Obs>::decodePosterior() const {
 
 template <typename Obs>
 double BasicForwardBackwardCalculator<Obs>::logSumExp(double a, double b) noexcept {
-    if (a == LOG_ZERO)
-        return b;
-    if (b == LOG_ZERO)
-        return a;
-    if (a > b)
-        return a + std::log1p(std::exp(b - a));
-    return b + std::log1p(std::exp(a - b));
+    return detail::logSumExp(a, b);
 }
 
 // =============================================================================

--- a/include/libhmm/calculators/basic_viterbi_calculator.h
+++ b/include/libhmm/calculators/basic_viterbi_calculator.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "libhmm/calculators/basic_calculator.h"
+#include "libhmm/detail/log_utils.h"
 #include "libhmm/linalg/linalg_types.h"
 
 namespace libhmm {
@@ -68,7 +69,7 @@ public:
     [[nodiscard]] std::size_t getNumStates() const noexcept { return numStates_; }
 
 private:
-    static constexpr double LOG_ZERO = -std::numeric_limits<double>::infinity();
+    static constexpr double LOG_ZERO = detail::LOG_ZERO;
 
     std::size_t numStates_{0};
 
@@ -113,7 +114,7 @@ private:
 
 template <typename Obs>
 BasicViterbiCalculator<Obs>::BasicViterbiCalculator(const HmmType &hmm, const SeqType &observations)
-    : Base(hmm, observations), numStates_(static_cast<std::size_t>(hmm.getNumStates())) {
+    : Base(hmm, observations), numStates_(hmm.getNumStatesModern()) {
     if (ObsSeqTraits<Obs>::sequence_length(observations) == 0) {
         throw std::invalid_argument("Observation sequence cannot be empty");
     }

--- a/include/libhmm/detail/log_utils.h
+++ b/include/libhmm/detail/log_utils.h
@@ -1,0 +1,39 @@
+#pragma once
+// include/libhmm/detail/log_utils.h
+//
+// Internal header — NOT part of the public API.
+// Not installed to CMAKE_INSTALL_PREFIX/include (detail/ is excluded).
+//
+// Canonical log-space utilities shared across ForwardBackward, BaumWelch,
+// MapBaumWelch, and Viterbi.  Centralising these prevents silent divergence
+// between per-class duplicates.
+
+#include <cmath>
+#include <limits>
+
+namespace libhmm {
+namespace detail {
+
+/// Sentinel value for log(0): -∞.
+/// All log-space algorithm classes reference this single definition.
+inline constexpr double LOG_ZERO = -std::numeric_limits<double>::infinity();
+
+/// Numerically stable log(exp(a) + exp(b)).
+///
+/// Uses the identity:
+///   log(exp(a) + exp(b)) = max(a,b) + log1p(exp(min(a,b) - max(a,b)))
+///
+/// Special-cases LOG_ZERO inputs to avoid exp(-inf) = 0 producing 0 + log1p(0)
+/// instead of the correct max value.
+[[nodiscard]] inline double logSumExp(double a, double b) noexcept {
+    if (a == LOG_ZERO)
+        return b;
+    if (b == LOG_ZERO)
+        return a;
+    if (a > b)
+        return a + std::log1p(std::exp(b - a));
+    return b + std::log1p(std::exp(a - b));
+}
+
+} // namespace detail
+} // namespace libhmm

--- a/include/libhmm/detail/simd_kernels_internal.h
+++ b/include/libhmm/detail/simd_kernels_internal.h
@@ -1,0 +1,413 @@
+#pragma once
+// include/libhmm/detail/simd_kernels_internal.h
+//
+// Internal header — NOT part of the public API.
+// Not installed to CMAKE_INSTALL_PREFIX/include (detail/ is excluded).
+//
+// Single source of truth for vector exp/log helpers shared between
+// transcendental_kernels.cpp and Tier-2 distribution TUs
+// (log_normal_distribution.cpp, pareto_distribution.cpp).
+//
+// Include only from .cpp files compiled with LIBHMM_BEST_SIMD_FLAGS.
+
+#include "libhmm/platform/simd_platform.h"
+#include "libhmm/math/constants.h"
+
+#include <cmath>
+#include <limits>
+
+namespace libhmm {
+namespace performance {
+namespace detail {
+namespace kernels {
+
+// ---------------------------------------------------------------------------
+// Shared constants
+// ---------------------------------------------------------------------------
+static constexpr double K_LN2_HI = 6.93147180369123816490e-1;
+static constexpr double K_LN2_LO = 1.90821492927058770002e-10;
+static constexpr double K_LOG2E = 1.44269504088896338700;
+static constexpr double K_SQRT2 = 1.41421356237309504880168872420969807;
+static constexpr double K_EXP_UNDERFLOW = constants::probability::MIN_LOG_PROBABILITY; // -700.0
+static constexpr double K_EXPONENT_BIAS = 1023.0;
+
+// log polynomial: 2y*(c0 + c1*y^2 + ... + c6*y^12), c_k = 1/(2k+1)
+static constexpr double K_LOG_C0 = 1.0;
+static constexpr double K_LOG_C1 = 3.3333333333333333e-1;
+static constexpr double K_LOG_C2 = 2.0000000000000000e-1;
+static constexpr double K_LOG_C3 = 1.4285714285714285e-1;
+static constexpr double K_LOG_C4 = 1.1111111111111111e-1;
+static constexpr double K_LOG_C5 = 9.0909090909090909e-2;
+static constexpr double K_LOG_C6 = 7.6923076923076923e-2;
+
+// exp polynomial: sum(r^k/k!), k=0..12
+static constexpr double K_EXP_C0 = 1.0;
+static constexpr double K_EXP_C1 = 1.0;
+static constexpr double K_EXP_C2 = 0.5;
+static constexpr double K_EXP_C3 = 1.6666666666666666e-1;
+static constexpr double K_EXP_C4 = 4.1666666666666664e-2;
+static constexpr double K_EXP_C5 = 8.3333333333333332e-3;
+static constexpr double K_EXP_C6 = 1.3888888888888889e-3;
+static constexpr double K_EXP_C7 = 1.9841269841269841e-4;
+static constexpr double K_EXP_C8 = 2.4801587301587302e-5;
+static constexpr double K_EXP_C9 = 2.7557319223985888e-6;
+static constexpr double K_EXP_C10 = 2.7557319223985888e-7;
+static constexpr double K_EXP_C11 = 2.5052108385441720e-8;
+static constexpr double K_EXP_C12 = 2.0876756987868099e-9;
+
+// ---------------------------------------------------------------------------
+// AVX-512 helpers
+// ---------------------------------------------------------------------------
+#if defined(LIBHMM_HAS_AVX512)
+
+[[nodiscard]] static inline __m512d k_log_pd_avx512(__m512d x) noexcept {
+    const __m512d neg_inf_v = _mm512_set1_pd(-std::numeric_limits<double>::infinity());
+    const __m512d sqrt2_v = _mm512_set1_pd(K_SQRT2);
+    const __m512d one_v = _mm512_set1_pd(1.0);
+    const __m512d half_v = _mm512_set1_pd(0.5);
+    const __m512d two_v = _mm512_set1_pd(2.0);
+    const __m512d ln2hi_v = _mm512_set1_pd(K_LN2_HI);
+    const __m512d ln2lo_v = _mm512_set1_pd(K_LN2_LO);
+
+    const __mmask8 invalid = _mm512_cmp_pd_mask(x, _mm512_setzero_pd(), _CMP_LE_OS);
+
+    __m512i bits = _mm512_castpd_si512(x);
+    __m512i e_biased = _mm512_srli_epi64(bits, 52);
+    const __m512i mant_mask = _mm512_set1_epi64(0x000FFFFFFFFFFFFFLL);
+    const __m512i exp_one = _mm512_set1_epi64(0x3FF0000000000000LL);
+    __m512i mbits = _mm512_or_si512(_mm512_and_si512(bits, mant_mask), exp_one);
+    __m512d m = _mm512_castsi512_pd(mbits);
+
+    // Convert int64 exponent to double via scalar (no AVX-512 DQ needed).
+    __m512i e_ub = _mm512_sub_epi64(e_biased, _mm512_set1_epi64(1023LL));
+    alignas(64) long long e_arr[8];
+    _mm512_storeu_si512(reinterpret_cast<__m512i *>(e_arr), e_ub);
+    __m512d e = _mm512_set_pd(static_cast<double>(e_arr[7]), static_cast<double>(e_arr[6]),
+                              static_cast<double>(e_arr[5]), static_cast<double>(e_arr[4]),
+                              static_cast<double>(e_arr[3]), static_cast<double>(e_arr[2]),
+                              static_cast<double>(e_arr[1]), static_cast<double>(e_arr[0]));
+
+    __mmask8 adj = _mm512_cmp_pd_mask(m, sqrt2_v, _CMP_GT_OS);
+    e = _mm512_mask_add_pd(e, adj, e, one_v);
+    m = _mm512_mask_mul_pd(m, adj, m, half_v);
+
+    __m512d y = _mm512_div_pd(_mm512_sub_pd(m, one_v), _mm512_add_pd(m, one_v));
+    __m512d y2 = _mm512_mul_pd(y, y);
+
+    __m512d p = _mm512_set1_pd(K_LOG_C6);
+    p = _mm512_fmadd_pd(p, y2, _mm512_set1_pd(K_LOG_C5));
+    p = _mm512_fmadd_pd(p, y2, _mm512_set1_pd(K_LOG_C4));
+    p = _mm512_fmadd_pd(p, y2, _mm512_set1_pd(K_LOG_C3));
+    p = _mm512_fmadd_pd(p, y2, _mm512_set1_pd(K_LOG_C2));
+    p = _mm512_fmadd_pd(p, y2, _mm512_set1_pd(K_LOG_C1));
+    p = _mm512_fmadd_pd(p, y2, _mm512_set1_pd(K_LOG_C0));
+    __m512d log_m = _mm512_mul_pd(_mm512_mul_pd(two_v, y), p);
+
+    __m512d result = _mm512_fmadd_pd(e, ln2hi_v, _mm512_fmadd_pd(e, ln2lo_v, log_m));
+    result = _mm512_mask_blend_pd(invalid, result, neg_inf_v);
+    return result;
+}
+
+[[nodiscard]] static inline __m512d k_exp_pd_avx512(__m512d x) noexcept {
+    const __m512d uflow_v = _mm512_set1_pd(K_EXP_UNDERFLOW);
+    const __m512d log2e_v = _mm512_set1_pd(K_LOG2E);
+    const __m512d half_v = _mm512_set1_pd(0.5);
+    const __m512d ln2hi_v = _mm512_set1_pd(K_LN2_HI);
+    const __m512d ln2lo_v = _mm512_set1_pd(K_LN2_LO);
+    const __m512d zero_v = _mm512_setzero_pd();
+    const __mmask8 uflow = _mm512_cmp_pd_mask(x, uflow_v, _CMP_LE_OS);
+    x = _mm512_max_pd(x, uflow_v);
+    __m512d n = _mm512_floor_pd(_mm512_fmadd_pd(x, log2e_v, half_v));
+    __m512d r = _mm512_fnmadd_pd(n, ln2hi_v, x);
+    r = _mm512_fnmadd_pd(n, ln2lo_v, r);
+    __m512d p = _mm512_set1_pd(K_EXP_C12);
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C11));
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C10));
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C9));
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C8));
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C7));
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C6));
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C5));
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C4));
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C3));
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C2));
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C1));
+    p = _mm512_fmadd_pd(p, r, _mm512_set1_pd(K_EXP_C0));
+    __m256i ni = _mm512_cvtpd_epi32(n);
+    __m512i ni64 = _mm512_cvtepi32_epi64(ni);
+    ni64 = _mm512_add_epi64(ni64, _mm512_set1_epi64(static_cast<long long>(K_EXPONENT_BIAS)));
+    ni64 = _mm512_slli_epi64(ni64, 52);
+    __m512d result = _mm512_mul_pd(p, _mm512_castsi512_pd(ni64));
+    result = _mm512_mask_blend_pd(uflow, result, zero_v);
+    return result;
+}
+
+#endif // LIBHMM_HAS_AVX512
+
+// ---------------------------------------------------------------------------
+// AVX helpers (AVX-1 compatible)
+// ---------------------------------------------------------------------------
+#if defined(LIBHMM_HAS_AVX) || defined(LIBHMM_HAS_AVX2)
+
+/// FMA emulation for AVX-1 targets without native _mm256_fmadd_pd.
+/// On AVX2+FMA3 hosts the compiler will typically fold this into vfmadd anyway.
+/// Returns a * b + c.
+[[nodiscard]] static inline __m256d k_fmadd_pd_avx(__m256d a, __m256d b, __m256d c) noexcept {
+    return _mm256_add_pd(_mm256_mul_pd(a, b), c);
+}
+
+[[nodiscard]] static inline __m256d k_log_pd_avx(__m256d x) noexcept {
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    const __m256d neg_inf_v = _mm256_set1_pd(neg_inf);
+    const __m256d sqrt2_v = _mm256_set1_pd(K_SQRT2);
+    const __m256d one_v = _mm256_set1_pd(1.0);
+    const __m256d half_v = _mm256_set1_pd(0.5);
+    const __m256d two_v = _mm256_set1_pd(2.0);
+    const __m256d ln2hi_v = _mm256_set1_pd(K_LN2_HI);
+    const __m256d ln2lo_v = _mm256_set1_pd(K_LN2_LO);
+    const __m256d invalid_mask = _mm256_cmp_pd(x, _mm256_setzero_pd(), _CMP_LE_OS);
+
+    auto extract_em = [](__m128d xh, __m128d &mh, __m128d &eh) {
+        __m128i bits = _mm_castpd_si128(xh);
+        __m128i eb = _mm_srli_epi64(bits, 52);
+        __m128i mm = _mm_set1_epi64x(0x000FFFFFFFFFFFFFLL);
+        __m128i eo = _mm_set1_epi64x(0x3FF0000000000000LL);
+        mh = _mm_castsi128_pd(_mm_or_si128(_mm_and_si128(bits, mm), eo));
+        __m128i eu = _mm_sub_epi64(eb, _mm_set1_epi64x(1023LL));
+        long long e0, e1;
+        _mm_storel_epi64(reinterpret_cast<__m128i *>(&e0), eu);
+        _mm_storel_epi64(reinterpret_cast<__m128i *>(&e1), _mm_unpackhi_epi64(eu, eu));
+        eh = _mm_set_pd(static_cast<double>(e1), static_cast<double>(e0));
+    };
+
+    __m128d m_lo, e_lo, m_hi, e_hi;
+    extract_em(_mm256_castpd256_pd128(x), m_lo, e_lo);
+    extract_em(_mm256_extractf128_pd(x, 1), m_hi, e_hi);
+    __m256d m = _mm256_set_m128d(m_hi, m_lo);
+    __m256d e = _mm256_set_m128d(e_hi, e_lo);
+
+    __m256d adj = _mm256_cmp_pd(m, sqrt2_v, _CMP_GT_OS);
+    e = _mm256_add_pd(e, _mm256_and_pd(adj, one_v));
+    m = _mm256_blendv_pd(m, _mm256_mul_pd(m, half_v), adj);
+
+    __m256d y = _mm256_div_pd(_mm256_sub_pd(m, one_v), _mm256_add_pd(m, one_v));
+    __m256d y2 = _mm256_mul_pd(y, y);
+
+    __m256d p = _mm256_set1_pd(K_LOG_C6);
+    p = k_fmadd_pd_avx(p, y2, _mm256_set1_pd(K_LOG_C5));
+    p = k_fmadd_pd_avx(p, y2, _mm256_set1_pd(K_LOG_C4));
+    p = k_fmadd_pd_avx(p, y2, _mm256_set1_pd(K_LOG_C3));
+    p = k_fmadd_pd_avx(p, y2, _mm256_set1_pd(K_LOG_C2));
+    p = k_fmadd_pd_avx(p, y2, _mm256_set1_pd(K_LOG_C1));
+    p = k_fmadd_pd_avx(p, y2, _mm256_set1_pd(K_LOG_C0));
+    __m256d log_m = _mm256_mul_pd(_mm256_mul_pd(two_v, y), p);
+    __m256d result =
+        _mm256_add_pd(_mm256_mul_pd(e, ln2hi_v), _mm256_add_pd(_mm256_mul_pd(e, ln2lo_v), log_m));
+    result = _mm256_blendv_pd(result, neg_inf_v, invalid_mask);
+    return result;
+}
+
+[[nodiscard]] static inline __m256d k_exp_pd_avx(__m256d x) noexcept {
+    const __m256d uflow_v = _mm256_set1_pd(K_EXP_UNDERFLOW);
+    const __m256d log2e_v = _mm256_set1_pd(K_LOG2E);
+    const __m256d half_v = _mm256_set1_pd(0.5);
+    const __m256d ln2hi_v = _mm256_set1_pd(K_LN2_HI);
+    const __m256d ln2lo_v = _mm256_set1_pd(K_LN2_LO);
+    const __m256d zero_v = _mm256_setzero_pd();
+    const __m256d ufl_mask = _mm256_cmp_pd(x, uflow_v, _CMP_LE_OS);
+    x = _mm256_max_pd(x, uflow_v);
+    __m256d n = _mm256_floor_pd(_mm256_add_pd(_mm256_mul_pd(x, log2e_v), half_v));
+    __m256d r = _mm256_sub_pd(x, _mm256_mul_pd(n, ln2hi_v));
+    r = _mm256_sub_pd(r, _mm256_mul_pd(n, ln2lo_v));
+
+    __m256d p = _mm256_set1_pd(K_EXP_C12);
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C11));
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C10));
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C9));
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C8));
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C7));
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C6));
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C5));
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C4));
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C3));
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C2));
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C1));
+    p = k_fmadd_pd_avx(p, r, _mm256_set1_pd(K_EXP_C0));
+
+    __m128d n_lo = _mm256_castpd256_pd128(n), n_hi = _mm256_extractf128_pd(n, 1);
+    auto bp2 = [](__m128d nd) {
+        __m128i ni32 =
+            _mm_add_epi32(_mm_cvttpd_epi32(nd), _mm_set1_epi32(static_cast<int>(K_EXPONENT_BIAS)));
+        __m128i i64 = _mm_slli_epi64(_mm_unpacklo_epi32(ni32, _mm_setzero_si128()), 52);
+        return _mm_castsi128_pd(i64);
+    };
+    __m256d result = _mm256_mul_pd(p, _mm256_set_m128d(bp2(n_hi), bp2(n_lo)));
+    result = _mm256_blendv_pd(result, zero_v, ufl_mask);
+    return result;
+}
+
+#endif // LIBHMM_HAS_AVX || LIBHMM_HAS_AVX2
+
+// ---------------------------------------------------------------------------
+// SSE2 helpers
+// ---------------------------------------------------------------------------
+#if defined(LIBHMM_HAS_SSE2)
+
+/// FMA emulation for SSE2 targets without native _mm_fmadd_pd.
+/// Returns a * b + c.
+[[nodiscard]] static inline __m128d k_fmadd_pd_sse2(__m128d a, __m128d b, __m128d c) noexcept {
+    return _mm_add_pd(_mm_mul_pd(a, b), c);
+}
+
+[[nodiscard]] static inline __m128d k_log_pd_sse2(__m128d x) noexcept {
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    const __m128d neg_inf_v = _mm_set1_pd(neg_inf);
+    const __m128d sqrt2_v = _mm_set1_pd(K_SQRT2);
+    const __m128d one_v = _mm_set1_pd(1.0);
+    const __m128d half_v = _mm_set1_pd(0.5);
+    const __m128d two_v = _mm_set1_pd(2.0);
+    const __m128d ln2hi_v = _mm_set1_pd(K_LN2_HI);
+    const __m128d ln2lo_v = _mm_set1_pd(K_LN2_LO);
+    const __m128d invalid = _mm_cmple_pd(x, _mm_setzero_pd());
+    __m128i bits = _mm_castpd_si128(x);
+    __m128i eb = _mm_srli_epi64(bits, 52);
+    __m128i mbits = _mm_or_si128(_mm_and_si128(bits, _mm_set1_epi64x(0x000FFFFFFFFFFFFFLL)),
+                                 _mm_set1_epi64x(0x3FF0000000000000LL));
+    __m128d m = _mm_castsi128_pd(mbits);
+    __m128i eu = _mm_sub_epi64(eb, _mm_set1_epi64x(1023LL));
+    long long e0, e1;
+    _mm_storel_epi64(reinterpret_cast<__m128i *>(&e0), eu);
+    _mm_storel_epi64(reinterpret_cast<__m128i *>(&e1), _mm_unpackhi_epi64(eu, eu));
+    __m128d e = _mm_set_pd(static_cast<double>(e1), static_cast<double>(e0));
+    __m128d adj = _mm_cmpgt_pd(m, sqrt2_v);
+    e = _mm_add_pd(e, _mm_and_pd(adj, one_v));
+    m = _mm_or_pd(_mm_andnot_pd(adj, m), _mm_and_pd(adj, _mm_mul_pd(m, half_v)));
+    __m128d y = _mm_div_pd(_mm_sub_pd(m, one_v), _mm_add_pd(m, one_v));
+    __m128d y2 = _mm_mul_pd(y, y);
+    __m128d p = _mm_set1_pd(K_LOG_C6);
+    p = k_fmadd_pd_sse2(p, y2, _mm_set1_pd(K_LOG_C5));
+    p = k_fmadd_pd_sse2(p, y2, _mm_set1_pd(K_LOG_C4));
+    p = k_fmadd_pd_sse2(p, y2, _mm_set1_pd(K_LOG_C3));
+    p = k_fmadd_pd_sse2(p, y2, _mm_set1_pd(K_LOG_C2));
+    p = k_fmadd_pd_sse2(p, y2, _mm_set1_pd(K_LOG_C1));
+    p = k_fmadd_pd_sse2(p, y2, _mm_set1_pd(K_LOG_C0));
+    __m128d log_m = _mm_mul_pd(_mm_mul_pd(two_v, y), p);
+    __m128d result = _mm_add_pd(_mm_mul_pd(e, ln2hi_v), _mm_add_pd(_mm_mul_pd(e, ln2lo_v), log_m));
+    result = _mm_or_pd(_mm_andnot_pd(invalid, result), _mm_and_pd(invalid, neg_inf_v));
+    return result;
+}
+
+[[nodiscard]] static inline __m128d k_exp_pd_sse2(__m128d x) noexcept {
+    const __m128d uflow_v = _mm_set1_pd(K_EXP_UNDERFLOW);
+    const __m128d log2e_v = _mm_set1_pd(K_LOG2E);
+    const __m128d half_v = _mm_set1_pd(0.5);
+    const __m128d ln2hi_v = _mm_set1_pd(K_LN2_HI);
+    const __m128d ln2lo_v = _mm_set1_pd(K_LN2_LO);
+    const __m128d zero_v = _mm_setzero_pd();
+    const __m128d ufl = _mm_cmple_pd(x, uflow_v);
+    x = _mm_max_pd(x, uflow_v);
+    __m128d t = _mm_add_pd(_mm_mul_pd(x, log2e_v), half_v);
+    __m128i ni = _mm_cvttpd_epi32(t);
+    __m128d n = _mm_cvtepi32_pd(ni);
+    n = _mm_sub_pd(n, _mm_and_pd(_mm_cmpgt_pd(n, t), _mm_set1_pd(1.0)));
+    __m128d r = _mm_sub_pd(x, _mm_mul_pd(n, ln2hi_v));
+    r = _mm_sub_pd(r, _mm_mul_pd(n, ln2lo_v));
+    __m128d p = _mm_set1_pd(K_EXP_C12);
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C11));
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C10));
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C9));
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C8));
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C7));
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C6));
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C5));
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C4));
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C3));
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C2));
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C1));
+    p = k_fmadd_pd_sse2(p, r, _mm_set1_pd(K_EXP_C0));
+    __m128i ni32b =
+        _mm_add_epi32(_mm_cvttpd_epi32(n), _mm_set1_epi32(static_cast<int>(K_EXPONENT_BIAS)));
+    __m128i i64 = _mm_slli_epi64(_mm_unpacklo_epi32(ni32b, _mm_setzero_si128()), 52);
+    __m128d result = _mm_mul_pd(p, _mm_castsi128_pd(i64));
+    result = _mm_or_pd(_mm_andnot_pd(ufl, result), _mm_and_pd(ufl, zero_v));
+    return result;
+}
+
+#endif // LIBHMM_HAS_SSE2
+
+// ---------------------------------------------------------------------------
+// NEON helpers
+// ---------------------------------------------------------------------------
+#if defined(LIBHMM_HAS_NEON)
+
+[[nodiscard]] static inline float64x2_t k_log_pd_neon(float64x2_t x) noexcept {
+    const float64x2_t neg_inf_v = vdupq_n_f64(-std::numeric_limits<double>::infinity());
+    const float64x2_t sqrt2_v = vdupq_n_f64(K_SQRT2);
+    const float64x2_t one_v = vdupq_n_f64(1.0);
+    const float64x2_t half_v = vdupq_n_f64(0.5);
+    const float64x2_t two_v = vdupq_n_f64(2.0);
+    const float64x2_t ln2hi_v = vdupq_n_f64(K_LN2_HI);
+    const float64x2_t ln2lo_v = vdupq_n_f64(K_LN2_LO);
+    const uint64x2_t invalid = vcleq_f64(x, vdupq_n_f64(0.0));
+    uint64x2_t bits = vreinterpretq_u64_f64(x);
+    uint64x2_t eb = vshrq_n_u64(bits, 52);
+    uint64x2_t mbits = vorrq_u64(vandq_u64(bits, vdupq_n_u64(0x000FFFFFFFFFFFFFULL)),
+                                 vdupq_n_u64(0x3FF0000000000000ULL));
+    float64x2_t m = vreinterpretq_f64_u64(mbits);
+    float64x2_t e = vcvtq_f64_s64(vsubq_s64(vreinterpretq_s64_u64(eb), vdupq_n_s64(1023LL)));
+    uint64x2_t adj = vcgtq_f64(m, sqrt2_v);
+    e = vbslq_f64(adj, vaddq_f64(e, one_v), e);
+    m = vbslq_f64(adj, vmulq_f64(m, half_v), m);
+    float64x2_t y = vdivq_f64(vsubq_f64(m, one_v), vaddq_f64(m, one_v));
+    float64x2_t y2 = vmulq_f64(y, y);
+    float64x2_t p = vdupq_n_f64(K_LOG_C6);
+    p = vfmaq_f64(vdupq_n_f64(K_LOG_C5), p, y2);
+    p = vfmaq_f64(vdupq_n_f64(K_LOG_C4), p, y2);
+    p = vfmaq_f64(vdupq_n_f64(K_LOG_C3), p, y2);
+    p = vfmaq_f64(vdupq_n_f64(K_LOG_C2), p, y2);
+    p = vfmaq_f64(vdupq_n_f64(K_LOG_C1), p, y2);
+    p = vfmaq_f64(vdupq_n_f64(K_LOG_C0), p, y2);
+    float64x2_t log_m = vmulq_f64(vmulq_f64(two_v, y), p);
+    float64x2_t result = vfmaq_f64(vfmaq_f64(log_m, e, ln2lo_v), e, ln2hi_v);
+    result = vbslq_f64(invalid, neg_inf_v, result);
+    return result;
+}
+
+[[nodiscard]] static inline float64x2_t k_exp_pd_neon(float64x2_t x) noexcept {
+    const float64x2_t uflow_v = vdupq_n_f64(K_EXP_UNDERFLOW);
+    const float64x2_t log2e_v = vdupq_n_f64(K_LOG2E);
+    const float64x2_t half_v = vdupq_n_f64(0.5);
+    const float64x2_t ln2hi_v = vdupq_n_f64(K_LN2_HI);
+    const float64x2_t ln2lo_v = vdupq_n_f64(K_LN2_LO);
+    const float64x2_t zero_v = vdupq_n_f64(0.0);
+    const uint64x2_t valid = vcgtq_f64(x, uflow_v);
+    x = vmaxq_f64(x, uflow_v);
+    float64x2_t n = vrndmq_f64(vfmaq_f64(half_v, x, log2e_v));
+    float64x2_t r = vfmsq_f64(x, n, ln2hi_v);
+    r = vfmsq_f64(r, n, ln2lo_v);
+    float64x2_t p = vdupq_n_f64(K_EXP_C12);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C11), p, r);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C10), p, r);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C9), p, r);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C8), p, r);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C7), p, r);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C6), p, r);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C5), p, r);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C4), p, r);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C3), p, r);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C2), p, r);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C1), p, r);
+    p = vfmaq_f64(vdupq_n_f64(K_EXP_C0), p, r);
+    int64x2_t ni64 =
+        vaddq_s64(vcvtq_s64_f64(n), vdupq_n_s64(static_cast<int64_t>(K_EXPONENT_BIAS)));
+    float64x2_t result = vmulq_f64(p, vreinterpretq_f64_s64(vshlq_n_s64(ni64, 52)));
+    result = vbslq_f64(valid, result, zero_v);
+    return result;
+}
+
+#endif // LIBHMM_HAS_NEON
+
+} // namespace kernels
+} // namespace detail
+} // namespace performance
+} // namespace libhmm

--- a/include/libhmm/distributions/distributions.h
+++ b/include/libhmm/distributions/distributions.h
@@ -32,9 +32,6 @@
 #include "libhmm/distributions/emission_distribution.h"
 #include "libhmm/distributions/distribution_base.h"
 
-// Distribution type traits (retained for backward compatibility; see emission_concepts.h)
-#include "libhmm/distributions/distribution_traits.h"
-
 // Discrete distributions
 #include "libhmm/distributions/discrete_distribution.h"
 #include "libhmm/distributions/binomial_distribution.h"

--- a/include/libhmm/training/basic_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_baum_welch_trainer.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "libhmm/calculators/basic_forward_backward_calculator.h"
+#include "libhmm/detail/log_utils.h"
 #include "libhmm/linalg/linalg_types.h"
 #include "libhmm/performance/transcendental_kernels.h"
 #include "libhmm/training/basic_trainer.h"
@@ -59,7 +60,7 @@ public:
     void train() override;
 
 private:
-    static constexpr double LOG_ZERO = -std::numeric_limits<double>::infinity();
+    static constexpr double LOG_ZERO = detail::LOG_ZERO;
 
     // -------------------------------------------------------------------------
     // Emission accumulator types
@@ -120,8 +121,6 @@ private:
                                    const std::vector<double> &transNumT,
                                    const std::vector<double> &transDen);
 
-    /** @brief log(exp(a) + exp(b)) — numerically stable. */
-    [[nodiscard]] static double logSumExp(double a, double b) noexcept;
 };
 
 // =============================================================================
@@ -143,7 +142,7 @@ BasicBaumWelchTrainer<Obs>::BasicBaumWelchTrainer(HmmType *hmm, const ListType &
 template <typename Obs>
 void BasicBaumWelchTrainer<Obs>::train() {
     HmmType &hmm = this->getHmmRef();
-    const std::size_t N = static_cast<std::size_t>(hmm.getNumStates());
+    const std::size_t N = hmm.getNumStatesModern();
 
     std::vector<double> logTransT(N * N);
     bool hasZeroTransitions = false;
@@ -310,17 +309,6 @@ void BasicBaumWelchTrainer<Obs>::m_step_transitions(HmmType &hmm, std::size_t N,
         }
     }
     hmm.setTrans(newTrans);
-}
-
-template <typename Obs>
-double BasicBaumWelchTrainer<Obs>::logSumExp(double a, double b) noexcept {
-    if (a == LOG_ZERO)
-        return b;
-    if (b == LOG_ZERO)
-        return a;
-    if (a > b)
-        return a + std::log1p(std::exp(b - a));
-    return b + std::log1p(std::exp(a - b));
 }
 
 // =============================================================================

--- a/include/libhmm/training/basic_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_baum_welch_trainer.h
@@ -120,7 +120,6 @@ private:
     static void m_step_transitions(HmmType &hmm, std::size_t N,
                                    const std::vector<double> &transNumT,
                                    const std::vector<double> &transDen);
-
 };
 
 // =============================================================================

--- a/include/libhmm/training/basic_map_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_map_baum_welch_trainer.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "libhmm/calculators/basic_forward_backward_calculator.h"
+#include "libhmm/detail/log_utils.h"
 #include "libhmm/distributions/discrete_distribution.h"
 #include "libhmm/linalg/linalg_types.h"
 #include "libhmm/performance/transcendental_kernels.h"
@@ -88,7 +89,7 @@ public:
 private:
     double pseudo_count_;
 
-    static constexpr double LOG_ZERO = -std::numeric_limits<double>::infinity();
+    static constexpr double LOG_ZERO = detail::LOG_ZERO;
 
     // Same type-adapting accumulator pattern as BasicBaumWelchTrainer.
     using EmisElem = std::conditional_t<std::is_same_v<Obs, double>, double, ObservationVectorView>;
@@ -207,7 +208,7 @@ double BasicMapBaumWelchTrainer<Obs>::computeLogPrior() const {
         return 0.0;
 
     const HmmType &hmm = this->getHmmRef();
-    const std::size_t N = static_cast<std::size_t>(hmm.getNumStates());
+    const std::size_t N = hmm.getNumStatesModern();
     const double c = pseudo_count_;
     double lp = 0.0;
 
@@ -308,7 +309,7 @@ bool BasicMapBaumWelchTrainer<Obs>::accum_one_sequence(const HmmType &hmm, const
 template <typename Obs>
 void BasicMapBaumWelchTrainer<Obs>::train() {
     HmmType &hmm = this->getHmmRef();
-    const std::size_t N = static_cast<std::size_t>(hmm.getNumStates());
+    const std::size_t N = hmm.getNumStatesModern();
     const double c = pseudo_count_;
 
     std::vector<double> logTransT(N * N);

--- a/include/libhmm/training/basic_viterbi_trainer.h
+++ b/include/libhmm/training/basic_viterbi_trainer.h
@@ -229,7 +229,7 @@ double BasicViterbiTrainer<Obs>::process_one_sequence(const HmmType &hmm, const 
 template <typename Obs>
 double BasicViterbiTrainer<Obs>::runIteration() {
     HmmType &hmm = this->getHmmRef();
-    const std::size_t N = static_cast<std::size_t>(hmm.getNumStates());
+    const std::size_t N = hmm.getNumStatesModern();
 
     Vector pi(N);
     clear_vector(pi);

--- a/include/libhmm/training/segmental_kmeans_trainer.h
+++ b/include/libhmm/training/segmental_kmeans_trainer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include <memory>
 #include <stdexcept>
@@ -13,20 +13,7 @@ namespace libhmm {
 /// Manages the mapping between observations and cluster assignments.
 class Clusters {
 private:
-    class Value {
-    private:
-        std::size_t clusterNb_;
-
-    public:
-        Value() noexcept : clusterNb_{0} {}
-        explicit Value(std::size_t clusterNb) noexcept : clusterNb_{clusterNb} {}
-
-        void setClusterNb(std::size_t clusterNb) noexcept { clusterNb_ = clusterNb; }
-
-        std::size_t getClusterNb() const noexcept { return clusterNb_; }
-    };
-
-    std::map<std::size_t, Value> clustersHash_;
+    std::unordered_map<std::size_t, std::size_t> clustersHash_;
     std::vector<std::vector<std::size_t>> clusters_;
 
 public:

--- a/scripts/setup-pre-commit.sh
+++ b/scripts/setup-pre-commit.sh
@@ -31,17 +31,18 @@ info "Python: $($PYTHON --version)"
 
 # ─── install pre-commit ───────────────────────────────────────────────────────
 step "Installing pre-commit"
-
-if command -v pre-commit &>/dev/null; then
-    info "pre-commit already installed: $(pre-commit --version)"
+if $PYTHON -m pre_commit --version &>/dev/null; then
+    info "pre-commit already available: $($PYTHON -m pre_commit --version)"
 else
-    $PYTHON -m pip install --user pre-commit
-    if ! command -v pre-commit &>/dev/null; then
-        warn "pre-commit installed but not in PATH."
-        warn "Add ~/.local/bin to your PATH and re-run this script."
+    if command -v pre-commit &>/dev/null && ! pre-commit --version &>/dev/null; then
+        warn "Ignoring broken pre-commit executable on PATH; installing via $PYTHON."
+    fi
+    $PYTHON -m pip install --user --upgrade pre-commit
+    if ! $PYTHON -m pre_commit --version &>/dev/null; then
+        error "pre-commit installed but cannot run via '$PYTHON -m pre_commit'."
         exit 1
     fi
-    info "Installed: $(pre-commit --version)"
+    info "Installed: $($PYTHON -m pre_commit --version)"
 fi
 
 # ─── check optional tools ─────────────────────────────────────────────────────
@@ -58,16 +59,16 @@ fi
 # ─── install git hooks ────────────────────────────────────────────────────────
 step "Installing git hooks"
 
-pre-commit install
+"$PYTHON" -m pre_commit install
 info "Git hooks installed. They will run automatically on 'git commit'."
 
 # ─── done ─────────────────────────────────────────────────────────────────────
 step "Setup complete"
 echo ""
 echo "Useful commands:"
-echo "  pre-commit run --all-files     # Run all hooks on all files"
-echo "  pre-commit run --files FILE    # Run hooks on specific files"
-echo "  pre-commit autoupdate          # Update hook versions"
+echo "  $PYTHON -m pre_commit run --all-files     # Run all hooks on all files"
+echo "  $PYTHON -m pre_commit run --files FILE    # Run hooks on specific files"
+echo "  $PYTHON -m pre_commit autoupdate          # Update hook versions"
 echo "  git commit --no-verify         # Skip hooks (use sparingly)"
 echo ""
 info "See .pre-commit-config.yaml for the active hook set."

--- a/src/distributions/log_normal_distribution.cpp
+++ b/src/distributions/log_normal_distribution.cpp
@@ -1,6 +1,6 @@
 #include "libhmm/distributions/log_normal_distribution.h"
 #include "libhmm/io/json_utils.h"
-#include "libhmm/performance/simd_kernels_internal.h"
+#include "libhmm/detail/simd_kernels_internal.h"
 // Header already includes: <iostream>, <sstream>, <iomanip>, <cmath>, <cassert>, <stdexcept> via common.h
 #include <numeric>   // For std::accumulate (not in common.h)
 #include <algorithm> // For std::for_each (exists in common.h, included for clarity)

--- a/src/distributions/pareto_distribution.cpp
+++ b/src/distributions/pareto_distribution.cpp
@@ -1,6 +1,6 @@
 #include "libhmm/distributions/pareto_distribution.h"
 #include "libhmm/io/json_utils.h"
-#include "libhmm/performance/simd_kernels_internal.h"
+#include "libhmm/detail/simd_kernels_internal.h"
 // Header already includes: <iostream>, <sstream>, <iomanip>, <cmath>, <cassert>, <stdexcept> via common.h
 #include <numeric>   // For std::accumulate (not in common.h)
 #include <algorithm> // For std::min_element (exists in common.h, included for clarity)

--- a/src/performance/transcendental_kernels.cpp
+++ b/src/performance/transcendental_kernels.cpp
@@ -14,7 +14,7 @@
 // Tier-2 distribution TUs (log_normal_distribution.cpp, pareto_distribution.cpp).
 
 #include "libhmm/performance/transcendental_kernels.h"
-#include "libhmm/performance/simd_kernels_internal.h"
+#include "libhmm/detail/simd_kernels_internal.h"
 #include "libhmm/math/constants.h"
 #include "libhmm/platform/simd_platform.h"
 

--- a/src/training/kmeans_init.cpp
+++ b/src/training/kmeans_init.cpp
@@ -151,7 +151,7 @@ void kmeans_init(HmmMV &hmm, const MultiObservationLists &data, std::mt19937_64 
                  std::size_t max_iter) {
     if (data.empty())
         throw std::invalid_argument("kmeans_init: data must be non-empty");
-    const std::size_t K = static_cast<std::size_t>(hmm.getNumStates());
+    const std::size_t K = hmm.getNumStatesModern();
     if (K == 0)
         throw std::invalid_argument("kmeans_init: HMM must have at least one state");
 

--- a/src/training/segmental_kmeans_trainer.cpp
+++ b/src/training/segmental_kmeans_trainer.cpp
@@ -39,7 +39,7 @@ Clusters::Clusters(std::size_t k, const ObservationSet &observations) {
         const auto obsValue = static_cast<std::size_t>(observations(i));
 
         clusters_[clusterIdx].push_back(obsValue);
-        clustersHash_[obsValue] = Value(clusterIdx);
+        clustersHash_[obsValue] = clusterIdx;
     }
 }
 
@@ -48,7 +48,7 @@ std::size_t Clusters::clusterNumber(std::size_t observation) const {
     if (it == clustersHash_.end()) {
         throw std::out_of_range("Observation not found in clusters");
     }
-    return it->second.getClusterNb();
+    return it->second;
 }
 
 const std::vector<std::size_t> &Clusters::cluster(std::size_t clusterNb) const {
@@ -73,7 +73,7 @@ void Clusters::remove(std::size_t observation, std::size_t clusterNb) {
     }
 
     clusterVec.erase(it);
-    clustersHash_[observation].setClusterNb(static_cast<std::size_t>(-1));
+    clustersHash_[observation] = static_cast<std::size_t>(-1);
 }
 
 void Clusters::put(std::size_t observation, std::size_t clusterNb) {
@@ -81,13 +81,13 @@ void Clusters::put(std::size_t observation, std::size_t clusterNb) {
         throw std::out_of_range("Invalid cluster number");
     }
 
-    clustersHash_[observation].setClusterNb(clusterNb);
+    clustersHash_[observation] = clusterNb;
     clusters_[clusterNb].push_back(observation);
 }
 
 void SegmentalKMeansTrainer::validateDiscreteDistributions() const {
     Hmm &hmm = hmm_ref_.get();
-    const auto numStates = static_cast<std::size_t>(hmm.getNumStates());
+    const auto numStates = hmm.getNumStatesModern();
     for (std::size_t i = 0; i < numStates; ++i) {
         const auto *dist = dynamic_cast<const DiscreteDistribution *>(&hmm.getDistribution(i));
         if (!dist) {
@@ -99,7 +99,7 @@ void SegmentalKMeansTrainer::validateDiscreteDistributions() const {
 
 void SegmentalKMeansTrainer::train() {
     ObservationSet observations = flattenObservationLists(getObservationLists());
-    const auto numStates = static_cast<std::size_t>(hmm_ref_.get().getNumStates());
+    const auto numStates = hmm_ref_.get().getNumStatesModern();
     clusters_ = Clusters(numStates, observations);
 
     do {
@@ -120,7 +120,7 @@ void SegmentalKMeansTrainer::iterate() {
 /// / total sequences.
 void SegmentalKMeansTrainer::learnPi() {
     Hmm &hmm = hmm_ref_.get();
-    const auto numStates = static_cast<std::size_t>(hmm.getNumStates());
+    const auto numStates = hmm.getNumStatesModern();
     Vector pi(numStates);
 
     clear_vector(pi);
@@ -146,7 +146,7 @@ void SegmentalKMeansTrainer::learnPi() {
 /// to uniform to avoid a degenerate transition matrix.
 void SegmentalKMeansTrainer::learnTrans() {
     Hmm &hmm = hmm_ref_.get();
-    const auto numStates = static_cast<std::size_t>(hmm.getNumStates());
+    const auto numStates = hmm.getNumStatesModern();
     Matrix trans(numStates, numStates);
 
     clear_matrix(trans);
@@ -188,7 +188,7 @@ void SegmentalKMeansTrainer::learnTrans() {
 /// cause -inf log-probabilities during subsequent Viterbi decoding.
 void SegmentalKMeansTrainer::learnEmis() {
     Hmm &hmm = hmm_ref_.get();
-    const auto numStates = static_cast<std::size_t>(hmm.getNumStates());
+    const auto numStates = hmm.getNumStatesModern();
 
     for (std::size_t i = 0; i < numStates; ++i) {
         auto *dist = dynamic_cast<DiscreteDistribution *>(&hmm.getDistribution(i));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,9 +44,6 @@ if(GTest_FOUND OR TARGET gtest)
     message(STATUS "Google Test found - building comprehensive test suite")
 
     include_directories(${CMAKE_SOURCE_DIR}/include)
-    if(GTest_FOUND)
-        include_directories(${GTEST_INCLUDE_DIRS})
-    endif()
 
     if(TARGET GTest::gtest AND TARGET GTest::gtest_main)
         set(TEST_LIBRARIES GTest::gtest_main GTest::gtest Threads::Threads hmm_static)
@@ -58,6 +55,17 @@ if(GTest_FOUND OR TARGET gtest)
         set(TEST_LIBRARIES ${GTEST_MAIN_LIBRARIES} ${GTEST_LIBRARIES} Threads::Threads hmm_static)
         message(STATUS "Using GTest library variables")
     endif()
+
+    foreach(_gtest_target GTest::gtest GTest::gtest_main gtest gtest_main)
+        if(TARGET ${_gtest_target})
+            get_target_property(_gtest_includes ${_gtest_target} INTERFACE_INCLUDE_DIRECTORIES)
+            if(_gtest_includes)
+                set_target_properties(${_gtest_target} PROPERTIES
+                    INTERFACE_INCLUDE_DIRECTORIES ""
+                    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_gtest_includes}")
+            endif()
+        endif()
+    endforeach()
 
     # =========================================================================
     # add_hmm_test(target source [LABELS label1 label2 ...])
@@ -74,13 +82,24 @@ if(GTest_FOUND OR TARGET gtest)
 
         add_executable(${TARGET_NAME} ${SOURCE_FILE})
         target_link_libraries(${TARGET_NAME} ${TEST_LIBRARIES})
+        if(GTest_FOUND AND GTEST_INCLUDE_DIRS)
+            target_include_directories(${TARGET_NAME} SYSTEM PRIVATE ${GTEST_INCLUDE_DIRS})
+        endif()
         set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD 20)
         set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
         # Apply same warning level as the library so test code is held to the
         # same standard. GTest itself is excluded via SYSTEM includes.
         if(MSVC)
             target_compile_options(${TARGET_NAME} PRIVATE /W4 /permissive-)
-        elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            # GTest's printer/comparison templates trigger these warnings under
+            # Clang for otherwise clean test code. Keep suppressions local to
+            # test executables so library, examples, and tools stay fully strict.
+            target_compile_options(${TARGET_NAME} PRIVATE
+                -Wall -Wextra -Wpedantic
+                -Wno-character-conversion
+                -Wno-sign-compare)
+        elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
             target_compile_options(${TARGET_NAME} PRIVATE -Wall -Wextra -Wpedantic)
         endif()
         add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,16 +56,6 @@ if(GTest_FOUND OR TARGET gtest)
         message(STATUS "Using GTest library variables")
     endif()
 
-    foreach(_gtest_target GTest::gtest GTest::gtest_main gtest gtest_main)
-        if(TARGET ${_gtest_target})
-            get_target_property(_gtest_includes ${_gtest_target} INTERFACE_INCLUDE_DIRECTORIES)
-            if(_gtest_includes)
-                set_target_properties(${_gtest_target} PROPERTIES
-                    INTERFACE_INCLUDE_DIRECTORIES ""
-                    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_gtest_includes}")
-            endif()
-        endif()
-    endforeach()
 
     # =========================================================================
     # add_hmm_test(target source [LABELS label1 label2 ...])
@@ -97,7 +87,6 @@ if(GTest_FOUND OR TARGET gtest)
             # test executables so library, examples, and tools stay fully strict.
             target_compile_options(${TARGET_NAME} PRIVATE
                 -Wall -Wextra -Wpedantic
-                -Wno-character-conversion
                 -Wno-sign-compare)
         elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
             target_compile_options(${TARGET_NAME} PRIVATE -Wall -Wextra -Wpedantic)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,7 +129,6 @@ if(GTest_FOUND OR TARGET gtest)
     # =========================================================================
     # Distributions
     # =========================================================================
-    add_hmm_test(test_distribution_traits       distributions/test_distribution_traits.cpp)
     add_hmm_test(test_distributions_header      distributions/test_distributions_header.cpp)
     add_hmm_test(test_distributions             distributions/test_distributions.cpp)
     add_hmm_test(test_distribution_type_safety  distributions/test_distribution_type_safety.cpp)

--- a/tests/calculators/test_calculator_continuous.cpp
+++ b/tests/calculators/test_calculator_continuous.cpp
@@ -117,7 +117,7 @@ TEST_F(ContinuousCalculatorTest, Viterbi_AllStatesValid) {
     const auto seq = vc.decode();
     for (std::size_t i = 0; i < seq.size(); ++i) {
         EXPECT_GE(seq(i), 0);
-        EXPECT_LT(seq(i), hmm_->getNumStates());
+        EXPECT_LT(seq(i), static_cast<int>(hmm_->getNumStatesModern()));
     }
 }
 

--- a/tests/calculators/test_canonical_calculators.cpp
+++ b/tests/calculators/test_canonical_calculators.cpp
@@ -102,9 +102,9 @@ TEST_F(CanonicalCalculatorTest, FB_MatrixDimensions) {
     const Matrix &alpha = fbc.getLogForwardVariables();
     const Matrix &beta = fbc.getLogBackwardVariables();
     EXPECT_EQ(alpha.size1(), obs5_.size());
-    EXPECT_EQ(alpha.size2(), static_cast<std::size_t>(hmm_->getNumStates()));
+    EXPECT_EQ(alpha.size2(), hmm_->getNumStatesModern());
     EXPECT_EQ(beta.size1(), obs5_.size());
-    EXPECT_EQ(beta.size2(), static_cast<std::size_t>(hmm_->getNumStates()));
+    EXPECT_EQ(beta.size2(), hmm_->getNumStatesModern());
 }
 
 TEST_F(CanonicalCalculatorTest, FB_SingleObservation) {
@@ -155,7 +155,7 @@ TEST_F(CanonicalCalculatorTest, Viterbi_AllStatesValid) {
     StateSequence seq = vc.decode();
     for (std::size_t i = 0; i < seq.size(); ++i) {
         EXPECT_GE(seq(i), 0);
-        EXPECT_LT(seq(i), hmm_->getNumStates());
+        EXPECT_LT(seq(i), static_cast<int>(hmm_->getNumStatesModern()));
     }
 }
 
@@ -179,7 +179,7 @@ TEST_F(CanonicalCalculatorTest, Viterbi_SingleObservation) {
     StateSequence seq = vc.decode();
     EXPECT_EQ(seq.size(), 1u);
     EXPECT_GE(seq(0), 0);
-    EXPECT_LT(seq(0), hmm_->getNumStates());
+    EXPECT_LT(seq(0), static_cast<int>(hmm_->getNumStatesModern()));
 }
 
 TEST_F(CanonicalCalculatorTest, Viterbi_LongSequence) {

--- a/tests/calculators/test_posterior_decoding.cpp
+++ b/tests/calculators/test_posterior_decoding.cpp
@@ -81,7 +81,7 @@ TEST(PosteriorDecodingTest, AllStatesInValidRange) {
     StateSequence posterior = fbc.decodePosterior();
     for (std::size_t t = 0; t < posterior.size(); ++t) {
         EXPECT_GE(posterior(t), 0);
-        EXPECT_LT(posterior(t), hmm->getNumStates());
+        EXPECT_LT(posterior(t), static_cast<int>(hmm->getNumStatesModern()));
     }
 }
 
@@ -93,7 +93,7 @@ TEST(PosteriorDecodingTest, SingleObservation) {
     StateSequence posterior = fbc.decodePosterior();
     ASSERT_EQ(posterior.size(), 1u);
     EXPECT_GE(posterior(0), 0);
-    EXPECT_LT(posterior(0), hmm->getNumStates());
+    EXPECT_LT(posterior(0), static_cast<int>(hmm->getNumStatesModern()));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/distributions/test_binomial_distribution.cpp
+++ b/tests/distributions/test_binomial_distribution.cpp
@@ -407,7 +407,7 @@ TEST(BinomialDistributionTest, Performance) {
     volatile double sum = 0.0; // volatile to prevent optimization
 
     for (int i = 0; i < pdfIterations; ++i) {
-        sum += binomial.getProbability(i % 101); // 0 to 100
+        sum = sum + binomial.getProbability(i % 101); // 0 to 100
     }
 
     auto end = std::chrono::high_resolution_clock::now();
@@ -419,7 +419,7 @@ TEST(BinomialDistributionTest, Performance) {
     volatile double logSum = 0.0;
 
     for (int i = 0; i < pdfIterations; ++i) {
-        logSum += binomial.getLogProbability(i % 101); // 0 to 100
+        logSum = logSum + binomial.getLogProbability(i % 101); // 0 to 100
     }
 
     end = std::chrono::high_resolution_clock::now();

--- a/tests/distributions/test_chi_squared_distribution.cpp
+++ b/tests/distributions/test_chi_squared_distribution.cpp
@@ -424,7 +424,7 @@ TEST(ChiSquaredDistributionTest, Performance) {
 
     for (int i = 0; i < pdfIterations; ++i) {
         double x = static_cast<double>(i) / 1000.0; // Range 0 to 10
-        sum += chi_dist.getProbability(x);
+        sum = sum + chi_dist.getProbability(x);
     }
 
     auto end = std::chrono::high_resolution_clock::now();
@@ -437,7 +437,7 @@ TEST(ChiSquaredDistributionTest, Performance) {
 
     for (int i = 0; i < pdfIterations; ++i) {
         double x = static_cast<double>(i) / 1000.0; // Range 0 to 10
-        logSum += chi_dist.getLogProbability(x);
+        logSum = logSum + chi_dist.getLogProbability(x);
     }
 
     end = std::chrono::high_resolution_clock::now();

--- a/tests/distributions/test_discrete_distribution.cpp
+++ b/tests/distributions/test_discrete_distribution.cpp
@@ -428,7 +428,7 @@ TEST(DiscreteDistributionTest, Performance) {
     volatile double sum = 0.0; // volatile to prevent optimization
 
     for (int i = 0; i < pdfIterations; ++i) {
-        sum += discrete.getProbability(i % 100); // 0 to 99
+        sum = sum + discrete.getProbability(i % 100); // 0 to 99
     }
 
     auto end = std::chrono::high_resolution_clock::now();
@@ -440,7 +440,7 @@ TEST(DiscreteDistributionTest, Performance) {
     volatile double logSum = 0.0;
 
     for (int i = 0; i < pdfIterations; ++i) {
-        logSum += discrete.getLogProbability(i % 100); // 0 to 99
+        logSum = logSum + discrete.getLogProbability(i % 100); // 0 to 99
     }
 
     end = std::chrono::high_resolution_clock::now();

--- a/tests/distributions/test_exponential_distribution.cpp
+++ b/tests/distributions/test_exponential_distribution.cpp
@@ -337,7 +337,7 @@ TEST(ExponentialDistributionTest, PerformanceCharacteristics) {
 
     for (int i = 0; i < pdfIterations; ++i) {
         double x = static_cast<double>(i) / 10000.0;
-        sum += exponential.getProbability(x);
+        sum = sum + exponential.getProbability(x);
     }
 
     auto end = std::chrono::high_resolution_clock::now();
@@ -350,7 +350,7 @@ TEST(ExponentialDistributionTest, PerformanceCharacteristics) {
 
     for (int i = 0; i < pdfIterations; ++i) {
         double x = static_cast<double>(i) / 10000.0;
-        logSum += exponential.getLogProbability(x);
+        logSum = logSum + exponential.getLogProbability(x);
     }
 
     end = std::chrono::high_resolution_clock::now();

--- a/tests/distributions/test_log_normal_distribution.cpp
+++ b/tests/distributions/test_log_normal_distribution.cpp
@@ -428,7 +428,7 @@ TEST(LogNormalDistributionTest, PerformanceCharacteristics) {
     auto start = std::chrono::high_resolution_clock::now();
     volatile double sum_pdf = 0.0;
     for (const auto &val : testValues) {
-        sum_pdf += lognormal.getProbability(val);
+        sum_pdf = sum_pdf + lognormal.getProbability(val);
     }
     auto end = std::chrono::high_resolution_clock::now();
     auto pdf_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
@@ -438,7 +438,7 @@ TEST(LogNormalDistributionTest, PerformanceCharacteristics) {
     start = std::chrono::high_resolution_clock::now();
     volatile double sum_logpdf = 0.0;
     for (const auto &val : testValues) {
-        sum_logpdf += lognormal.getLogProbability(val);
+        sum_logpdf = sum_logpdf + lognormal.getLogProbability(val);
     }
     end = std::chrono::high_resolution_clock::now();
     auto logpdf_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);

--- a/tests/distributions/test_negative_binomial_distribution.cpp
+++ b/tests/distributions/test_negative_binomial_distribution.cpp
@@ -553,7 +553,7 @@ TEST(NegativeBinomialDistributionTest, Performance) {
     volatile double sum = 0.0; // volatile to prevent optimization
 
     for (int i = 0; i < pdfIterations; ++i) {
-        sum += negbinom.getProbability(i % 30); // 0 to 29
+        sum = sum + negbinom.getProbability(i % 30); // 0 to 29
     }
 
     auto end = std::chrono::high_resolution_clock::now();
@@ -565,7 +565,7 @@ TEST(NegativeBinomialDistributionTest, Performance) {
     volatile double logSum = 0.0;
 
     for (int i = 0; i < pdfIterations; ++i) {
-        logSum += negbinom.getLogProbability(i % 30); // 0 to 29
+        logSum = logSum + negbinom.getLogProbability(i % 30); // 0 to 29
     }
 
     end = std::chrono::high_resolution_clock::now();

--- a/tests/distributions/test_pareto_distribution.cpp
+++ b/tests/distributions/test_pareto_distribution.cpp
@@ -430,7 +430,7 @@ TEST(ParetoDistributionTest, PerformanceCharacteristics) {
     auto start = std::chrono::high_resolution_clock::now();
     volatile double sum_pdf = 0.0; // volatile to prevent optimization
     for (const auto &val : testValues) {
-        sum_pdf += pareto.getProbability(val);
+        sum_pdf = sum_pdf + pareto.getProbability(val);
     }
     auto end = std::chrono::high_resolution_clock::now();
     auto pdf_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
@@ -440,7 +440,7 @@ TEST(ParetoDistributionTest, PerformanceCharacteristics) {
     start = std::chrono::high_resolution_clock::now();
     volatile double sum_logpdf = 0.0;
     for (const auto &val : testValues) {
-        sum_logpdf += pareto.getLogProbability(val);
+        sum_logpdf = sum_logpdf + pareto.getLogProbability(val);
     }
     end = std::chrono::high_resolution_clock::now();
     auto logpdf_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);

--- a/tests/distributions/test_poisson_distribution.cpp
+++ b/tests/distributions/test_poisson_distribution.cpp
@@ -265,7 +265,7 @@ TEST(PoissonDistributionTest, Performance) {
     volatile double sum = 0.0; // volatile to prevent optimization
 
     for (int i = 0; i < pdfIterations; ++i) {
-        sum += poisson.getProbability(i % 50); // 0 to 49
+        sum = sum + poisson.getProbability(i % 50); // 0 to 49
     }
 
     auto end = std::chrono::high_resolution_clock::now();
@@ -277,7 +277,7 @@ TEST(PoissonDistributionTest, Performance) {
     volatile double logSum = 0.0;
 
     for (int i = 0; i < pdfIterations; ++i) {
-        logSum += poisson.getLogProbability(i % 50); // 0 to 49
+        logSum = logSum + poisson.getLogProbability(i % 50); // 0 to 49
     }
 
     end = std::chrono::high_resolution_clock::now();

--- a/tests/distributions/test_rayleigh_distribution.cpp
+++ b/tests/distributions/test_rayleigh_distribution.cpp
@@ -231,7 +231,7 @@ TEST(RayleighDistributionTest, PerformanceCharacteristics) {
 
     for (int i = 0; i < pdfIterations; ++i) {
         double x = static_cast<double>(i + 1) / 10000.0; // Range 0.0001 to 10
-        sum += rayleigh.getProbability(x);
+        sum = sum + rayleigh.getProbability(x);
     }
 
     auto end = std::chrono::high_resolution_clock::now();
@@ -244,7 +244,7 @@ TEST(RayleighDistributionTest, PerformanceCharacteristics) {
 
     for (int i = 0; i < pdfIterations; ++i) {
         double x = static_cast<double>(i + 1) / 10000.0; // Range 0.0001 to 10
-        logSum += rayleigh.getLogProbability(x);
+        logSum = logSum + rayleigh.getLogProbability(x);
     }
 
     end = std::chrono::high_resolution_clock::now();

--- a/tests/distributions/test_student_t_distribution.cpp
+++ b/tests/distributions/test_student_t_distribution.cpp
@@ -397,7 +397,7 @@ TEST(StudentTDistributionTest, Performance) {
 
     for (int i = 0; i < pdfIterations; ++i) {
         double x = static_cast<double>(i) / 1000.0 - 5.0; // Range -5 to 5
-        sum += t_dist.getProbability(x);
+        sum = sum + t_dist.getProbability(x);
     }
 
     auto end = std::chrono::high_resolution_clock::now();
@@ -410,7 +410,7 @@ TEST(StudentTDistributionTest, Performance) {
 
     for (int i = 0; i < pdfIterations; ++i) {
         double x = static_cast<double>(i) / 1000.0 - 5.0; // Range -5 to 5
-        logSum += t_dist.getLogProbability(x);
+        logSum = logSum + t_dist.getLogProbability(x);
     }
 
     end = std::chrono::high_resolution_clock::now();

--- a/tests/distributions/test_uniform_distribution.cpp
+++ b/tests/distributions/test_uniform_distribution.cpp
@@ -479,7 +479,7 @@ TEST(UniformDistributionTest, PerformanceCharacteristics) {
 
     for (int i = 0; i < pdfIterations; ++i) {
         double x = 1.0 + static_cast<double>(i) / 20000.0; // Values in [1, 6]
-        sum += uniform.getProbability(x);
+        sum = sum + uniform.getProbability(x);
     }
 
     auto end = std::chrono::high_resolution_clock::now();
@@ -492,7 +492,7 @@ TEST(UniformDistributionTest, PerformanceCharacteristics) {
 
     for (int i = 0; i < pdfIterations; ++i) {
         double x = 1.0 + static_cast<double>(i) / 20000.0; // Values in [1, 6]
-        logSum += uniform.getLogProbability(x);
+        logSum = logSum + uniform.getLogProbability(x);
     }
 
     end = std::chrono::high_resolution_clock::now();

--- a/tests/distributions/test_weibull_distribution.cpp
+++ b/tests/distributions/test_weibull_distribution.cpp
@@ -470,7 +470,7 @@ TEST(WeibullDistributionTest, PerformanceCharacteristics) {
     auto start = std::chrono::high_resolution_clock::now();
     volatile double sum_pdf = 0.0; // volatile to prevent optimization
     for (const auto &val : testValues) {
-        sum_pdf += weibull.getProbability(val);
+        sum_pdf = sum_pdf + weibull.getProbability(val);
     }
     auto end = std::chrono::high_resolution_clock::now();
     auto pdf_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
@@ -479,7 +479,7 @@ TEST(WeibullDistributionTest, PerformanceCharacteristics) {
     start = std::chrono::high_resolution_clock::now();
     volatile double sum_log_pdf = 0.0; // volatile to prevent optimization
     for (const auto &val : testValues) {
-        sum_log_pdf += weibull.getLogProbability(val);
+        sum_log_pdf = sum_log_pdf + weibull.getLogProbability(val);
     }
     end = std::chrono::high_resolution_clock::now();
     auto log_pdf_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
@@ -488,7 +488,7 @@ TEST(WeibullDistributionTest, PerformanceCharacteristics) {
     start = std::chrono::high_resolution_clock::now();
     volatile double sum_cdf = 0.0; // volatile to prevent optimization
     for (const auto &val : testValues) {
-        sum_cdf += weibull.CDF(val);
+        sum_cdf = sum_cdf + weibull.CDF(val);
     }
     end = std::chrono::high_resolution_clock::now();
     auto cdf_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);

--- a/tests/integration/test_end_to_end.cpp
+++ b/tests/integration/test_end_to_end.cpp
@@ -214,7 +214,7 @@ TEST(CasinoEndToEnd, TrainThenDecode_ValidPath) {
     EXPECT_EQ(path.size(), seq.size());
     for (std::size_t i = 0; i < path.size(); ++i) {
         EXPECT_GE(path(i), 0);
-        EXPECT_LT(path(i), hmm->getNumStates());
+        EXPECT_LT(path(i), static_cast<int>(hmm->getNumStatesModern()));
     }
 }
 

--- a/tests/io/test_xml_file_io.cpp
+++ b/tests/io/test_xml_file_io.cpp
@@ -286,7 +286,7 @@ TEST_F(IOTest, XMLFileReaderBasicFunctionality) {
     XMLFileReader reader;
     Hmm readHmm(1);
     ASSERT_NO_THROW(readHmm = reader.read(xmlFile_));
-    EXPECT_EQ(readHmm.getNumStates(), hmm_->getNumStates());
+    EXPECT_EQ(readHmm.getNumStatesModern(), hmm_->getNumStatesModern());
 }
 
 TEST_F(IOTest, XMLFileReaderStringPath) {
@@ -296,7 +296,7 @@ TEST_F(IOTest, XMLFileReaderStringPath) {
     XMLFileReader reader;
     Hmm readHmm(1);
     ASSERT_NO_THROW(readHmm = reader.read(std::string_view{xmlFile_.string()}));
-    EXPECT_EQ(readHmm.getNumStates(), hmm_->getNumStates());
+    EXPECT_EQ(readHmm.getNumStatesModern(), hmm_->getNumStatesModern());
 }
 
 TEST_F(IOTest, XMLFileReaderNonExistentFileThrows) {
@@ -344,11 +344,11 @@ TEST_F(IOTest, XMLRoundTripConsistency) {
     writer.write(*hmm_, xmlFile_);
 
     Hmm readHmm = reader.read(xmlFile_); // throws on failure — no skip
-    EXPECT_EQ(readHmm.getNumStates(), hmm_->getNumStates());
+    EXPECT_EQ(readHmm.getNumStatesModern(), hmm_->getNumStatesModern());
 
     // Distributions should have the same type and approximate parameters
     // (6-decimal-place format means ~1e-6 precision on probability values).
-    for (int i = 0; i < readHmm.getNumStates(); ++i) {
+    for (std::size_t i = 0; i < readHmm.getNumStatesModern(); ++i) {
         const auto *orig = dynamic_cast<const DiscreteDistribution *>(&hmm_->getDistribution(i));
         const auto *rest = dynamic_cast<const DiscreteDistribution *>(&readHmm.getDistribution(i));
         ASSERT_NE(orig, nullptr) << "state " << i;
@@ -376,7 +376,7 @@ TEST_F(IOTest, HMMStreamOperators) {
 
     Hmm readHmm(1);
     ASSERT_NO_THROW(ss >> readHmm);
-    EXPECT_EQ(readHmm.getNumStates(), hmm_->getNumStates());
+    EXPECT_EQ(readHmm.getNumStatesModern(), hmm_->getNumStatesModern());
 
     // Verify the discrete distribution round-trips correctly.
     const auto *orig = dynamic_cast<const DiscreteDistribution *>(&hmm_->getDistribution(0));

--- a/tests/test_hmm_core.cpp
+++ b/tests/test_hmm_core.cpp
@@ -21,16 +21,16 @@ protected:
 // Constructor Tests
 TEST_F(HmmCoreTest, DefaultConstructor) {
     Hmm defaultHmm;
-    EXPECT_EQ(defaultHmm.getNumStates(), 4);
+    EXPECT_EQ(defaultHmm.getNumStatesModern(), 4u);
     EXPECT_NO_THROW(defaultHmm.validate());
 }
 
 TEST_F(HmmCoreTest, SizeConstructor) {
     Hmm hmm3(3);
-    EXPECT_EQ(hmm3.getNumStates(), 3);
+    EXPECT_EQ(hmm3.getNumStatesModern(), 3u);
 
     Hmm hmm5(5);
-    EXPECT_EQ(hmm5.getNumStates(), 5);
+    EXPECT_EQ(hmm5.getNumStatesModern(), 5u);
 }
 
 TEST_F(HmmCoreTest, ZeroStatesThrows) {
@@ -132,10 +132,10 @@ TEST_F(HmmCoreTest, ValidationPasses) {
 // Move Semantics Tests
 TEST_F(HmmCoreTest, MoveConstructor) {
     Hmm original(3);
-    auto originalStates = original.getNumStates();
+    const auto originalStates = original.getNumStatesModern();
 
     Hmm moved = std::move(original);
-    EXPECT_EQ(moved.getNumStates(), originalStates);
+    EXPECT_EQ(moved.getNumStatesModern(), originalStates);
 }
 
 TEST_F(HmmCoreTest, MoveAssignment) {
@@ -143,12 +143,11 @@ TEST_F(HmmCoreTest, MoveAssignment) {
     Hmm source(5);
 
     target = std::move(source);
-    EXPECT_EQ(target.getNumStates(), 5);
+    EXPECT_EQ(target.getNumStatesModern(), 5u);
 }
 
 // Legacy Compatibility Tests
-TEST_F(HmmCoreTest, LegacyIntInterface) {
-    EXPECT_EQ(hmm_->getNumStates(), 2);
+TEST_F(HmmCoreTest, ModernStateCountInterface) {
     EXPECT_EQ(hmm_->getNumStatesModern(), 2u);
 }
 
@@ -158,7 +157,7 @@ TEST_F(HmmCoreTest, BoundaryConditions) {
 
     // Test edge case of 1 state
     Hmm singleState(1);
-    EXPECT_EQ(singleState.getNumStates(), 1);
+    EXPECT_EQ(singleState.getNumStatesModern(), 1u);
     EXPECT_NO_THROW(singleState.validate());
 }
 

--- a/tests/training/test_bw_parity.cpp
+++ b/tests/training/test_bw_parity.cpp
@@ -147,7 +147,7 @@ TEST(BaumWelchParity, OneStepDeterministic_DiscreteN3) {
 
     expectVectorsEqual(hmmA->getPi(), hmmB->getPi(), kBitExactTol);
     expectMatricesEqual(hmmA->getTrans(), hmmB->getTrans(), kBitExactTol);
-    for (int i = 0; i < hmmA->getNumStates(); ++i) {
+    for (std::size_t i = 0; i < hmmA->getNumStatesModern(); ++i) {
         const auto *distA = dynamic_cast<const DiscreteDistribution *>(&hmmA->getDistribution(i));
         const auto *distB = dynamic_cast<const DiscreteDistribution *>(&hmmB->getDistribution(i));
         ASSERT_NE(distA, nullptr);

--- a/tests/training/test_mv_training.cpp
+++ b/tests/training/test_mv_training.cpp
@@ -236,7 +236,7 @@ TEST(KmeansInit, DistributionDimensionsValidAfterInit) {
     auto lists = make_two_cluster_data(15, 8, D, 0.0, 10.0);
     std::mt19937_64 rng(0);
     kmeans_init(hmm, lists, rng);
-    for (int i = 0; i < hmm.getNumStates(); ++i)
+    for (std::size_t i = 0; i < hmm.getNumStatesModern(); ++i)
         EXPECT_EQ(hmm.getDistribution(i).getDimension(), D);
 }
 

--- a/tools/bw_hotspot.cpp
+++ b/tools/bw_hotspot.cpp
@@ -105,7 +105,7 @@ struct BwBreakdown {
 };
 
 BwBreakdown profile_bw(const Hmm &hmm, const ObservationSet &obs, int warmup, int runs) {
-    const std::size_t N = static_cast<std::size_t>(hmm.getNumStates());
+    const std::size_t N = hmm.getNumStatesModern();
     const std::size_t T = obs.size();
 
     // Precompute flat log-transition (row-major N×N) once — same as trainer would do.

--- a/tools/fb_contour_sweep.cpp
+++ b/tools/fb_contour_sweep.cpp
@@ -120,7 +120,7 @@ ObservationSet make_obs(const int t, const int n) {
 
 Timings run_once(const Hmm &hmm, const ObservationSet &obs) {
     Timings out;
-    const std::size_t n = static_cast<std::size_t>(hmm.getNumStates());
+    const std::size_t n = hmm.getNumStatesModern();
     const std::size_t t = obs.size();
 
     auto total_start = Clock::now();

--- a/tools/hmm_validator.cpp
+++ b/tools/hmm_validator.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    const int N = hmm.getNumStates();
+    const auto N = static_cast<int>(hmm.getNumStatesModern());
     std::cout << "\nHMM summary:\n";
     std::cout << "  States: " << N << "\n";
 

--- a/tools/hotspot_breakdown.cpp
+++ b/tools/hotspot_breakdown.cpp
@@ -128,7 +128,7 @@ ObservationSet make_obs(const int t, const int n) {
 
 ForwardBreakdown profile_forward_backward(const Hmm &hmm, const ObservationSet &obs,
                                           const int warmup, const int runs) {
-    const std::size_t n = static_cast<std::size_t>(hmm.getNumStates());
+    const std::size_t n = hmm.getNumStatesModern();
     const std::size_t t = obs.size();
 
     std::vector<double> transition_ms;
@@ -293,7 +293,7 @@ ForwardBreakdown profile_forward_backward(const Hmm &hmm, const ObservationSet &
 
 ViterbiBreakdown profile_viterbi(const Hmm &hmm, const ObservationSet &obs, const int warmup,
                                  const int runs) {
-    const std::size_t n = static_cast<std::size_t>(hmm.getNumStates());
+    const std::size_t n = hmm.getNumStatesModern();
     const std::size_t t = obs.size();
 
     std::vector<double> transition_ms;


### PR DESCRIPTION
Addresses the valid findings from the June 2026 architectural review. All 46 tests pass; zero warnings from library or test code.

## Changes

### Group 1 — Structural cleanups

**`include/libhmm/detail/` — new private-header directory (excluded from install)**
- `log_utils.h`: canonical `LOG_ZERO` and `logSumExp`. All four algorithm classes (`BasicForwardBackwardCalculator`, `BasicViterbiCalculator`, `BasicBaumWelchTrainer`, `BasicMapBaumWelchTrainer`) now alias `detail::LOG_ZERO` and delegate `logSumExp` to `detail::logSumExp`. Eliminates four independent `LOG_ZERO` definitions and two independent `logSumExp` bodies, removing the latent E-step divergence risk called out by the review.
- `simd_kernels_internal.h` (moved from `include/libhmm/performance/`): header is still included only from SIMD-flagged `.cpp` files but now lives in a directory excluded from `cmake install`, making the boundary enforceable rather than comment-enforced. The four `#define`/`#undef` FMA-emulation macro pairs (`K_FMA256`/`K_MA256` and `K_FMA128`/`K_MA128` — both pairs were identical) are replaced with two `static inline` functions (`k_fmadd_pd_avx`, `k_fmadd_pd_sse2`).

**`getNumStates()` deprecation**: `[[deprecated]]` added to `BasicHmm::getNumStates()`; all call sites in the library, examples, tests, and tools migrated to `getNumStatesModern()`.

**`Clusters::Value` simplification**: the single-field `Value` wrapper class in `SegmentalKMeansTrainer` is replaced with a direct `std::unordered_map<std::size_t, std::size_t>`.

### Group 2 — `distribution_traits.h` retirement

The file was annotated "retained for backward compatibility" but its `supports_fitting` trait checked `fit(std::vector<double>&)` (wrong signature), `VonMisesDistribution` was absent from the discrete/continuous classification lists, and `trainer_selector` mapped types to `int` constants that were never consumed anywhere. Deleted the header, its test file, and its `#include` from `distributions.h`.

### Branch hygiene
Pruned `feature/v3.8.0` (fully merged into main) and `perf/trainers-calculators-phase1` (old v3.x benchmarking work, no remote, superseded).

Added `.cache/` and `*.synctex.gz` to `.gitignore`.

---
[Warp conversation](https://app.warp.dev/conversation/11a15fdc-5932-4c9c-84b4-34ef6e69b089)