### PR TITLE
fix: audit findings C-1, H-1, H-2, M-2 (v4.0.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,34 @@ jobs:
       run: ctest --test-dir build -C Release --output-on-failure --timeout 60 -LE "known_broken|benchmark"
 
   # ---------------------------------------------------------------------------
+  # ThreadSanitizer — catches data races (e.g. concurrent cache fills).
+  # Linux/GCC only: TSan on macOS/AppleClang is unreliable with system libraries.
+  # -O1 keeps stack frames intact for readable reports; BUILD_TESTS=ON required.
+  # ---------------------------------------------------------------------------
+  tsan:
+    name: ThreadSanitizer (Linux / GCC)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure with TSan
+      run: |
+        cmake -B build-tsan \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DCMAKE_CXX_FLAGS="-fsanitize=thread -g -O1" \
+          -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBUILD_EXAMPLES=OFF \
+          -DBUILD_TOOLS=OFF
+
+    - name: Build
+      run: cmake --build build-tsan --parallel
+
+    - name: Test
+      run: ctest --test-dir build-tsan -C RelWithDebInfo --output-on-failure --timeout 120 -LE "known_broken|benchmark"
+
+  # ---------------------------------------------------------------------------
   # Quality jobs — ubuntu only; run independently of the build matrix.
   # pre-commit mirrors local hook policy. cppcheck remains a dedicated analysis step.
   # ---------------------------------------------------------------------------

--- a/cmake/libhmmConfig.cmake.in
+++ b/cmake/libhmmConfig.cmake.in
@@ -17,9 +17,6 @@ set(LIBHMM_LIBRARIES libhmm::hmm)
 # Check that all required components are available
 check_required_components(libhmm)
 
-# Find required dependencies
-find_dependency(Boost REQUIRED)
-
 # Set include directories
 if(NOT TARGET libhmm::hmm)
   add_library(libhmm::hmm INTERFACE IMPORTED)

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -340,7 +340,7 @@ Use **Doxygen-style comments** for all public interfaces:
  * @return Probability density at the given value
  * @throws std::invalid_argument if value is NaN or infinite
  *
- * @note This method is thread-safe and uses cached normalization constants
+ * @note Thread-safe for concurrent reads; cache fills are serialized by an internal mutex
  * @complexity O(1) - constant time computation
  *
  * @example
@@ -370,7 +370,7 @@ double getProbability(double value) override;
  * - Support: x ∈ (-∞, ∞)
  * - Symmetry: Symmetric around μ
  *
- * @note Thread-safe for read operations, not thread-safe for modifications
+ * @note Thread-safe for concurrent read operations; modifications are not thread-safe
  * @note Uses efficient caching for repeated probability calculations
  *
  * @example Basic usage:

--- a/include/libhmm/distributions/beta_distribution.h
+++ b/include/libhmm/distributions/beta_distribution.h
@@ -23,6 +23,8 @@ namespace libhmm {
  * - α > β: Skewed toward 1
  */
 class BetaDistribution : public DistributionBase<BetaDistribution> {
+    friend class DistributionBase<BetaDistribution>;
+
 private:
     /**
      * Shape parameter α (alpha) - must be positive

--- a/include/libhmm/distributions/binomial_distribution.h
+++ b/include/libhmm/distributions/binomial_distribution.h
@@ -18,6 +18,8 @@ namespace libhmm {
  * - Support: k ∈ {0, 1, 2, ..., n}
  */
 class BinomialDistribution : public DistributionBase<BinomialDistribution> {
+    friend class DistributionBase<BinomialDistribution>;
+
 private:
     /** Number of trials n - must be a positive integer */
     int n_{10};
@@ -52,8 +54,7 @@ private:
     double logBinomialCoefficient(int n, int k) const {
         if (k < 0 || k > n)
             return -std::numeric_limits<double>::infinity();
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         const auto un = static_cast<std::size_t>(n);
         const auto uk = static_cast<std::size_t>(k);
         return logFactorialCache_[un] - logFactorialCache_[uk] - logFactorialCache_[un - uk];

--- a/include/libhmm/distributions/chi_squared_distribution.h
+++ b/include/libhmm/distributions/chi_squared_distribution.h
@@ -30,6 +30,8 @@ namespace libhmm {
  * - Likelihood ratio tests
  */
 class ChiSquaredDistribution : public DistributionBase<ChiSquaredDistribution> {
+    friend class DistributionBase<ChiSquaredDistribution>;
+
 private:
     /**
      * Degrees of freedom parameter k - must be positive

--- a/include/libhmm/distributions/discrete_distribution.h
+++ b/include/libhmm/distributions/discrete_distribution.h
@@ -31,6 +31,8 @@ namespace libhmm {
  * - Any scenario with discrete, mutually exclusive outcomes
  */
 class DiscreteDistribution : public DistributionBase<DiscreteDistribution> {
+    friend class DistributionBase<DiscreteDistribution>;
+
 private:
     /**
      * Number of discrete symbols/categories
@@ -238,18 +240,15 @@ public:
      * @return Sum of all probabilities
      */
     double getProbabilitySum() const {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return cachedSum_;
     }
     double getEntropy() const {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return cachedEntropy_;
     }
     std::size_t getMode() const {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return cachedMode_;
     }
 
@@ -295,8 +294,7 @@ public:
      * Useful after manual probability modifications.
      */
     void normalize() {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         if (cachedSum_ > 0.0) {
             for (double &p : pdf_)
                 p /= cachedSum_;

--- a/include/libhmm/distributions/distribution_base.h
+++ b/include/libhmm/distributions/distribution_base.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <mutex>
 #include <cstddef>
 #include <memory>
 #include <span>
@@ -142,12 +143,25 @@ protected:
     // =========================================================================
     // Thread-safe cache management
     //
-    // Use std::atomic<bool> rather than plain mutable bool because the
-    // calculator thread pool can trigger concurrent const reads of the same
-    // distribution. Plain bool would be a data race under concurrent reads
-    // that cause a cache fill.
+    // cacheValid_ is a std::atomic<bool> (not a plain bool) so that the
+    // fast-path check in ensureCache() is a lock-free acquire load visible
+    // to all threads. cacheMutex_ serializes concurrent first-fills: two
+    // threads racing on a cold cache both pass the atomic check, then one
+    // acquires the mutex and fills while the other blocks; the second
+    // re-checks under the lock and skips the fill. After the fill,
+    // markCacheValid() does a release store so subsequent acquire loads
+    // from any thread see all cached fields written by updateCache().
+    //
+    // Memory ordering:
+    //   - isCacheValid() load: acquire — cached values visible before flag
+    //   - markCacheValid() store: release — updateCache() writes visible to readers
+    //   - invalidateCache() store: relaxed — invalidation needs no ordering
+    //
+    // cacheMutex_ is not copied or moved: each object constructs its own
+    // independent mutex via the explicit copy/move constructors below.
     // =========================================================================
     mutable std::atomic<bool> cacheValid_{false};
+    mutable std::mutex cacheMutex_;
 
     /** Mark cache as stale. Call from setters and fit(). */
     void invalidateCache() noexcept { cacheValid_.store(false, std::memory_order_relaxed); }
@@ -159,6 +173,27 @@ protected:
 
     /** Mark cache as valid. Call at end of updateCache(). */
     void markCacheValid() const noexcept { cacheValid_.store(true, std::memory_order_release); }
+
+    // =========================================================================
+    // ensureCache() — CRTP double-checked-locking fill helper
+    //
+    // Replace every `if (!isCacheValid()) updateCache();` in derived-class
+    // const methods with a single `ensureCache();` call. The atomic fast
+    // path avoids lock acquisition once the cache is warm; the mutex
+    // serializes concurrent first-fills so cached fields are never written
+    // by two threads simultaneously.
+    //
+    // Derived-class updateCache() must call markCacheValid() at the end and
+    // must not call ensureCache() itself (would deadlock on cacheMutex_).
+    // =========================================================================
+    void ensureCache() const noexcept {
+        if (!cacheValid_.load(std::memory_order_acquire)) {
+            std::lock_guard<std::mutex> lock(cacheMutex_);
+            if (!cacheValid_.load(std::memory_order_acquire)) {
+                static_cast<const Derived *>(this)->updateCache();
+            }
+        }
+    }
 };
 
 } // namespace libhmm

--- a/include/libhmm/distributions/exponential_distribution.h
+++ b/include/libhmm/distributions/exponential_distribution.h
@@ -24,6 +24,8 @@ namespace libhmm {
  * - Memoryless property: P(X > s+t | X > s) = P(X > t)
  */
 class ExponentialDistribution : public DistributionBase<ExponentialDistribution> {
+    friend class DistributionBase<ExponentialDistribution>;
+
 private:
     /**
      * Rate parameter λ - must be positive
@@ -167,23 +169,19 @@ public:
      * @return Mean value
      */
     double getMean() const noexcept {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return invLambda_;
     }
     double getVariance() const noexcept {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return invLambdaSquared_;
     }
     double getStandardDeviation() const noexcept {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return invLambda_;
     }
     double getScale() const noexcept {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return invLambda_;
     }
 

--- a/include/libhmm/distributions/gamma_distribution.h
+++ b/include/libhmm/distributions/gamma_distribution.h
@@ -28,6 +28,8 @@ namespace libhmm {
  * - Special cases: k=1 gives exponential distribution, k→∞ approaches normal
  */
 class GammaDistribution : public DistributionBase<GammaDistribution> {
+    friend class DistributionBase<GammaDistribution>;
+
 private:
     /**
      * Shape parameter k - must be positive

--- a/include/libhmm/distributions/gaussian_distribution.h
+++ b/include/libhmm/distributions/gaussian_distribution.h
@@ -18,6 +18,8 @@ namespace libhmm {
  *   - Weighted fit() added for Baum-Welch M-step
  */
 class GaussianDistribution : public DistributionBase<GaussianDistribution> {
+    friend class DistributionBase<GaussianDistribution>;
+
 private:
     /**
      * Mean parameter μ - can be any finite real number

--- a/include/libhmm/distributions/log_normal_distribution.h
+++ b/include/libhmm/distributions/log_normal_distribution.h
@@ -29,6 +29,8 @@ namespace libhmm {
  * - Support: x ∈ (0, ∞)
  */
 class LogNormalDistribution : public DistributionBase<LogNormalDistribution> {
+    friend class DistributionBase<LogNormalDistribution>;
+
 private:
     /**
      * Mean parameter μ of the underlying normal distribution (mean of ln(X))

--- a/include/libhmm/distributions/negative_binomial_distribution.h
+++ b/include/libhmm/distributions/negative_binomial_distribution.h
@@ -26,6 +26,8 @@ namespace libhmm {
  * - Support: k ∈ {0, 1, 2, ...}
  */
 class NegativeBinomialDistribution : public DistributionBase<NegativeBinomialDistribution> {
+    friend class DistributionBase<NegativeBinomialDistribution>;
+
 private:
     /**
      * Number of successes r - must be positive
@@ -83,8 +85,7 @@ private:
             return -std::numeric_limits<double>::infinity();
 
         // Ensure cache is valid
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         // log C(k+r-1, k) = log Γ(k+r) - log Γ(k+1) - log Γ(r)
         //                 = log Γ(k+r) - log k! - log Γ(r)
         const double logGammaKPlusR = std::lgamma(k + r_);

--- a/include/libhmm/distributions/pareto_distribution.h
+++ b/include/libhmm/distributions/pareto_distribution.h
@@ -26,6 +26,8 @@ namespace libhmm {
  * - Heavy-tailed distribution (polynomial decay)
  */
 class ParetoDistribution : public DistributionBase<ParetoDistribution> {
+    friend class DistributionBase<ParetoDistribution>;
+
 private:
     /**
      * Shape parameter k - must be positive

--- a/include/libhmm/distributions/poisson_distribution.h
+++ b/include/libhmm/distributions/poisson_distribution.h
@@ -18,6 +18,8 @@ namespace libhmm {
  * where λ (lambda) is the rate parameter (mean number of events per interval)
  */
 class PoissonDistribution : public DistributionBase<PoissonDistribution> {
+    friend class DistributionBase<PoissonDistribution>;
+
 private:
     /**
      * Rate parameter λ (lambda) - average number of events per interval.
@@ -171,8 +173,7 @@ public:
      * @return Standard deviation
      */
     double getStandardDeviation() const noexcept {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return sqrtLambda_;
     }
 

--- a/include/libhmm/distributions/rayleigh_distribution.h
+++ b/include/libhmm/distributions/rayleigh_distribution.h
@@ -34,6 +34,8 @@ namespace libhmm {
  * - Communications (fading channel modeling)
  */
 class RayleighDistribution : public DistributionBase<RayleighDistribution> {
+    friend class DistributionBase<RayleighDistribution>;
+
 private:
     /**
      * Scale parameter σ (sigma) - must be positive
@@ -182,13 +184,11 @@ public:
      * @return Mean value
      */
     double getMean() const noexcept {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return mean_;
     }
     double getVariance() const noexcept {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return variance_;
     }
 

--- a/include/libhmm/distributions/student_t_distribution.h
+++ b/include/libhmm/distributions/student_t_distribution.h
@@ -29,6 +29,8 @@ namespace libhmm {
  * - Robust regression analysis
  */
 class StudentTDistribution : public DistributionBase<StudentTDistribution> {
+    friend class DistributionBase<StudentTDistribution>;
+
 private:
     /**
      * Degrees of freedom parameter ν - must be positive

--- a/include/libhmm/distributions/uniform_distribution.h
+++ b/include/libhmm/distributions/uniform_distribution.h
@@ -25,6 +25,8 @@ namespace libhmm {
  * - Support: x ∈ [a, b]
  */
 class UniformDistribution : public DistributionBase<UniformDistribution> {
+    friend class DistributionBase<UniformDistribution>;
+
 private:
     double a_; ///< Lower bound
     double b_; ///< Upper bound

--- a/include/libhmm/distributions/von_mises_distribution.h
+++ b/include/libhmm/distributions/von_mises_distribution.h
@@ -38,6 +38,8 @@ namespace libhmm {
  * - Speech / audio phase modelling
  */
 class VonMisesDistribution : public DistributionBase<VonMisesDistribution> {
+    friend class DistributionBase<VonMisesDistribution>;
+
 private:
     /**
      * Mean direction μ — maintained in (−π, π].
@@ -162,8 +164,7 @@ public:
      * 0 = perfectly concentrated; 1 = uniform.
      */
     [[nodiscard]] double getCircularVariance() const noexcept {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return circularVariance_;
     }
 

--- a/include/libhmm/distributions/weibull_distribution.h
+++ b/include/libhmm/distributions/weibull_distribution.h
@@ -30,6 +30,8 @@ namespace libhmm {
  * - Materials science (strength of materials)
  */
 class WeibullDistribution : public DistributionBase<WeibullDistribution> {
+    friend class DistributionBase<WeibullDistribution>;
+
 private:
     /**
      * Shape parameter k - must be positive

--- a/src/distributions/beta_distribution.cpp
+++ b/src/distributions/beta_distribution.cpp
@@ -23,8 +23,7 @@ double BetaDistribution::getProbability(double value) const {
     }
 
     // Update cache if needed
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     // Handle boundary cases - use cached invBeta_
     if (value == math::ZERO_DOUBLE) {
         return (alpha_ == math::ONE) ? invBeta_ : math::ZERO_DOUBLE;
@@ -100,8 +99,7 @@ double BetaDistribution::getLogProbability(double value) const noexcept {
     }
 
     // Update cache if needed
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     // Handle boundary cases carefully
     if (value == 0.0) {
         if (alpha_ == 1.0) {
@@ -369,8 +367,7 @@ void BetaDistribution::getBatchLogProbabilities(std::span<const double> observat
     // Tier 2 upgrade requires vectorised lgamma (log B(α,β) = lgamma(α)+lgamma(β)-lgamma(α+β)):
     // available via Intel SVML or platform-specific math libraries, but not
     // portably available without a dedicated math-library dependency.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = BetaDistribution::getLogProbability(observations[i]);
     }

--- a/src/distributions/binomial_distribution.cpp
+++ b/src/distributions/binomial_distribution.cpp
@@ -38,8 +38,7 @@ double BinomialDistribution::getProbability(double value) const {
     }
 
     // Ensure cache is valid
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     const double logCoeff = logBinomialCoefficient(n_, k);
     const double logProb =
         logCoeff + static_cast<double>(k) * logP_ + static_cast<double>(n_ - k) * log1MinusP_;
@@ -173,8 +172,7 @@ double BinomialDistribution::getLogProbability(double value) const noexcept {
     }
 
     // Ensure cache is valid
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     const double logCoeff = logBinomialCoefficient(n_, k);
     return logCoeff + static_cast<double>(k) * logP_ + static_cast<double>(n_ - k) * log1MinusP_;
 }
@@ -246,8 +244,7 @@ void BinomialDistribution::getBatchLogProbabilities(std::span<const double> obse
     // Tier 2 upgrade requires vectorised log-binomial-coefficient (uses lgamma internally):
     // available via Intel SVML or platform-specific math libraries, but not
     // portably available without a dedicated math-library dependency.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = BinomialDistribution::getLogProbability(observations[i]);
     }

--- a/src/distributions/chi_squared_distribution.cpp
+++ b/src/distributions/chi_squared_distribution.cpp
@@ -9,8 +9,7 @@ using namespace libhmm::constants;
 namespace libhmm {
 
 double ChiSquaredDistribution::getProbability(double value) const {
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     const double x = value;
     if (!std::isfinite(x))
         return math::ZERO_DOUBLE;
@@ -39,8 +38,7 @@ double ChiSquaredDistribution::getProbability(double value) const {
 }
 
 double ChiSquaredDistribution::getLogProbability(double value) const noexcept {
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     const double x = value;
 
     // Handle invalid inputs
@@ -165,8 +163,7 @@ void ChiSquaredDistribution::getBatchLogProbabilities(std::span<const double> ob
     // lgamma(k/2) is precomputed in the cache, but the per-element (k/2-1)*log(x)
     // term needs vectorised log(x)): available via Intel SVML or platform-specific
     // math libraries, but not portably available without a math-library dependency.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = ChiSquaredDistribution::getLogProbability(observations[i]);
     }

--- a/src/distributions/discrete_distribution.cpp
+++ b/src/distributions/discrete_distribution.cpp
@@ -126,8 +126,7 @@ double DiscreteDistribution::getLogProbability(double value) const noexcept {
         return -std::numeric_limits<double>::infinity();
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     return cachedLogProbs_[index];
 }
 
@@ -152,8 +151,7 @@ double DiscreteDistribution::getCumulativeProbability(double value) const noexce
         return math::ONE;
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     return cachedCDF_[k];
 }
 
@@ -218,8 +216,7 @@ void DiscreteDistribution::getBatchLogProbabilities(std::span<const double> obse
     // the index lookups, but the per-element index-validation branch limits
     // vectorization benefit. The cached log-probability table is already optimal
     // for the scalar case.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = DiscreteDistribution::getLogProbability(observations[i]);
     }

--- a/src/distributions/exponential_distribution.cpp
+++ b/src/distributions/exponential_distribution.cpp
@@ -35,8 +35,7 @@ double ExponentialDistribution::getProbability(double value) const {
         return lambda_;
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     return lambda_ * std::exp(negLambda_ * value);
 }
 
@@ -54,8 +53,7 @@ double ExponentialDistribution::getLogProbability(double value) const noexcept {
         return -std::numeric_limits<double>::infinity();
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     return logLambda_ - lambda_ * value;
 }
 
@@ -281,8 +279,7 @@ void exponential_logpdf_batch(const double *obs, double *out, std::size_t n, dou
 
 void ExponentialDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                        std::span<double> out) const {
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     detail::exponential_logpdf_batch(observations.data(), out.data(), observations.size(),
                                      logLambda_, negLambda_);
 }

--- a/src/distributions/gamma_distribution.cpp
+++ b/src/distributions/gamma_distribution.cpp
@@ -20,8 +20,7 @@ double GammaDistribution::getProbability(double x) const {
         return 0.0;
     if (x == 0.0)
         return (k_ < 1.0) ? std::numeric_limits<double>::infinity() : 0.0;
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
 
     // Use log space for numerical stability then exponentiate
     const double logPdf = getLogProbability(x);
@@ -51,8 +50,7 @@ double GammaDistribution::getLogProbability(double x) const noexcept {
                           : -std::numeric_limits<double>::infinity();
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     // log PDF(x) = (k-1)*ln(x) - x/θ - k*ln(θ) - ln(Γ(k))
     const double logPdf = kMinus1_ * std::log(x) - x / theta_ - kLogTheta_ - logGammaK_;
 
@@ -243,8 +241,7 @@ void GammaDistribution::getBatchLogProbabilities(std::span<const double> observa
     // (k-1)*log(x) - x/θ, which needs a vectorised log — available via Intel SVML,
     // GNU libmvec, or Apple Accelerate vvlog, but not portably without a
     // math-library dependency.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = GammaDistribution::getLogProbability(observations[i]);
     }

--- a/src/distributions/gaussian_distribution.cpp
+++ b/src/distributions/gaussian_distribution.cpp
@@ -18,9 +18,7 @@ double GaussianDistribution::getProbability(double x) const {
     if (std::isnan(x) || std::isinf(x)) {
         return 0.0;
     }
-    if (!isCacheValid()) {
-        updateCache();
-    }
+    ensureCache();
 
     const double exponent = (x - mean_) * (x - mean_) * negHalfSigmaSquaredInv_;
     return normalizationConstant_ * std::exp(exponent);
@@ -36,9 +34,7 @@ double GaussianDistribution::getLogProbability(double x) const noexcept {
         return -std::numeric_limits<double>::infinity();
     }
 
-    if (!isCacheValid()) {
-        updateCache();
-    }
+    ensureCache();
     // Use cached values for maximum performance
     const double z = (x - mean_) * invStandardDeviation_;
     const double logPdf = -0.5 * math::LN_2PI - logStandardDeviation_ - 0.5 * z * z;
@@ -65,9 +61,7 @@ double GaussianDistribution::getCumulativeProbability(double x) const noexcept {
         return (x >= mean_) ? 1.0 : 0.0;
     }
 
-    if (!isCacheValid()) {
-        updateCache();
-    }
+    ensureCache();
     // Use cached sigma*sqrt(2) for efficiency
     const double y = 0.5 * (1 + std::erf((x - mean_) / sigmaSqrt2_));
 
@@ -327,8 +321,7 @@ double GaussianDistribution::sample(std::mt19937_64 &rng) const {
 
 void GaussianDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                     std::span<double> out) const {
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     const double log_norm = -0.5 * math::LN_2PI - logStandardDeviation_;
     detail::gaussian_logpdf_batch(observations.data(), out.data(), observations.size(), mean_,
                                   negHalfSigmaSquaredInv_, log_norm);

--- a/src/distributions/log_normal_distribution.cpp
+++ b/src/distributions/log_normal_distribution.cpp
@@ -24,8 +24,7 @@ namespace libhmm {
 double LogNormalDistribution::getProbability(double x) const {
     if (std::isnan(x) || std::isinf(x) || x <= math::ZERO_DOUBLE)
         return math::ZERO_DOUBLE;
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
 
     // Use direct PDF calculation for better performance
     // f(x) = 1/(x*σ*√(2π)) * exp(-½*((ln(x)-μ)/σ)²)
@@ -55,8 +54,7 @@ double LogNormalDistribution::getLogProbability(double value) const noexcept {
         return -std::numeric_limits<double>::infinity();
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     const double logX = std::log(value);
     const double delta = logX - mean_;
     return -logX - logNormalizationConstant_ + negHalfSigmaSquaredInv_ * delta * delta;
@@ -311,8 +309,7 @@ void lognormal_logpdf_batch(const double *obs, double *out, std::size_t n, doubl
 void LogNormalDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                      std::span<double> out) const {
     // Tier 2 — explicit SIMD via simd_kernels_internal.h
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     detail::lognormal_logpdf_batch(observations.data(), out.data(), observations.size(), mean_,
                                    negHalfSigmaSquaredInv_, logNormalizationConstant_);
 }

--- a/src/distributions/negative_binomial_distribution.cpp
+++ b/src/distributions/negative_binomial_distribution.cpp
@@ -36,8 +36,7 @@ double NegativeBinomialDistribution::getProbability(double value) const {
         return (k == 0) ? math::ONE : math::ZERO_DOUBLE;
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     const double logCoeff = logGeneralizedBinomialCoefficient(k);
     const double logProb = logCoeff + r_ * logP_ + static_cast<double>(k) * log1MinusP_;
     const double prob = std::exp(logProb);
@@ -248,8 +247,7 @@ double NegativeBinomialDistribution::getLogProbability(double value) const noexc
         return (k == 0) ? math::ZERO_DOUBLE : -std::numeric_limits<double>::infinity();
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     const double logCoeff = logGeneralizedBinomialCoefficient(k);
     return logCoeff + r_ * logP_ + static_cast<double>(k) * log1MinusP_;
 }
@@ -322,8 +320,7 @@ void NegativeBinomialDistribution::getBatchLogProbabilities(std::span<const doub
     // Tier 2 upgrade requires vectorised generalised log-binomial-coefficient
     // (uses lgamma internally): available via Intel SVML or platform-specific
     // math libraries, but not portably without a math-library dependency.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = NegativeBinomialDistribution::getLogProbability(observations[i]);
     }

--- a/src/distributions/pareto_distribution.cpp
+++ b/src/distributions/pareto_distribution.cpp
@@ -23,8 +23,7 @@ namespace libhmm {
 double ParetoDistribution::getProbability(double x) const {
     if (std::isnan(x) || std::isinf(x) || x < xm_)
         return math::ZERO_DOUBLE;
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
 
     // Direct PDF calculation: f(x) = (k * x_m^k) / x^(k+1)
     // Using cached kXmPowK_ = k * x_m^k and kPlus1_ = k + 1 for efficiency
@@ -51,16 +50,14 @@ double ParetoDistribution::getLogProbability(double value) const noexcept {
         return -std::numeric_limits<double>::infinity();
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     return logK_ + kLogXm_ - kPlus1_ * std::log(value);
 }
 
 double ParetoDistribution::getCumulativeProbability(double value) const noexcept {
     if (std::isnan(value) || value < xm_)
         return math::ZERO_DOUBLE;
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
 
     return math::ONE - std::pow(xm_ / value, k_);
 }
@@ -288,8 +285,7 @@ void pareto_logpdf_batch(const double *obs, double *out, std::size_t n, double x
 void ParetoDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                   std::span<double> out) const {
     // Tier 2 — explicit SIMD via simd_kernels_internal.h
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     // logK_ + kLogXm_ is a single scalar constant — compute once.
     detail::pareto_logpdf_batch(observations.data(), out.data(), observations.size(), xm_,
                                 logK_ + kLogXm_, kPlus1_);

--- a/src/distributions/poisson_distribution.cpp
+++ b/src/distributions/poisson_distribution.cpp
@@ -19,8 +19,7 @@ double PoissonDistribution::logFactorial(int k) const noexcept {
     if (k < 0)
         return -std::numeric_limits<double>::infinity();
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     if (k <= 12) {
         return std::log(smallFactorials_[k]);
     }
@@ -35,8 +34,7 @@ double PoissonDistribution::getProbability(double value) const {
     if (!isValidCount(value))
         return 0.0;
     const auto k = static_cast<int>(value);
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
 
     // Handle edge cases - use cached exp(-lambda) for efficiency
     if (k == 0) {
@@ -138,8 +136,7 @@ double PoissonDistribution::getLogProbability(double value) const noexcept {
 
     const auto k = static_cast<int>(value);
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     const double logProb = k * logLambda_ - lambda_ - logFactorial(k);
 
     return logProb;
@@ -164,8 +161,7 @@ double PoissonDistribution::getCumulativeProbability(double k) const noexcept {
     // For very large k or lambda, the cumulative sum becomes computationally expensive
     // and numerically unstable. In such cases, use normal approximation.
     if (kInt > 100 && lambda_ > 100.0) {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         // Normal approximation with continuity correction
         // Use cached sqrt(lambda) for efficiency
         const double z = (static_cast<double>(kInt) + 0.5 - lambda_) * invSqrtLambda_;
@@ -228,8 +224,7 @@ void PoissonDistribution::getBatchLogProbabilities(std::span<const double> obser
     // via Intel SVML or platform-specific math libraries, but not portably
     // without a math-library dependency. A small-k lookup table (k ≤ 20) could
     // serve as a portable partial optimisation.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = PoissonDistribution::getLogProbability(observations[i]);
     }

--- a/src/distributions/rayleigh_distribution.cpp
+++ b/src/distributions/rayleigh_distribution.cpp
@@ -19,8 +19,7 @@ using namespace constants;
 double RayleighDistribution::getProbability(double value) const {
     if (value < constants::math::ZERO_DOUBLE || std::isnan(value) || std::isinf(value))
         return constants::math::ZERO_DOUBLE;
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
 
     // PDF calculation
     return (value * invSigmaSquared_) * std::exp(negHalfInvSigmaSquared_ * value * value);
@@ -39,8 +38,7 @@ double RayleighDistribution::getLogProbability(double value) const noexcept {
         return -std::numeric_limits<double>::infinity();
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     return std::log(value) - constants::math::TWO * logSigma_ +
            negHalfInvSigmaSquared_ * value * value;
 }
@@ -48,8 +46,7 @@ double RayleighDistribution::getLogProbability(double value) const noexcept {
 double RayleighDistribution::getCumulativeProbability(double value) const noexcept {
     if (value < constants::math::ZERO_DOUBLE)
         return constants::math::ZERO_DOUBLE;
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
 
     return constants::math::ONE - std::exp(negHalfInvSigmaSquared_ * value * value);
 }
@@ -165,8 +162,7 @@ void RayleighDistribution::getBatchLogProbabilities(std::span<const double> obse
     // Gaussian tier 2 but with an extra log(x) term. Available via Intel SVML,
     // GNU libmvec, or Apple Accelerate vvlog, but not portably without a
     // math-library dependency.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = RayleighDistribution::getLogProbability(observations[i]);
     }

--- a/src/distributions/student_t_distribution.cpp
+++ b/src/distributions/student_t_distribution.cpp
@@ -28,8 +28,7 @@ StudentTDistribution::StudentTDistribution(double degrees_of_freedom, double loc
 }
 
 double StudentTDistribution::getProbability(double value) const {
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     if (!std::isfinite(value))
         return math::ZERO_DOUBLE;
     const double x = value;
@@ -52,8 +51,7 @@ double StudentTDistribution::getProbability(double value) const {
 double StudentTDistribution::getLogProbability(double value) const noexcept {
     if (!std::isfinite(value))
         return -std::numeric_limits<double>::infinity();
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     const double z = (value - location_) * cached_inv_scale_;
     // Optimized log PDF
     // log(f(x|ν,μ,σ)) = cached_log_normalization - ((ν+1)/2) * log(1 + z²/ν)
@@ -76,8 +74,7 @@ double StudentTDistribution::getCumulativeProbability(double value) const noexce
         return (std::isnan(value) || value < math::ZERO_DOUBLE) ? math::ZERO_DOUBLE : math::ONE;
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     const double t = (value - location_) * cached_inv_scale_;
 
     // Exact CDF via regularised incomplete beta:
@@ -396,8 +393,7 @@ void StudentTDistribution::getBatchLogProbabilities(std::span<const double> obse
     // so the per-element work is log(1 + t²/ν) — requires vectorised log.
     // Available via Intel SVML, GNU libmvec, or Apple Accelerate vvlog, but
     // not portably without a math-library dependency.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = StudentTDistribution::getLogProbability(observations[i]);
     }

--- a/src/distributions/uniform_distribution.cpp
+++ b/src/distributions/uniform_distribution.cpp
@@ -44,8 +44,7 @@ double UniformDistribution::getProbability(double val) const {
     if (std::isnan(val) || std::isinf(val))
         return math::ZERO_DOUBLE;
     if (val >= a_ && val <= b_) {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return cached_pdf_;
     }
     return math::ZERO_DOUBLE;
@@ -55,8 +54,7 @@ double UniformDistribution::getLogProbability(double val) const noexcept {
     if (std::isnan(val) || std::isinf(val))
         return -std::numeric_limits<double>::infinity();
     if (val >= a_ && val <= b_) {
-        if (!isCacheValid())
-            updateCache();
+        ensureCache();
         return cached_log_pdf_;
     }
     return -std::numeric_limits<double>::infinity();
@@ -170,20 +168,17 @@ void UniformDistribution::setParameters(double a, double b) {
 }
 
 double UniformDistribution::getMean() const {
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     return cached_mean_;
 }
 
 double UniformDistribution::getVariance() const {
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     return cached_variance_;
 }
 
 double UniformDistribution::getStandardDeviation() const {
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     return cached_std_dev_;
 }
 
@@ -227,8 +222,7 @@ void UniformDistribution::getBatchLogProbabilities(std::span<const double> obser
     // blend under -march=native / /arch:AVX512.
     // Tier 2 with explicit intrinsics would replicate that same compare/blend
     // pattern for marginal gain; the auto-vectorized version is near-optimal.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = UniformDistribution::getLogProbability(observations[i]);
     }

--- a/src/distributions/von_mises_distribution.cpp
+++ b/src/distributions/von_mises_distribution.cpp
@@ -125,16 +125,14 @@ void VonMisesDistribution::updateCache() const noexcept {
 double VonMisesDistribution::getProbability(double value) const {
     if (std::isnan(value) || std::isinf(value))
         return 0.0;
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     return std::exp(kappa_ * std::cos(value - mu_) - logNormaliser_);
 }
 
 double VonMisesDistribution::getLogProbability(double value) const noexcept {
     if (std::isnan(value) || std::isinf(value))
         return -std::numeric_limits<double>::infinity();
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     return kappa_ * std::cos(value - mu_) - logNormaliser_;
 }
 
@@ -143,8 +141,7 @@ void VonMisesDistribution::getBatchLogProbabilities(std::span<const double> obse
     // Tier 1 — concrete non-virtual loop; inner cos() is the bottleneck.
     // The hot path is: kappa * cos(x - mu) - logNormaliser
     // Both kappa and mu are loop-invariant; compilers can hoist them.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         const double x = observations[i];
         out[i] = (std::isnan(x) || std::isinf(x)) ? -std::numeric_limits<double>::infinity()
@@ -157,8 +154,7 @@ void VonMisesDistribution::getBatchLogProbabilities(std::span<const double> obse
 // ---------------------------------------------------------------------------
 
 double VonMisesDistribution::sample(std::mt19937_64 &rng) const {
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
 
     // Near-uniform case (kappa ≈ 0): sample uniformly on the circle.
     if (kappa_ < 1e-9) {
@@ -210,8 +206,7 @@ double VonMisesDistribution::getCumulativeProbability(double value) const noexce
     if (!std::isfinite(value))
         return std::isnan(value) ? 0.0 : 1.0;
     const double v = wrap_angle(value);
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
 
     // Integrate f(x) from -π to v using trapezoidal rule with 512 steps.
     constexpr int N = 512;

--- a/src/distributions/weibull_distribution.cpp
+++ b/src/distributions/weibull_distribution.cpp
@@ -12,8 +12,7 @@ namespace libhmm {
 double WeibullDistribution::getProbability(double value) const {
     if (value < math::ZERO_DOUBLE || std::isnan(value) || std::isinf(value))
         return math::ZERO_DOUBLE;
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
 
     // Handle boundary case
     if (value == math::ZERO_DOUBLE) {
@@ -36,8 +35,7 @@ double WeibullDistribution::getLogProbability(double value) const noexcept {
         return -std::numeric_limits<double>::infinity();
     }
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     if (value == math::ZERO_DOUBLE)
         return (k_ == math::ONE) ? logK_ - logLambda_ : -std::numeric_limits<double>::infinity();
 
@@ -104,12 +102,14 @@ void weibull_mom_init(double mean, double var, double &k_out, double &lambda_out
         double s1 = 0.0; // Σ w_i x_i^k log(x_i)
         double s2 = 0.0; // Σ w_i x_i^k (log x_i)^2
         for (std::size_t i = 0; i < n; ++i) {
-            const double wxk = (unit_w ? 1.0 : w[i]) * std::exp(k * log_x[i]);
+            // Clamp exponent to avoid std::exp overflow to inf on outlier data.
+            const double exponent = std::clamp(k * log_x[i], -700.0, 700.0);
+            const double wxk = (unit_w ? 1.0 : w[i]) * std::exp(exponent);
             s0 += wxk;
             s1 += wxk * log_x[i];
             s2 += wxk * log_x2[i];
         }
-        if (s0 <= 0.0)
+        if (!std::isfinite(s0) || s0 <= 0.0)
             break;
 
         const double c1 = s1 / s0;               // E_k[log x]
@@ -127,10 +127,16 @@ void weibull_mom_init(double mean, double var, double &k_out, double &lambda_out
             break;
     }
 
+    // Fall back to the MoM seed rather than returning a garbage k.
+    if (!std::isfinite(k) || k <= 0.0)
+        k = init_k;
+
     // λ = (Σ w_i x_i^k / sumW)^(1/k)
     double s0f = 0.0;
-    for (std::size_t i = 0; i < n; ++i)
-        s0f += (unit_w ? 1.0 : w[i]) * std::exp(k * log_x[i]);
+    for (std::size_t i = 0; i < n; ++i) {
+        const double exponent = std::clamp(k * log_x[i], -700.0, 700.0);
+        s0f += (unit_w ? 1.0 : w[i]) * std::exp(exponent);
+    }
     const double lambda = (s0f > 0.0 && sumW > 0.0) ? std::exp(std::log(s0f / sumW) / k) : 1.0;
     return {k, lambda};
 }
@@ -273,8 +279,7 @@ double WeibullDistribution::CDF(double x) const noexcept {
     if (x <= math::ZERO_DOUBLE)
         return math::ZERO_DOUBLE;
 
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     // CDF(x) = 1 - exp(-(x/λ)^k)
     const double xTimesInvLambda = x * invLambda_; // Use cached reciprocal
 
@@ -335,8 +340,7 @@ void WeibullDistribution::getBatchLogProbabilities(std::span<const double> obser
     // Intel SVML (_mm512_log_pd + _mm512_pow_pd), but not portably without a
     // math-library dependency. The k=1 (exponential) and k=2 (Rayleigh) special
     // cases eliminate pow and could be handled without SVML.
-    if (!isCacheValid())
-        updateCache();
+    ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = WeibullDistribution::getLogProbability(observations[i]);
     }


### PR DESCRIPTION
Addresses the four "fix before next release" findings from the independent v4.0.4 audit.

## C-1 (Critical) — Cache-fill data race in `DistributionBase`

The `std::atomic<bool> cacheValid_` flag was correctly ordered (acquire/release) but only guarded itself — the cached `double` fields written by each distribution's `updateCache()` had no synchronization. Two threads concurrently calling a `const` accessor on a cold cache both wrote to the same non-atomic memory: a real, TSan-detectable data race that contradicted the library's documented "thread-safe for read operations" guarantee.

**Fix:** Add `mutable std::mutex cacheMutex_` to `DistributionBase<Derived,Obs>` and a CRTP helper `ensureCache()` that uses double-checked locking — lock-free atomic fast path once the cache is warm, mutex-serialized fill on the cold path. Add `friend class DistributionBase<Derived>` to all 16 scalar distributions so the CRTP call can reach private `updateCache()`. Replace every `if (!isCacheValid()) updateCache()` call site (~50 sites, 23 files) with `ensureCache()`. `DiagonalGaussianDistribution` and `FullCovarianceGaussianDistribution` already had their own per-class mutex inside `updateCache()`; left unchanged.

## H-1 (High) — Weibull MLE solver silent overflow

`weibull_mle_solve()` computed `std::exp(k * log_x[i])` with no bound on the exponent. With outlier-heavy data, `k * log_x[i]` can exceed ~709, producing `+inf` in `s0/s1/s2`. The existing `s0 <= 0.0` break guard is `false` for `inf` and `nan`, so the solver could silently return a garbage `{k, lambda}` pair.

**Fix:** Clamp the exponent argument to `[-700, 700]` before `std::exp` in both the Newton–Raphson loop and the final lambda pass. Extend the break condition to `!isfinite(s0) || s0 <= 0`. Add an `init_k` fallback after the loop when `k` diverges.

## H-2 (High) — Stale Boost dependency in installed CMake config

`cmake/libhmmConfig.cmake.in` still contained `find_dependency(Boost REQUIRED)` even though Boost was removed from the build in Phase 8.3. Any downstream project doing `find_package(libhmm)` on a machine without Boost would fail to configure, directly contradicting the "zero external dependencies" claim.

**Fix:** Remove the stale `find_dependency(Boost REQUIRED)` line.

## M-2 (Medium) — No ThreadSanitizer CI job

TSan would have caught C-1 directly. Without it there is no automated guard against future cache-fill races.

**Fix:** Add a `tsan` CI job (Linux/GCC, `RelWithDebInfo`, `-fsanitize=thread -g -O1`) that runs the full test suite under TSan.