### PR TITLE
test: close audit gaps M-3, L-5 (test coverage)

### DIFF
--- a/tests/calculators/test_calculator_edge_cases.cpp
+++ b/tests/calculators/test_calculator_edge_cases.cpp
@@ -193,6 +193,42 @@ TEST_F(CalculatorEdgeCasesTest, LongSequence_Viterbi_NoErrors) {
     });
 }
 
+// ---------------------------------------------------------------------------
+// Very long sequences — log P << −700, exercises the full underflow-protection
+// path in log-space FB/Viterbi at scale (audit finding M-3).
+// ---------------------------------------------------------------------------
+
+TEST_F(CalculatorEdgeCasesTest, VeryLongSequence_FB_DeepNegativeLogP) {
+    // T = 2000 uniform 4-symbol single-state HMM.
+    // log P = 2000 * log(0.25) ≈ −2773, well below −700.
+    auto hmm = make_single_state_hmm();
+    ObservationSet obs(2000);
+    for (std::size_t i = 0; i < 2000; ++i)
+        obs(i) = static_cast<double>(i % 4);
+
+    ForwardBackwardCalculator fbc(*hmm, obs);
+    const double logP = fbc.getLogProbability();
+    EXPECT_TRUE(std::isfinite(logP)) << "log P must be finite, not ±inf or NaN";
+    EXPECT_LT(logP, -700.0) << "log P must be below −700 to exercise underflow path";
+    EXPECT_GT(logP, -std::numeric_limits<double>::infinity());
+    // Exact value: each symbol drawn with prob 0.25, all independent.
+    EXPECT_NEAR(logP, 2000.0 * std::log(0.25), 1e-6);
+}
+
+TEST_F(CalculatorEdgeCasesTest, VeryLongSequence_Viterbi_Stable) {
+    // T = 2000; Viterbi must complete without overflow/underflow errors.
+    auto hmm = make_single_state_hmm();
+    ObservationSet obs(2000);
+    for (std::size_t i = 0; i < 2000; ++i)
+        obs(i) = static_cast<double>(i % 4);
+
+    ViterbiCalculator vc(*hmm, obs);
+    const auto &seq = vc.getStateSequence();
+    EXPECT_EQ(seq.size(), obs.size());
+    for (std::size_t i = 0; i < seq.size(); ++i)
+        EXPECT_EQ(seq(i), 0) << "Single-state HMM: all states must be 0";
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/distributions/test_chi_squared_distribution.cpp
+++ b/tests/distributions/test_chi_squared_distribution.cpp
@@ -139,19 +139,8 @@ TEST(ChiSquaredDistributionTest, Fitting) {
 TEST(ChiSquaredDistributionTest, ParameterValidation) {
 
     // Test invalid constructor parameters
-    try {
-        ChiSquaredDistribution chi_dist(0.0); // Zero degrees of freedom
-        ADD_FAILURE();                        // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
-
-    try {
-        ChiSquaredDistribution chi_dist(-1.0); // Negative degrees of freedom
-        ADD_FAILURE();                         // Should not reach here
-    } catch (const std::invalid_argument &) {
-        // Expected behavior
-    }
+    EXPECT_THROW(ChiSquaredDistribution(0.0), std::invalid_argument);  // zero df
+    EXPECT_THROW(ChiSquaredDistribution(-1.0), std::invalid_argument); // negative df
 
     // Test invalid parameters with NaN and infinity
     double nan_val = std::numeric_limits<double>::quiet_NaN();
@@ -519,6 +508,53 @@ TEST(ChiSquaredDistributionTest, CDFAccuracy) {
         EXPECT_EQ(d.getCumulativeProbability(-1.0), 0.0);
         EXPECT_GT(d.getCumulativeProbability(1e6), 1.0 - 1e-9);
     }
+}
+
+// =============================================================================
+// Tests added to close L-5 audit gap: weighted fit, batch log-prob, JSON type.
+// =============================================================================
+
+TEST(ChiSquaredDistributionTest, WeightedFit) {
+    // Weighted MOM estimator: k̂ = Σ(w_i * x_i) / Σw_i
+    ChiSquaredDistribution chi;
+
+    // Equal weights: weighted mean == sample mean.
+    std::vector<double> data = {2.0, 4.0, 6.0, 8.0};
+    std::vector<double> weights = {1.0, 1.0, 1.0, 1.0};
+    chi.fit(data, weights);
+    EXPECT_NEAR(chi.getDegreesOfFreedom(), 5.0, 1e-10);
+
+    // Unequal weights: k̂ = (0*2 + 0*4 + 1*6 + 0*8) / 1 = 6.
+    std::vector<double> w2 = {0.0, 0.0, 1.0, 0.0};
+    chi.fit(data, w2);
+    EXPECT_NEAR(chi.getDegreesOfFreedom(), 6.0, 1e-10);
+
+    // All-zero weights: sumW = 0 triggers the EM-collapse guard and parameters must
+    // not change (same contract as all other distributions with zero weight).
+    ChiSquaredDistribution chi2(3.0);
+    std::vector<double> zero = {0.0, 0.0, 0.0, 0.0};
+    chi2.fit(data, zero);
+    EXPECT_NEAR(chi2.getDegreesOfFreedom(), 3.0, 1e-10);
+}
+
+TEST(ChiSquaredDistributionTest, BatchLogProbabilityMatchesScalar) {
+    ChiSquaredDistribution chi(5.0);
+    std::vector<double> obs = {0.5, 1.0, 2.0, 5.0, 10.0, 20.0};
+    std::vector<double> out(obs.size());
+    chi.getBatchLogProbabilities(obs, out);
+    for (std::size_t i = 0; i < obs.size(); ++i)
+        EXPECT_NEAR(out[i], chi.getLogProbability(obs[i]), 1e-12)
+            << "Batch vs scalar mismatch at index " << i;
+}
+
+TEST(ChiSquaredDistributionTest, JsonTypeField) {
+    // to_json() must open with {"type":"ChiSquared" (exact format required by from_json).
+    ChiSquaredDistribution chi(7.5);
+    const std::string j = chi.to_json();
+    // Mirror the prefix check used in test_hmm_json.cpp's TypeFieldPrefix test.
+    const std::string prefix = std::string(R"({"type":")") + "ChiSquared" + "\"";
+    EXPECT_EQ(j.substr(0, prefix.size()), prefix);
+    EXPECT_NE(j.find("7.5"), std::string::npos);
 }
 
 /**


### PR DESCRIPTION
Closes the two remaining test-coverage gaps flagged by the independent v4.0.4 audit.

## M-3: Long-sequence underflow stress tests

The existing `LongSequence_*` tests used T=500 (log P ≈ −693), which is close to but not below the −700 threshold that exercises the full log-space underflow-protection path. Two new tests in `test_calculator_edge_cases.cpp` use T=2000:

- **`VeryLongSequence_FB_DeepNegativeLogP`**: asserts log P is finite, strictly below −700, and equal to `2000 * log(0.25) ≈ −2773` within 1e-6. Also asserts it is not −∞.
- **`VeryLongSequence_Viterbi_Stable`**: runs Viterbi on the same sequence and verifies all 2000 decoded states are 0 (single-state HMM).

## L-5: ChiSquared distribution coverage

Four new tests and one fix in `test_chi_squared_distribution.cpp`:

- **`WeightedFit`**: equal weights recover the sample mean; unequal weights (single non-zero entry) pick the corresponding data value; all-zero weights trigger the EM-collapse guard and leave parameters unchanged.
- **`BatchLogProbabilityMatchesScalar`**: `getBatchLogProbabilities` output matches `getLogProbability` at 1e-12 across six sample points — the same pattern used by all peer distributions.
- **`JsonTypeField`**: `to_json()` prefix matches `{"type":"ChiSquared"`, the exact format required by `from_json()`.
- **`ParameterValidation` fix**: replace `try/catch` + `ADD_FAILURE()` anti-pattern with `EXPECT_THROW` for the zero and negative degrees-of-freedom constructor cases.

**Note**: M-1 (BW/MAP-EM monotonic likelihood), M-4 (JSON/XML malformed-input), and VonMises coverage were already comprehensively present — confirmed by reading the full test files before writing anything new.