### PR TITLE
docs/style: close audit gaps L-2, L-3, M-5; fix GTest AppleClang warning

### DIFF
--- a/docs/EXPERIMENTAL_FLAGS.md
+++ b/docs/EXPERIMENTAL_FLAGS.md
@@ -1,0 +1,53 @@
+# Experimental Compiler Flags
+
+This document describes compile-time preprocessor macros that gate alternative
+algorithms in libhmm. These are **not CMake options** and are **not part of the
+public API or build system**. They exist solely for algorithm comparison during
+profiling work.
+
+## Forward-Backward Recurrence Experiments
+
+Two macros control recurrence kernel selection in
+`BasicForwardBackwardCalculator` (`include/libhmm/calculators/basic_forward_backward_calculator.h`):
+
+### `LIBHMM_EXPERIMENT_FB_MAX_REDUCE`
+
+Forces `FbRecurrenceMode::MaxReduce` for every sequence, regardless of
+sequence length or state count. Use this to benchmark the max-reduce
+log-sum-exp kernel in isolation without the overhead of runtime mode selection.
+
+### `LIBHMM_EXPERIMENT_FB_ADAPTIVE_SELECTOR`
+
+Applies a simplified heuristic: select `FbRecurrenceMode::MaxReduce` when the
+model has more than 2 states, `FbRecurrenceMode::Pairwise` otherwise. Use this
+to evaluate a cheaper selection rule against the full policy in
+`selectFbRecurrenceMode()`.
+
+## Activation
+
+Neither macro is exposed through CMake. Activate via a compile definition on a
+local build tree:
+
+```bash
+# Force MaxReduce for all sequences
+cmake -B build-focus-maxreduce \
+  -DCMAKE_CXX_FLAGS="-DLIBHMM_EXPERIMENT_FB_MAX_REDUCE" \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+# Test the N>2 adaptive heuristic
+cmake -B build-focus-adaptive \
+  -DCMAKE_CXX_FLAGS="-DLIBHMM_EXPERIMENT_FB_ADAPTIVE_SELECTOR" \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+```
+
+The `tools/fb_contour_sweep` and `tools/hotspot_breakdown` programs use these
+macros to compare kernel performance across different sequence lengths and state
+counts. The local build trees `build-focus-*` and `build-bench-adaptive-*` are
+gitignored.
+
+## When to use
+
+Do not use these in production or release builds. They exist to answer the
+question "does the max-reduce kernel help or hurt for this workload?" before
+committing to a policy change in `selectFbRecurrenceMode()`. After any such
+change, delete the local build tree and rebuild clean.

--- a/include/libhmm/calculators/basic_calculator.h
+++ b/include/libhmm/calculators/basic_calculator.h
@@ -20,6 +20,11 @@ namespace libhmm {
  *
  * For the scalar alias:
  *   using Calculator = BasicCalculator<double>;
+ *
+ * @note Passing a temporary observation sequence is a compile error (the
+ *       `SeqType&&` constructor overload is deleted). Bind the sequence to a
+ *       named variable with sufficient lifetime before constructing a calculator;
+ *       the reference must remain valid for the calculator's entire lifetime.
  */
 template <typename Obs>
 class BasicCalculator {

--- a/include/libhmm/training/basic_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_baum_welch_trainer.h
@@ -159,9 +159,9 @@ void BasicBaumWelchTrainer<Obs>::train() {
     // Pre-allocate emission buffers on the scalar path to avoid repeated
     // reallocations when accumulating over many sequences.
     if constexpr (std::is_same_v<Obs, double>) {
-        std::size_t totalLen = 0;
-        for (const auto &obs : this->getObservationLists())
-            totalLen += obs.size();
+        const std::size_t totalLen = std::accumulate(
+            this->getObservationLists().begin(), this->getObservationLists().end(), std::size_t{0},
+            [](std::size_t s, const auto &obs) { return s + obs.size(); });
         for (std::size_t i = 0; i < N; ++i) {
             emisAccum[i].reserve(totalLen);
             emisWts[i].reserve(totalLen);

--- a/include/libhmm/training/basic_map_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_map_baum_welch_trainer.h
@@ -323,9 +323,9 @@ void BasicMapBaumWelchTrainer<Obs>::train() {
     std::vector<std::vector<double>> emisWts(N);
 
     if constexpr (std::is_same_v<Obs, double>) {
-        std::size_t totalLen = 0;
-        for (const auto &obs : this->getObservationLists())
-            totalLen += obs.size();
+        const std::size_t totalLen = std::accumulate(
+            this->getObservationLists().begin(), this->getObservationLists().end(), std::size_t{0},
+            [](std::size_t s, const auto &obs) { return s + obs.size(); });
         for (std::size_t i = 0; i < N; ++i) {
             emisAccum[i].reserve(totalLen);
             emisWts[i].reserve(totalLen);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,16 @@ if(NOT GTest_FOUND AND NOT TARGET gtest)
     # On Windows, prevent GTest from overriding the project's CRT choice
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
+    # Suppress Apple Clang's -Wcharacter-conversion warning in GTest's own headers.
+    # gtest-printers.h:528 casts char8_t to char32_t, which is valid C++ but triggers
+    # this diagnostic on AppleClang + C++20. Not a libhmm issue; suppressed here so
+    # the build log stays clean for warnings we actually own.
+    foreach(_gt_target gtest gtest_main gmock gmock_main)
+        if(TARGET ${_gt_target})
+            target_compile_options(${_gt_target} PRIVATE
+                $<$<CXX_COMPILER_ID:AppleClang>:-Wno-character-conversion>)
+        endif()
+    endforeach()
 endif()
 
 # Check if Google Test is available


### PR DESCRIPTION
Closes the remaining quick-win audit gaps (L-2, L-3, M-5) and fixes a pre-existing GTest build warning on Apple Clang.

## GTest -Wcharacter-conversion warning (Apple Clang)

`gtest-printers.h:528` casts `char8_t` to `char32_t`, which is valid C++ but triggers `-Wcharacter-conversion` on Apple Clang + C++20. The warning appeared interleaved with library object compilation in parallel builds, giving the misleading impression that it was a libhmm issue. Suppressed at the FetchContent GTest target level with a `target_compile_options` foreach — not globally, so libhmm code is unaffected.

## L-3: BasicCalculator deleted-rvalue documentation

`BasicTrainer` already documented in its class-level Doxygen that passing a temporary observation list is a compile error. `BasicCalculator` had only an inline comment on the deleted constructor. Added an equivalent `@note` to the `BasicCalculator` class Doxygen so Doxygen-generated docs and IDE hovers carry the lifetime warning.

## L-2: Experimental Forward-Backward recurrence flags

Created `docs/EXPERIMENTAL_FLAGS.md` documenting `LIBHMM_EXPERIMENT_FB_MAX_REDUCE` and `LIBHMM_EXPERIMENT_FB_ADAPTIVE_SELECTOR`: what each does, how to activate via local build trees, which tools programs use them, and that they must not appear in production builds. These macros were previously undocumented outside the source code.

## M-5: Raw loop → std::accumulate in training headers (selective)

Replaced the `for (...) totalLen += obs.size()` pattern in both `BasicBaumWelchTrainer::train()` and `BasicMapBaumWelchTrainer::train()` with `std::accumulate`. The `validSeqs` counting loops in the same functions are intentionally left as raw loops — they have side effects inside `accum_one_sequence` that make `std::count_if` semantically incorrect. All other cppcheck `useStlAlgorithm` and `functionStatic` findings are suppressed in CI for good reasons (performance-critical linalg loops; API-breaking static promotion of XML I/O methods) and are not touched here.