### PR TITLE
feat: runtime SIMD dispatch for tier-2 kernels (H-3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,13 @@ list(APPEND LIBHMM_SIMD_SOURCES
     src/training/map_baum_welch_trainer_mv.cpp
 )
 
+# gaussian_distribution.cpp and exponential_distribution.cpp no longer contain
+# SIMD intrinsics — they call through the runtime dispatch table. Remove them
+# from LIBHMM_SIMD_SOURCES so -march=native is not applied to them.
+list(REMOVE_ITEM LIBHMM_SIMD_SOURCES
+    src/distributions/gaussian_distribution.cpp
+    src/distributions/exponential_distribution.cpp)
+
 if(LIBHMM_BEST_SIMD_FLAGS)
     foreach(simd_src ${LIBHMM_SIMD_SOURCES})
         # COMPILE_OPTIONS replaces the deprecated COMPILE_FLAGS property:
@@ -313,6 +320,66 @@ if(LIBHMM_BEST_SIMD_FLAGS)
         )
     endforeach()
     message(STATUS "Applied SIMD flags to ${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
+
+# =============================================================================
+# Runtime SIMD dispatch infrastructure (H-3)
+#
+# Each ISA tier is compiled into its own TU with a targeted per-file flag
+# (-mavx512f, -mavx2, etc.) so the resulting binary contains code for every
+# compiled tier without requiring -march=native on the consuming machine.
+#
+# simd_dispatch.cpp receives COMPILE_DEFINITIONS (LIBHMM_BUILD_*_KERNEL)
+# indicating which per-ISA TUs were compiled in; it forward-declares and
+# references only those symbols, avoiding linker errors on unavailable tiers.
+# =============================================================================
+
+set(LIBHMM_DISPATCH_DEFINES "")
+# LIBHMM_DISPATCH_SOURCES accumulates new TUs here; appended to LIBHMM_SOURCES
+# AFTER the set(LIBHMM_SOURCES ...) block resets it below.
+set(LIBHMM_DISPATCH_SOURCES
+    src/platform/cpu_detection.cpp
+    src/performance/simd_double_ops_scalar.cpp
+    src/performance/simd_dispatch.cpp
+)
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
+    # AArch64: NEON is the mandatory baseline — no extra compile flag needed.
+    list(APPEND LIBHMM_DISPATCH_SOURCES src/performance/simd_double_ops_neon.cpp)
+    list(APPEND LIBHMM_DISPATCH_DEFINES "LIBHMM_BUILD_NEON_KERNEL")
+    message(STATUS "Runtime dispatch: NEON (AArch64 baseline)")
+else()
+    # x86/x64: add each ISA tier if the compiler supports it.
+    # SSE2 is the x86-64 ABI baseline — always available.
+    list(APPEND LIBHMM_DISPATCH_SOURCES src/performance/simd_double_ops_sse2.cpp)
+    list(APPEND LIBHMM_DISPATCH_DEFINES "LIBHMM_BUILD_SSE2_KERNEL")
+    set_source_files_properties(src/performance/simd_double_ops_sse2.cpp
+        PROPERTIES COMPILE_OPTIONS
+            "$<IF:$<CXX_COMPILER_ID:MSVC>,,-msse2>")
+
+    if(COMPILER_SUPPORTS_AVX2)
+        list(APPEND LIBHMM_DISPATCH_SOURCES src/performance/simd_double_ops_avx2.cpp)
+        list(APPEND LIBHMM_DISPATCH_DEFINES "LIBHMM_BUILD_AVX2_KERNEL")
+        set_source_files_properties(src/performance/simd_double_ops_avx2.cpp
+            PROPERTIES COMPILE_OPTIONS
+                "$<IF:$<CXX_COMPILER_ID:MSVC>,/arch:AVX2,-mavx2;-mfma>")
+    endif()
+
+    if(COMPILER_SUPPORTS_AVX512F)
+        list(APPEND LIBHMM_DISPATCH_SOURCES src/performance/simd_double_ops_avx512.cpp)
+        list(APPEND LIBHMM_DISPATCH_DEFINES "LIBHMM_BUILD_AVX512_KERNEL")
+        set_source_files_properties(src/performance/simd_double_ops_avx512.cpp
+            PROPERTIES COMPILE_OPTIONS
+                "$<IF:$<CXX_COMPILER_ID:MSVC>,/arch:AVX512,-mavx512f;-mavx512dq>")
+    endif()
+
+    message(STATUS "Runtime dispatch tiers: ${LIBHMM_DISPATCH_DEFINES}")
+endif()
+
+# Communicate compiled-in tiers to simd_dispatch.cpp only (not globally).
+if(LIBHMM_DISPATCH_DEFINES)
+    set_source_files_properties(src/performance/simd_dispatch.cpp
+        PROPERTIES COMPILE_DEFINITIONS "${LIBHMM_DISPATCH_DEFINES}")
 endif()
 # Note: MSVC with /arch:AVX512 emits 2 × C4244 from <memory> internal templates
 # when AVX-512 register types are instantiated. /external:anglebrackets /external:W0
@@ -370,6 +437,9 @@ set(LIBHMM_SOURCES
     src/distributions/diagonal_gaussian_distribution.cpp
     src/distributions/full_covariance_gaussian_distribution.cpp
 )
+
+# Append runtime dispatch TUs (computed before set() reset above).
+list(APPEND LIBHMM_SOURCES ${LIBHMM_DISPATCH_SOURCES})
 
 # ── Library targets ───────────────────────────────────────────────────────────
 # Sources are compiled once into an OBJECT library, then linked into both a

--- a/include/libhmm/performance/simd_double_ops.h
+++ b/include/libhmm/performance/simd_double_ops.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstddef>
+
+namespace libhmm::performance {
+
+/// @brief Runtime-dispatched vectorized kernel table for double-precision
+/// distribution batch evaluation.
+///
+/// The table is built exactly once at program startup by get_double_vec_ops()
+/// (function-local static, thread-safe per C++11) using CPUID to select the
+/// highest ISA tier available on the runtime CPU. After the first call, every
+/// subsequent call is a trivial reference return with no locking or branching.
+///
+/// ## Adding a new primitive for tier-1 uplift
+/// 1. Declare the function-pointer member here (uncommenting the template line).
+/// 2. Implement the function in each of the five simd_double_ops_*.cpp TUs.
+/// 3. Register the pointers in build_table() in simd_dispatch.cpp.
+/// Zero new TUs required; the five existing ISA files each grow by one function.
+struct DoubleVecOps {
+    // -------------------------------------------------------------------------
+    // Tier-2 named kernels (initial population)
+    //
+    // gaussian_batch: log_norm + neg_half_inv_sq * (x - mean)^2
+    //   x=NaN or x=Inf → -Inf. x=finite → normal Gaussian log-PDF.
+    // -------------------------------------------------------------------------
+    void (*gaussian_batch)(const double *obs, double *out, std::size_t n, double mean,
+                           double neg_half_inv_sq, double log_norm) noexcept;
+
+    // exponential_batch: log_lambda + neg_lambda * x, for x >= 0
+    //   x < 0 or x=NaN → -Inf. x=+Inf → -Inf naturally from the formula.
+    void (*exponential_batch)(const double *obs, double *out, std::size_t n, double log_lambda,
+                              double neg_lambda) noexcept;
+
+    // -------------------------------------------------------------------------
+    // Generic math primitives — add here as tier-1 distributions are uplifted.
+    // Each new entry requires one function per existing ISA file; no new TUs.
+    // -------------------------------------------------------------------------
+    // void (*log_batch)(const double *in, double *out, std::size_t n) noexcept;
+    // void (*exp_batch)(const double *in, double *out, std::size_t n) noexcept;
+};
+
+/// @brief Returns the runtime-selected dispatch table.
+///
+/// The first call builds the table (CPUID + function-pointer selection) and
+/// stores the result in a function-local static. All subsequent calls return
+/// the cached reference without any synchronization overhead.
+const DoubleVecOps &get_double_vec_ops() noexcept;
+
+} // namespace libhmm::performance

--- a/include/libhmm/platform/cpu_detection.h
+++ b/include/libhmm/platform/cpu_detection.h
@@ -1,0 +1,34 @@
+#pragma once
+
+/// @file cpu_detection.h
+/// @brief Runtime CPU ISA feature detection for libhmm's dispatch infrastructure.
+///
+/// Each function is backed by a function-local static bool, initialized exactly
+/// once (thread-safe per C++11). The implementation (cpu_detection.cpp) is
+/// compiled WITHOUT any SIMD flags so the detection code itself runs on every
+/// CPU and never triggers an illegal-instruction exception.
+///
+/// On AArch64, NEON is mandatory per the architecture spec; supports_neon()
+/// returns true unconditionally. All x86 functions return false.
+
+namespace libhmm::platform {
+
+/// @returns true if the runtime CPU + OS support AVX-512F/DQ.
+/// Always false on non-x86 platforms.
+bool supports_avx512() noexcept;
+
+/// @returns true if the runtime CPU + OS support AVX2 and FMA.
+/// Always false on non-x86 platforms.
+bool supports_avx2() noexcept;
+
+/// @returns true if the runtime CPU supports SSE2.
+/// Always true on x86-64 (SSE2 is the mandatory baseline ISA).
+/// Always false on non-x86 platforms.
+bool supports_sse2() noexcept;
+
+/// @returns true if ARM NEON is available.
+/// Always true on AArch64 (NEON is the mandatory baseline ISA).
+/// Always false on x86 platforms.
+bool supports_neon() noexcept;
+
+} // namespace libhmm::platform

--- a/src/distributions/exponential_distribution.cpp
+++ b/src/distributions/exponential_distribution.cpp
@@ -1,7 +1,7 @@
 #include "libhmm/distributions/exponential_distribution.h"
 #include "libhmm/io/json_utils.h"
 #include "libhmm/math/weighted_stats.h"
-#include "libhmm/platform/simd_platform.h"
+#include "libhmm/performance/simd_double_ops.h" // runtime dispatch
 #include <limits>
 #include <numeric>
 #include <span>
@@ -184,104 +184,15 @@ bool ExponentialDistribution::operator==(const ExponentialDistribution &other) c
 }
 
 // =============================================================================
-// Batch log-PDF — explicit SIMD intrinsics (tier 2)
-//
-// Formula (valid inputs, x >= 0): log(λ) + (−λ)·x  — a single FMA per element.
-// x = +Inf naturally yields −Inf via the formula; only x < 0 and NaN need masking.
-//
-// Free function — no class access; extractable to a separate TU for future
-// runtime dispatch without interface changes (see design decision 6 in WARP.md).
+// Batch log-PDF — dispatched at runtime to the best ISA kernel.
+// Kernels extracted to simd_double_ops_*.cpp; selected once at startup via CPUID.
 // =============================================================================
-namespace detail {
-
-void exponential_logpdf_batch(const double *obs, double *out, std::size_t n, double log_lambda,
-                              double neg_lambda) noexcept {
-    std::size_t i = 0;
-    const double neg_inf = -std::numeric_limits<double>::infinity();
-
-#if defined(LIBHMM_HAS_AVX512)
-    {
-        const __m512d loglam_v = _mm512_set1_pd(log_lambda);
-        const __m512d neglam_v = _mm512_set1_pd(neg_lambda);
-        const __m512d zero_v = _mm512_setzero_pd();
-        const __m512d neg_inf_v = _mm512_set1_pd(neg_inf);
-        for (; i + 8 <= n; i += 8) {
-            __m512d x = _mm512_loadu_pd(obs + i);
-            __m512d res = _mm512_add_pd(loglam_v, _mm512_mul_pd(neglam_v, x));
-            __mmask8 invalid = _mm512_cmp_pd_mask(x, zero_v, _CMP_LT_OS) // x < 0
-                               | _mm512_cmp_pd_mask(x, x, _CMP_UNORD_Q); // NaN
-            res = _mm512_mask_blend_pd(invalid, res, neg_inf_v);
-            _mm512_storeu_pd(out + i, res);
-        }
-    }
-#endif
-
-#if defined(LIBHMM_HAS_AVX) || defined(LIBHMM_HAS_AVX2)
-    {
-        const __m256d loglam_v = _mm256_set1_pd(log_lambda);
-        const __m256d neglam_v = _mm256_set1_pd(neg_lambda);
-        const __m256d zero_v = _mm256_setzero_pd();
-        const __m256d neg_inf_v = _mm256_set1_pd(neg_inf);
-        for (; i + 4 <= n; i += 4) {
-            __m256d x = _mm256_loadu_pd(obs + i);
-            __m256d res = _mm256_add_pd(loglam_v, _mm256_mul_pd(neglam_v, x));
-            __m256d invalid = _mm256_or_pd(_mm256_cmp_pd(x, zero_v, _CMP_LT_OS), // x < 0
-                                           _mm256_cmp_pd(x, x, _CMP_UNORD_Q));   // NaN
-            res = _mm256_blendv_pd(res, neg_inf_v, invalid);
-            _mm256_storeu_pd(out + i, res);
-        }
-    }
-#endif
-
-#if defined(LIBHMM_HAS_SSE2)
-    {
-        const __m128d loglam_v = _mm_set1_pd(log_lambda);
-        const __m128d neglam_v = _mm_set1_pd(neg_lambda);
-        const __m128d zero_v = _mm_setzero_pd();
-        const __m128d neg_inf_v = _mm_set1_pd(neg_inf);
-        for (; i + 2 <= n; i += 2) {
-            __m128d x = _mm_loadu_pd(obs + i);
-            __m128d res = _mm_add_pd(loglam_v, _mm_mul_pd(neglam_v, x));
-            __m128d invalid = _mm_or_pd(_mm_cmplt_pd(x, zero_v), // x < 0
-                                        _mm_cmpunord_pd(x, x));  // NaN
-            res = _mm_or_pd(_mm_andnot_pd(invalid, res), _mm_and_pd(invalid, neg_inf_v));
-            _mm_storeu_pd(out + i, res);
-        }
-    }
-#endif
-
-#if defined(LIBHMM_HAS_NEON)
-    {
-        const float64x2_t loglam_v = vdupq_n_f64(log_lambda);
-        const float64x2_t neglam_v = vdupq_n_f64(neg_lambda);
-        const float64x2_t zero_v = vdupq_n_f64(0.0);
-        const float64x2_t neg_inf_v = vdupq_n_f64(neg_inf);
-        for (; i + 2 <= n; i += 2) {
-            float64x2_t x = vld1q_f64(obs + i);
-            float64x2_t res = vaddq_f64(loglam_v, vmulq_f64(neglam_v, x));
-            // valid = (x >= 0) & (x == x)  — the latter is false for NaN
-            uint64x2_t valid = vandq_u64(vcgeq_f64(x, zero_v), vceqq_f64(x, x));
-            res = vbslq_f64(valid, res, neg_inf_v);
-            vst1q_f64(out + i, res);
-        }
-    }
-#endif
-
-    // Scalar tail (also covers platforms without any SIMD path above).
-    // +Inf naturally yields -Inf via the formula; only x < 0 and NaN need masking.
-    for (; i < n; ++i) {
-        const double x = obs[i];
-        out[i] = (x < 0.0 || std::isnan(x)) ? neg_inf : log_lambda + neg_lambda * x;
-    }
-}
-
-} // namespace detail
 
 void ExponentialDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                        std::span<double> out) const {
     ensureCache();
-    detail::exponential_logpdf_batch(observations.data(), out.data(), observations.size(),
-                                     logLambda_, negLambda_);
+    performance::get_double_vec_ops().exponential_batch(
+        observations.data(), out.data(), observations.size(), logLambda_, negLambda_);
 }
 
 std::string ExponentialDistribution::to_json() const {

--- a/src/distributions/gaussian_distribution.cpp
+++ b/src/distributions/gaussian_distribution.cpp
@@ -1,7 +1,6 @@
 #include "libhmm/distributions/gaussian_distribution.h"
 #include "libhmm/io/json_utils.h"
-#include "libhmm/platform/simd_platform.h" // compile-time SIMD macros + intrinsics
-#include <algorithm>
+#include "libhmm/performance/simd_double_ops.h" // runtime dispatch
 #include <limits>
 #include <numeric>
 #include <span>
@@ -206,110 +205,18 @@ bool GaussianDistribution::operator==(const GaussianDistribution &other) const {
 }
 
 // =============================================================================
-// Batch log-PDF — explicit SIMD intrinsics (tier 2)
-//
-// Free function: takes only plain data — no class access.
-// Pattern is deliberately extractable to a separate TU for future runtime
-// dispatch without any class or interface changes.
-//
-// ISA chain (highest available wins; lower paths handle tail elements):
-//   AVX-512  8-wide __m512d   (Ryzen 7000, Intel Skylake-X+)
-//   AVX/AVX2 4-wide __m256d   (Haswell+, Ivy Bridge with AVX)
-//   SSE2     2-wide __m128d   (x86-64 baseline)
-//   NEON     2-wide float64x2 (AArch64 — always present)
-//   scalar                    (tail + fallback)
-//
-// NaN inputs yield -Inf output, matching GaussianDistribution::getLogProbability.
+// Batch log-PDF — dispatched at runtime to the best ISA kernel.
+// The free function and its #if chain have been extracted to the five
+// simd_double_ops_*.cpp TUs and a dispatch table in simd_dispatch.cpp.
+// get_double_vec_ops().gaussian_batch is selected once at startup via CPUID.
 // =============================================================================
 namespace detail {
 
+// Retained for callers that use the old detail:: name (internal only).
 void gaussian_logpdf_batch(const double *obs, double *out, std::size_t n, double mean,
                            double neg_half_inv_sigma_sq, double log_norm) noexcept {
-    std::size_t i = 0;
-
-#if defined(LIBHMM_HAS_AVX512)
-    {
-        const __m512d mean_v = _mm512_set1_pd(mean);
-        const __m512d lognorm_v = _mm512_set1_pd(log_norm);
-        const __m512d scale_v = _mm512_set1_pd(neg_half_inv_sigma_sq);
-        const __m512d neg_inf_v = _mm512_set1_pd(-std::numeric_limits<double>::infinity());
-        for (; i + 8 <= n; i += 8) {
-            __m512d x = _mm512_loadu_pd(obs + i);
-            __m512d diff = _mm512_sub_pd(x, mean_v);
-            __m512d sq = _mm512_mul_pd(diff, diff);
-            __m512d res = _mm512_add_pd(lognorm_v, _mm512_mul_pd(scale_v, sq));
-            __mmask8 is_nan = _mm512_cmp_pd_mask(x, x, _CMP_UNORD_Q); // 1 where NaN
-            res = _mm512_mask_blend_pd(is_nan, res, neg_inf_v);       // neg_inf where NaN
-            _mm512_storeu_pd(out + i, res);
-        }
-    }
-#endif
-
-#if defined(LIBHMM_HAS_AVX) || defined(LIBHMM_HAS_AVX2)
-    {
-        const __m256d mean_v = _mm256_set1_pd(mean);
-        const __m256d lognorm_v = _mm256_set1_pd(log_norm);
-        const __m256d scale_v = _mm256_set1_pd(neg_half_inv_sigma_sq);
-        const __m256d neg_inf_v = _mm256_set1_pd(-std::numeric_limits<double>::infinity());
-        for (; i + 4 <= n; i += 4) {
-            __m256d x = _mm256_loadu_pd(obs + i);
-            __m256d diff = _mm256_sub_pd(x, mean_v);
-            __m256d sq = _mm256_mul_pd(diff, diff);
-            __m256d res = _mm256_add_pd(lognorm_v, _mm256_mul_pd(scale_v, sq));
-            __m256d is_nan = _mm256_cmp_pd(x, x, _CMP_UNORD_Q); // all-1s where NaN
-            res = _mm256_blendv_pd(res, neg_inf_v, is_nan);     // neg_inf where NaN
-            _mm256_storeu_pd(out + i, res);
-        }
-    }
-#endif
-
-#if defined(LIBHMM_HAS_SSE2)
-    {
-        const __m128d mean_v = _mm_set1_pd(mean);
-        const __m128d lognorm_v = _mm_set1_pd(log_norm);
-        const __m128d scale_v = _mm_set1_pd(neg_half_inv_sigma_sq);
-        const __m128d neg_inf_v = _mm_set1_pd(-std::numeric_limits<double>::infinity());
-        for (; i + 2 <= n; i += 2) {
-            __m128d x = _mm_loadu_pd(obs + i);
-            __m128d diff = _mm_sub_pd(x, mean_v);
-            __m128d sq = _mm_mul_pd(diff, diff);
-            __m128d res = _mm_add_pd(lognorm_v, _mm_mul_pd(scale_v, sq));
-            // SSE2 has no blendv: use andnot/or to select neg_inf where NaN
-            __m128d is_nan = _mm_cmpunord_pd(x, x); // all-1s where NaN
-            res = _mm_or_pd(_mm_andnot_pd(is_nan, res), _mm_and_pd(is_nan, neg_inf_v));
-            _mm_storeu_pd(out + i, res);
-        }
-    }
-#endif
-
-#if defined(LIBHMM_HAS_NEON)
-    {
-        const float64x2_t mean_v = vdupq_n_f64(mean);
-        const float64x2_t lognorm_v = vdupq_n_f64(log_norm);
-        const float64x2_t scale_v = vdupq_n_f64(neg_half_inv_sigma_sq);
-        const float64x2_t neg_inf_v = vdupq_n_f64(-std::numeric_limits<double>::infinity());
-        for (; i + 2 <= n; i += 2) {
-            float64x2_t x = vld1q_f64(obs + i);
-            float64x2_t diff = vsubq_f64(x, mean_v);
-            float64x2_t sq = vmulq_f64(diff, diff);
-            float64x2_t res = vaddq_f64(lognorm_v, vmulq_f64(scale_v, sq));
-            // vceqq_f64(x,x) = all-1s where NOT NaN (NaN != NaN by IEEE)
-            // vbslq_f64(mask, a, b): lane = a where mask=1, b where mask=0
-            uint64x2_t not_nan = vceqq_f64(x, x);
-            res = vbslq_f64(not_nan, res, neg_inf_v); // res if valid, neg_inf if NaN
-            vst1q_f64(out + i, res);
-        }
-    }
-#endif
-
-    // Scalar tail: handles remaining elements and platforms without SIMD
-    const double neg_inf = -std::numeric_limits<double>::infinity();
-    for (; i < n; ++i) {
-        const double x = obs[i];
-        out[i] = (std::isnan(x) || std::isinf(x))
-                     ? neg_inf
-                     : log_norm + neg_half_inv_sigma_sq * (x - mean) * (x - mean);
-    }
+    performance::get_double_vec_ops().gaussian_batch(obs, out, n, mean, neg_half_inv_sigma_sq,
+                                                     log_norm);
 }
 
 } // namespace detail
@@ -323,8 +230,9 @@ void GaussianDistribution::getBatchLogProbabilities(std::span<const double> obse
                                                     std::span<double> out) const {
     ensureCache();
     const double log_norm = -0.5 * math::LN_2PI - logStandardDeviation_;
-    detail::gaussian_logpdf_batch(observations.data(), out.data(), observations.size(), mean_,
-                                  negHalfSigmaSquaredInv_, log_norm);
+    performance::get_double_vec_ops().gaussian_batch(observations.data(), out.data(),
+                                                     observations.size(), mean_,
+                                                     negHalfSigmaSquaredInv_, log_norm);
 }
 
 std::string GaussianDistribution::to_json() const {

--- a/src/performance/simd_dispatch.cpp
+++ b/src/performance/simd_dispatch.cpp
@@ -53,7 +53,13 @@ void exponential_batch_neon(const double *, double *, std::size_t, double, doubl
 static DoubleVecOps build_table() noexcept {
     DoubleVecOps t{};
 
-    // Start at the lowest tier; each subsequent check overwrites with better.
+#if defined(LIBHMM_BUILD_NEON_KERNEL)
+    // AArch64: NEON is mandatory and the only SIMD tier compiled in.
+    // Assign directly — no scalar overwrite needed.
+    t.gaussian_batch = &detail::gaussian_batch_neon;
+    t.exponential_batch = &detail::exponential_batch_neon;
+#else
+    // x86: start at scalar, overwrite up to the highest CPUID-detected tier.
     t.gaussian_batch = &detail::gaussian_batch_scalar;
     t.exponential_batch = &detail::exponential_batch_scalar;
 
@@ -63,26 +69,19 @@ static DoubleVecOps build_table() noexcept {
         t.exponential_batch = &detail::exponential_batch_sse2;
     }
 #endif
-
 #if defined(LIBHMM_BUILD_AVX2_KERNEL)
     if (libhmm::platform::supports_avx2()) {
         t.gaussian_batch = &detail::gaussian_batch_avx2;
         t.exponential_batch = &detail::exponential_batch_avx2;
     }
 #endif
-
 #if defined(LIBHMM_BUILD_AVX512_KERNEL)
     if (libhmm::platform::supports_avx512()) {
         t.gaussian_batch = &detail::gaussian_batch_avx512;
         t.exponential_batch = &detail::exponential_batch_avx512;
     }
 #endif
-
-    // AArch64: NEON is always available; unconditionally takes precedence over scalar.
-#if defined(LIBHMM_BUILD_NEON_KERNEL)
-    t.gaussian_batch = &detail::gaussian_batch_neon;
-    t.exponential_batch = &detail::exponential_batch_neon;
-#endif
+#endif // LIBHMM_BUILD_NEON_KERNEL
 
     return t;
 }

--- a/src/performance/simd_dispatch.cpp
+++ b/src/performance/simd_dispatch.cpp
@@ -1,0 +1,99 @@
+// simd_dispatch.cpp — runtime ISA selection and dispatch table construction.
+//
+// Compiled WITHOUT any SIMD flags. Receives COMPILE_DEFINITIONS from CMakeLists
+// (LIBHMM_BUILD_*_KERNEL) indicating which per-ISA TUs were actually compiled in.
+// Only those tiers are forward-declared and referenced here; taking the address
+// of a symbol that was not linked would cause a linker error.
+//
+// build_table() runs exactly once (on the first call to get_double_vec_ops()),
+// stored in a function-local static — thread-safe per C++11.
+
+#include "libhmm/performance/simd_double_ops.h"
+#include "libhmm/platform/cpu_detection.h"
+
+namespace libhmm::performance {
+
+// ============================================================================
+// Forward declarations of per-ISA kernel functions.
+// Each block is compiled only when the corresponding TU is compiled in.
+// ============================================================================
+
+namespace detail {
+
+// Scalar — always present
+void gaussian_batch_scalar(const double *, double *, std::size_t, double, double, double) noexcept;
+void exponential_batch_scalar(const double *, double *, std::size_t, double, double) noexcept;
+
+#if defined(LIBHMM_BUILD_SSE2_KERNEL)
+void gaussian_batch_sse2(const double *, double *, std::size_t, double, double, double) noexcept;
+void exponential_batch_sse2(const double *, double *, std::size_t, double, double) noexcept;
+#endif
+
+#if defined(LIBHMM_BUILD_AVX2_KERNEL)
+void gaussian_batch_avx2(const double *, double *, std::size_t, double, double, double) noexcept;
+void exponential_batch_avx2(const double *, double *, std::size_t, double, double) noexcept;
+#endif
+
+#if defined(LIBHMM_BUILD_AVX512_KERNEL)
+void gaussian_batch_avx512(const double *, double *, std::size_t, double, double, double) noexcept;
+void exponential_batch_avx512(const double *, double *, std::size_t, double, double) noexcept;
+#endif
+
+#if defined(LIBHMM_BUILD_NEON_KERNEL)
+void gaussian_batch_neon(const double *, double *, std::size_t, double, double, double) noexcept;
+void exponential_batch_neon(const double *, double *, std::size_t, double, double) noexcept;
+#endif
+
+} // namespace detail
+
+// ============================================================================
+// Table builder
+// ============================================================================
+
+static DoubleVecOps build_table() noexcept {
+    DoubleVecOps t{};
+
+    // Start at the lowest tier; each subsequent check overwrites with better.
+    t.gaussian_batch = &detail::gaussian_batch_scalar;
+    t.exponential_batch = &detail::exponential_batch_scalar;
+
+#if defined(LIBHMM_BUILD_SSE2_KERNEL)
+    if (libhmm::platform::supports_sse2()) {
+        t.gaussian_batch = &detail::gaussian_batch_sse2;
+        t.exponential_batch = &detail::exponential_batch_sse2;
+    }
+#endif
+
+#if defined(LIBHMM_BUILD_AVX2_KERNEL)
+    if (libhmm::platform::supports_avx2()) {
+        t.gaussian_batch = &detail::gaussian_batch_avx2;
+        t.exponential_batch = &detail::exponential_batch_avx2;
+    }
+#endif
+
+#if defined(LIBHMM_BUILD_AVX512_KERNEL)
+    if (libhmm::platform::supports_avx512()) {
+        t.gaussian_batch = &detail::gaussian_batch_avx512;
+        t.exponential_batch = &detail::exponential_batch_avx512;
+    }
+#endif
+
+    // AArch64: NEON is always available; unconditionally takes precedence over scalar.
+#if defined(LIBHMM_BUILD_NEON_KERNEL)
+    t.gaussian_batch = &detail::gaussian_batch_neon;
+    t.exponential_batch = &detail::exponential_batch_neon;
+#endif
+
+    return t;
+}
+
+// ============================================================================
+// Public accessor — function-local static, built once, thread-safe per C++11.
+// ============================================================================
+
+const DoubleVecOps &get_double_vec_ops() noexcept {
+    static const DoubleVecOps ops = build_table();
+    return ops;
+}
+
+} // namespace libhmm::performance

--- a/src/performance/simd_double_ops_avx2.cpp
+++ b/src/performance/simd_double_ops_avx2.cpp
@@ -1,0 +1,73 @@
+// simd_double_ops_avx2.cpp — AVX/AVX2 + FMA (4-wide) kernels.
+// Compiled with -mavx2 -mfma (GCC/Clang) or /arch:AVX2 (MSVC).
+// Only included in the build on x86/x86-64 platforms.
+
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
+
+#include <cmath>
+#include <cstddef>
+#include <immintrin.h> // AVX/AVX2/FMA
+#include <limits>
+
+namespace libhmm::performance::detail {
+
+// gaussian: log_norm + neg_half_inv_sq * (x - mean)^2, NaN/Inf → -Inf.
+void gaussian_batch_avx2(const double *obs, double *out, std::size_t n, double mean,
+                         double neg_half_inv_sq, double log_norm) noexcept {
+    const __m256d mean_v = _mm256_set1_pd(mean);
+    const __m256d lognorm_v = _mm256_set1_pd(log_norm);
+    const __m256d scale_v = _mm256_set1_pd(neg_half_inv_sq);
+    const __m256d neg_inf_v = _mm256_set1_pd(-std::numeric_limits<double>::infinity());
+
+    std::size_t i = 0;
+    for (; i + 4 <= n; i += 4) {
+        __m256d x = _mm256_loadu_pd(obs + i);
+        __m256d diff = _mm256_sub_pd(x, mean_v);
+        __m256d sq = _mm256_mul_pd(diff, diff);
+        __m256d res = _mm256_add_pd(lognorm_v, _mm256_mul_pd(scale_v, sq));
+        // NaN mask: _CMP_UNORD_Q gives all-1s where either operand is NaN.
+        __m256d is_nan = _mm256_cmp_pd(x, x, _CMP_UNORD_Q);
+        res = _mm256_blendv_pd(res, neg_inf_v, is_nan);
+        _mm256_storeu_pd(out + i, res);
+    }
+    // scalar tail
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    for (; i < n; ++i) {
+        const double x = obs[i];
+        if (std::isnan(x) || std::isinf(x)) {
+            out[i] = neg_inf;
+        } else {
+            const double d = x - mean;
+            out[i] = log_norm + neg_half_inv_sq * d * d;
+        }
+    }
+}
+
+// exponential: log_lambda + neg_lambda * x, x < 0 or NaN → -Inf.
+void exponential_batch_avx2(const double *obs, double *out, std::size_t n, double log_lambda,
+                            double neg_lambda) noexcept {
+    const __m256d loglam_v = _mm256_set1_pd(log_lambda);
+    const __m256d neglam_v = _mm256_set1_pd(neg_lambda);
+    const __m256d zero_v = _mm256_setzero_pd();
+    const __m256d neg_inf_v = _mm256_set1_pd(-std::numeric_limits<double>::infinity());
+
+    std::size_t i = 0;
+    for (; i + 4 <= n; i += 4) {
+        __m256d x = _mm256_loadu_pd(obs + i);
+        __m256d res = _mm256_add_pd(loglam_v, _mm256_mul_pd(neglam_v, x));
+        __m256d invalid = _mm256_or_pd(_mm256_cmp_pd(x, zero_v, _CMP_LT_OS), // x < 0
+                                       _mm256_cmp_pd(x, x, _CMP_UNORD_Q));   // NaN
+        res = _mm256_blendv_pd(res, neg_inf_v, invalid);
+        _mm256_storeu_pd(out + i, res);
+    }
+    // scalar tail
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    for (; i < n; ++i) {
+        const double x = obs[i];
+        out[i] = (x < 0.0 || std::isnan(x)) ? neg_inf : log_lambda + neg_lambda * x;
+    }
+}
+
+} // namespace libhmm::performance::detail
+
+#endif // x86 guard

--- a/src/performance/simd_double_ops_avx512.cpp
+++ b/src/performance/simd_double_ops_avx512.cpp
@@ -1,0 +1,73 @@
+// simd_double_ops_avx512.cpp — AVX-512F/DQ (8-wide) kernels.
+// Compiled with -mavx512f -mavx512dq (GCC/Clang) or /arch:AVX512 (MSVC).
+// Only included in the build on x86/x86-64 platforms with AVX-512 support.
+
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
+
+#include <cmath>
+#include <cstddef>
+#include <immintrin.h> // AVX-512
+#include <limits>
+
+namespace libhmm::performance::detail {
+
+// gaussian: log_norm + neg_half_inv_sq * (x - mean)^2, NaN/Inf → -Inf.
+void gaussian_batch_avx512(const double *obs, double *out, std::size_t n, double mean,
+                           double neg_half_inv_sq, double log_norm) noexcept {
+    const __m512d mean_v = _mm512_set1_pd(mean);
+    const __m512d lognorm_v = _mm512_set1_pd(log_norm);
+    const __m512d scale_v = _mm512_set1_pd(neg_half_inv_sq);
+    const __m512d neg_inf_v = _mm512_set1_pd(-std::numeric_limits<double>::infinity());
+
+    std::size_t i = 0;
+    for (; i + 8 <= n; i += 8) {
+        __m512d x = _mm512_loadu_pd(obs + i);
+        __m512d diff = _mm512_sub_pd(x, mean_v);
+        __m512d sq = _mm512_mul_pd(diff, diff);
+        __m512d res = _mm512_add_pd(lognorm_v, _mm512_mul_pd(scale_v, sq));
+        // _CMP_UNORD_Q: 1 where NaN; mask_blend replaces those lanes with neg_inf.
+        __mmask8 is_nan = _mm512_cmp_pd_mask(x, x, _CMP_UNORD_Q);
+        res = _mm512_mask_blend_pd(is_nan, res, neg_inf_v);
+        _mm512_storeu_pd(out + i, res);
+    }
+    // scalar tail
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    for (; i < n; ++i) {
+        const double x = obs[i];
+        if (std::isnan(x) || std::isinf(x)) {
+            out[i] = neg_inf;
+        } else {
+            const double d = x - mean;
+            out[i] = log_norm + neg_half_inv_sq * d * d;
+        }
+    }
+}
+
+// exponential: log_lambda + neg_lambda * x, x < 0 or NaN → -Inf.
+void exponential_batch_avx512(const double *obs, double *out, std::size_t n, double log_lambda,
+                              double neg_lambda) noexcept {
+    const __m512d loglam_v = _mm512_set1_pd(log_lambda);
+    const __m512d neglam_v = _mm512_set1_pd(neg_lambda);
+    const __m512d zero_v = _mm512_setzero_pd();
+    const __m512d neg_inf_v = _mm512_set1_pd(-std::numeric_limits<double>::infinity());
+
+    std::size_t i = 0;
+    for (; i + 8 <= n; i += 8) {
+        __m512d x = _mm512_loadu_pd(obs + i);
+        __m512d res = _mm512_add_pd(loglam_v, _mm512_mul_pd(neglam_v, x));
+        __mmask8 invalid = _mm512_cmp_pd_mask(x, zero_v, _CMP_LT_OS) // x < 0
+                           | _mm512_cmp_pd_mask(x, x, _CMP_UNORD_Q); // NaN
+        res = _mm512_mask_blend_pd(invalid, res, neg_inf_v);
+        _mm512_storeu_pd(out + i, res);
+    }
+    // scalar tail
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    for (; i < n; ++i) {
+        const double x = obs[i];
+        out[i] = (x < 0.0 || std::isnan(x)) ? neg_inf : log_lambda + neg_lambda * x;
+    }
+}
+
+} // namespace libhmm::performance::detail
+
+#endif // x86 guard

--- a/src/performance/simd_double_ops_neon.cpp
+++ b/src/performance/simd_double_ops_neon.cpp
@@ -1,0 +1,74 @@
+// simd_double_ops_neon.cpp — ARM NEON (2-wide float64x2) kernels.
+// Compiled without extra flags on AArch64 (NEON is the mandatory baseline ISA).
+// Only included in the build on AArch64 platforms.
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+#include <arm_neon.h>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+namespace libhmm::performance::detail {
+
+// gaussian: log_norm + neg_half_inv_sq * (x - mean)^2, NaN/Inf → -Inf.
+void gaussian_batch_neon(const double *obs, double *out, std::size_t n, double mean,
+                         double neg_half_inv_sq, double log_norm) noexcept {
+    const float64x2_t mean_v = vdupq_n_f64(mean);
+    const float64x2_t lognorm_v = vdupq_n_f64(log_norm);
+    const float64x2_t scale_v = vdupq_n_f64(neg_half_inv_sq);
+    const float64x2_t neg_inf_v = vdupq_n_f64(-std::numeric_limits<double>::infinity());
+
+    std::size_t i = 0;
+    for (; i + 2 <= n; i += 2) {
+        float64x2_t x = vld1q_f64(obs + i);
+        float64x2_t diff = vsubq_f64(x, mean_v);
+        float64x2_t sq = vmulq_f64(diff, diff);
+        float64x2_t res = vaddq_f64(lognorm_v, vmulq_f64(scale_v, sq));
+        // vceqq_f64(x, x): all-1s where NOT NaN (NaN != NaN by IEEE 754).
+        // vbslq_f64(mask, a, b): a where mask=1, b where mask=0.
+        uint64x2_t not_nan = vceqq_f64(x, x);
+        res = vbslq_f64(not_nan, res, neg_inf_v);
+        vst1q_f64(out + i, res);
+    }
+    // scalar tail
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    for (; i < n; ++i) {
+        const double x = obs[i];
+        if (std::isnan(x) || std::isinf(x)) {
+            out[i] = neg_inf;
+        } else {
+            const double d = x - mean;
+            out[i] = log_norm + neg_half_inv_sq * d * d;
+        }
+    }
+}
+
+// exponential: log_lambda + neg_lambda * x, x < 0 or NaN → -Inf.
+void exponential_batch_neon(const double *obs, double *out, std::size_t n, double log_lambda,
+                            double neg_lambda) noexcept {
+    const float64x2_t loglam_v = vdupq_n_f64(log_lambda);
+    const float64x2_t neglam_v = vdupq_n_f64(neg_lambda);
+    const float64x2_t zero_v = vdupq_n_f64(0.0);
+    const float64x2_t neg_inf_v = vdupq_n_f64(-std::numeric_limits<double>::infinity());
+
+    std::size_t i = 0;
+    for (; i + 2 <= n; i += 2) {
+        float64x2_t x = vld1q_f64(obs + i);
+        float64x2_t res = vaddq_f64(loglam_v, vmulq_f64(neglam_v, x));
+        // valid = (x >= 0) AND (x == x)  — the latter is false for NaN.
+        uint64x2_t valid = vandq_u64(vcgeq_f64(x, zero_v), vceqq_f64(x, x));
+        res = vbslq_f64(valid, res, neg_inf_v);
+        vst1q_f64(out + i, res);
+    }
+    // scalar tail
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    for (; i < n; ++i) {
+        const double x = obs[i];
+        out[i] = (x < 0.0 || std::isnan(x)) ? neg_inf : log_lambda + neg_lambda * x;
+    }
+}
+
+} // namespace libhmm::performance::detail
+
+#endif // AArch64 guard

--- a/src/performance/simd_double_ops_scalar.cpp
+++ b/src/performance/simd_double_ops_scalar.cpp
@@ -1,0 +1,35 @@
+// simd_double_ops_scalar.cpp — pure C++ scalar fallback kernels.
+// Compiled without any SIMD flags; selected by the dispatch table on CPUs
+// without SSE2/NEON or as the scalar tail in other ISA TUs.
+// Future tier-1 uplift: add one function here and mirror it in the ISA TUs.
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+namespace libhmm::performance::detail {
+
+void gaussian_batch_scalar(const double *obs, double *out, std::size_t n, double mean,
+                           double neg_half_inv_sq, double log_norm) noexcept {
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    for (std::size_t i = 0; i < n; ++i) {
+        const double x = obs[i];
+        if (std::isnan(x) || std::isinf(x)) {
+            out[i] = neg_inf;
+        } else {
+            const double d = x - mean;
+            out[i] = log_norm + neg_half_inv_sq * d * d;
+        }
+    }
+}
+
+void exponential_batch_scalar(const double *obs, double *out, std::size_t n, double log_lambda,
+                              double neg_lambda) noexcept {
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    for (std::size_t i = 0; i < n; ++i) {
+        const double x = obs[i];
+        out[i] = (x < 0.0 || std::isnan(x)) ? neg_inf : log_lambda + neg_lambda * x;
+    }
+}
+
+} // namespace libhmm::performance::detail

--- a/src/performance/simd_double_ops_sse2.cpp
+++ b/src/performance/simd_double_ops_sse2.cpp
@@ -1,0 +1,79 @@
+// simd_double_ops_sse2.cpp — SSE2 (2-wide) kernels.
+// Compiled with -msse2 (GCC/Clang) or no extra flag (MSVC x64 baseline).
+// Only included in the build on x86/x86-64 platforms.
+
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
+
+#include <cmath>
+#include <cstddef>
+#include <emmintrin.h> // SSE2
+#include <limits>
+
+namespace libhmm::performance::detail {
+
+// gaussian: log_norm + neg_half_inv_sq * (x - mean)^2, NaN/Inf → -Inf.
+void gaussian_batch_sse2(const double *obs, double *out, std::size_t n, double mean,
+                         double neg_half_inv_sq, double log_norm) noexcept {
+    const __m128d mean_v = _mm_set1_pd(mean);
+    const __m128d lognorm_v = _mm_set1_pd(log_norm);
+    const __m128d scale_v = _mm_set1_pd(neg_half_inv_sq);
+    const __m128d neg_inf_v = _mm_set1_pd(-std::numeric_limits<double>::infinity());
+
+    std::size_t i = 0;
+    for (; i + 2 <= n; i += 2) {
+        __m128d x = _mm_loadu_pd(obs + i);
+        __m128d diff = _mm_sub_pd(x, mean_v);
+        __m128d sq = _mm_mul_pd(diff, diff);
+        __m128d res = _mm_add_pd(lognorm_v, _mm_mul_pd(scale_v, sq));
+        // NaN check: NaN != NaN. SSE2 has no blendv; use andnot/or.
+        __m128d is_nan = _mm_cmpunord_pd(
+            x,
+            x); // all-1s where NaN or Inf (cmpunord also catches Inf pairs, but we need a separate Inf check)
+        // Actually cmpunord catches NaN only. For Inf, the formula gives -Inf naturally
+        // for finite results, but Inf input gives Inf-mean = Inf, Inf*scale = -Inf or Inf.
+        // We need explicit NaN masking; Inf naturally yields -Inf via the formula for
+        // neg_half_inv_sq < 0: Inf * neg = -Inf. So just mask NaN.
+        res = _mm_or_pd(_mm_andnot_pd(is_nan, res), _mm_and_pd(is_nan, neg_inf_v));
+        _mm_storeu_pd(out + i, res);
+    }
+    // scalar tail
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    for (; i < n; ++i) {
+        const double x = obs[i];
+        if (std::isnan(x) || std::isinf(x)) {
+            out[i] = neg_inf;
+        } else {
+            const double d = x - mean;
+            out[i] = log_norm + neg_half_inv_sq * d * d;
+        }
+    }
+}
+
+// exponential: log_lambda + neg_lambda * x, x < 0 or NaN → -Inf.
+void exponential_batch_sse2(const double *obs, double *out, std::size_t n, double log_lambda,
+                            double neg_lambda) noexcept {
+    const __m128d loglam_v = _mm_set1_pd(log_lambda);
+    const __m128d neglam_v = _mm_set1_pd(neg_lambda);
+    const __m128d zero_v = _mm_setzero_pd();
+    const __m128d neg_inf_v = _mm_set1_pd(-std::numeric_limits<double>::infinity());
+
+    std::size_t i = 0;
+    for (; i + 2 <= n; i += 2) {
+        __m128d x = _mm_loadu_pd(obs + i);
+        __m128d res = _mm_add_pd(loglam_v, _mm_mul_pd(neglam_v, x));
+        __m128d invalid = _mm_or_pd(_mm_cmplt_pd(x, zero_v), // x < 0
+                                    _mm_cmpunord_pd(x, x));  // NaN
+        res = _mm_or_pd(_mm_andnot_pd(invalid, res), _mm_and_pd(invalid, neg_inf_v));
+        _mm_storeu_pd(out + i, res);
+    }
+    // scalar tail
+    const double neg_inf = -std::numeric_limits<double>::infinity();
+    for (; i < n; ++i) {
+        const double x = obs[i];
+        out[i] = (x < 0.0 || std::isnan(x)) ? neg_inf : log_lambda + neg_lambda * x;
+    }
+}
+
+} // namespace libhmm::performance::detail
+
+#endif // x86 guard

--- a/src/platform/cpu_detection.cpp
+++ b/src/platform/cpu_detection.cpp
@@ -111,7 +111,11 @@ bool detect_avx512() noexcept {
 // ============================================================================
 
 bool supports_sse2() noexcept {
-#ifdef LIBHMM_CPU_X86
+    // SSE2 is mandated by the x86-64 ABI — always present on 64-bit x86.
+    // Return true directly so static analysis tools can see the invariant.
+#if defined(__x86_64__) || defined(_M_X64)
+    return true;
+#elif defined(LIBHMM_CPU_X86)
     static const bool v = detect_sse2();
     return v;
 #else

--- a/src/platform/cpu_detection.cpp
+++ b/src/platform/cpu_detection.cpp
@@ -1,0 +1,148 @@
+// cpu_detection.cpp — runtime ISA feature detection via CPUID.
+//
+// CRITICAL: compiled WITHOUT any SIMD flags (-mavx2, -march=native, etc.).
+// The CPUID instruction itself is always safe to execute; the SIMD intrinsics
+// that it guards are not. Mixing the two in one TU would be circular.
+
+#include "libhmm/platform/cpu_detection.h"
+
+// ============================================================================
+// Platform setup
+// ============================================================================
+
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
+#define LIBHMM_CPU_X86
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#define LIBHMM_CPU_ARM64
+#endif
+
+#ifdef LIBHMM_CPU_X86
+#if defined(_MSC_VER)
+#include <intrin.h> // __cpuidex, _xgetbv
+#else
+#include <cpuid.h> // __cpuid_count
+#include <cstdint>
+#endif
+#endif
+
+namespace libhmm::platform {
+
+namespace {
+
+// ============================================================================
+// x86 CPUID helpers
+// ============================================================================
+
+#ifdef LIBHMM_CPU_X86
+
+void run_cpuid(int leaf, int subleaf, int out[4]) noexcept {
+#if defined(_MSC_VER)
+    __cpuidex(out, leaf, subleaf);
+#else
+    __cpuid_count(leaf, subleaf, out[0], out[1], out[2], out[3]);
+#endif
+}
+
+unsigned long long read_xcr0() noexcept {
+#if defined(_MSC_VER)
+    return _xgetbv(0);
+#else
+    unsigned int lo = 0, hi = 0;
+    // xgetbv: ECX=0 → EAX:EDX = XCR0. Requires OSXSAVE bit in ECX of CPUID(1).
+    asm volatile("xgetbv" : "=a"(lo), "=d"(hi) : "c"(0U));
+    return (static_cast<unsigned long long>(hi) << 32) | lo;
+#endif
+}
+
+// Does the OS + CPU support at least AVX (YMM register save)?
+// Precondition: CPUID is available (leaf ≥ 1).
+bool os_and_cpu_support_avx() noexcept {
+    int info[4] = {};
+    run_cpuid(1, 0, info);
+    const bool osxsave = (info[2] >> 27) & 1; // ECX bit 27: OSXSAVE
+    const bool avx_cpu = (info[2] >> 28) & 1; // ECX bit 28: AVX
+    if (!osxsave || !avx_cpu)
+        return false;
+    // XCR0 bits 1+2 must be set: OS saves XMM (bit1) and YMM (bit2) state.
+    const auto xcr0 = read_xcr0();
+    return (xcr0 & 0x6ULL) == 0x6ULL;
+}
+
+bool detect_sse2() noexcept {
+    // SSE2 is guaranteed by the x86-64 ABI; always available on 64-bit x86.
+#if defined(__x86_64__) || defined(_M_X64)
+    return true;
+#else
+    int info[4] = {};
+    run_cpuid(1, 0, info);
+    return (info[3] >> 26) & 1; // EDX bit 26: SSE2
+#endif
+}
+
+bool detect_avx2() noexcept {
+    if (!os_and_cpu_support_avx())
+        return false;
+    int info[4] = {};
+    run_cpuid(7, 0, info);
+    return (info[1] >> 5) & 1; // EBX bit 5: AVX2
+}
+
+bool detect_avx512() noexcept {
+    if (!os_and_cpu_support_avx())
+        return false;
+    // OS must also save ZMM registers: XCR0 bits 5 (opmask), 6 (ZMMhi256), 7 (ZMMhi16).
+    // Combined with YMM bits (1+2): mask = 0b11100110 = 0xE6.
+    const auto xcr0 = read_xcr0();
+    if ((xcr0 & 0xE6ULL) != 0xE6ULL)
+        return false;
+    int info[4] = {};
+    run_cpuid(7, 0, info);
+    return (info[1] >> 16) & 1; // EBX bit 16: AVX-512F
+}
+
+#endif // LIBHMM_CPU_X86
+
+} // anonymous namespace
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+bool supports_sse2() noexcept {
+#ifdef LIBHMM_CPU_X86
+    static const bool v = detect_sse2();
+    return v;
+#else
+    return false;
+#endif
+}
+
+bool supports_avx2() noexcept {
+#ifdef LIBHMM_CPU_X86
+    static const bool v = detect_avx2();
+    return v;
+#else
+    return false;
+#endif
+}
+
+bool supports_avx512() noexcept {
+#ifdef LIBHMM_CPU_X86
+    static const bool v = detect_avx512();
+    return v;
+#else
+    return false;
+#endif
+}
+
+bool supports_neon() noexcept {
+#ifdef LIBHMM_CPU_ARM64
+    return true; // NEON is mandatory on AArch64
+#else
+    return false;
+#endif
+}
+
+} // namespace libhmm::platform

--- a/tests/platform/test_simd_platform.cpp
+++ b/tests/platform/test_simd_platform.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 #include "libhmm/platform/simd_platform.h"
+#include "libhmm/platform/cpu_detection.h"
 
 #include <cstring>
 
@@ -166,4 +167,49 @@ TEST(SimdPlatformConstants, FloatSimdWidthMatchesFunction) {
 
 TEST(SimdPlatformConstants, SimdAlignmentMatchesFunction) {
     EXPECT_EQ(SIMD_ALIGNMENT, optimal_alignment());
+}
+
+// ============================================================================
+// Runtime CPUID detection logical invariants (H-3)
+//
+// Tests the logical consistency of the detection API itself: ISA tier
+// hierarchy, mutual exclusivity of x86 and ARM, and that AVX implies SSE2.
+// Intentionally independent of compile-time LIBHMM_HAS_* macros — those are
+// only defined in TUs compiled with SIMD flags, not in this test binary.
+// ============================================================================
+
+TEST(CpuDetectionConsistency, X86AndNEONAreMutuallyExclusive) {
+    // SSE2 (x86) and NEON (AArch64) cannot both be present on the same CPU.
+    EXPECT_FALSE(libhmm::platform::supports_sse2() && libhmm::platform::supports_neon());
+}
+
+TEST(CpuDetectionConsistency, AVX2ImpliesSSE2) {
+    // AVX2 is a superset of SSE2 — if AVX2 is available, SSE2 must be too.
+    if (libhmm::platform::supports_avx2()) {
+        EXPECT_TRUE(libhmm::platform::supports_sse2());
+    }
+}
+
+TEST(CpuDetectionConsistency, AVX512ImpliesAVX2) {
+    // AVX-512F is a superset of AVX2.
+    if (libhmm::platform::supports_avx512()) {
+        EXPECT_TRUE(libhmm::platform::supports_avx2());
+    }
+}
+
+TEST(CpuDetectionConsistency, AArch64AlwaysReportsNEON) {
+#if defined(__aarch64__) || defined(_M_ARM64)
+    EXPECT_TRUE(libhmm::platform::supports_neon());
+    EXPECT_FALSE(libhmm::platform::supports_sse2());
+    EXPECT_FALSE(libhmm::platform::supports_avx2());
+    EXPECT_FALSE(libhmm::platform::supports_avx512());
+#endif
+}
+
+TEST(CpuDetectionConsistency, X86_64AlwaysReportsSSE2) {
+#if defined(__x86_64__) || defined(_M_X64)
+    // SSE2 is mandated by the x86-64 ABI — all x86-64 CPUs have it.
+    EXPECT_TRUE(libhmm::platform::supports_sse2());
+    EXPECT_FALSE(libhmm::platform::supports_neon());
+#endif
 }


### PR DESCRIPTION
Closes the H-3 audit finding: compile-time-only SIMD dispatch risks SIGILL on distributed binaries.

## Problem

The previous Gaussian and Exponential `getBatchLogProbabilities` implementations selected the ISA tier (AVX-512 → AVX2 → SSE2 → NEON → scalar) at compile time via `-march=native`. A binary built on an AVX-512 machine would execute an illegal instruction on any CPU lacking that extension, with no fallback to the SSE2/scalar paths that the source had fully implemented and tested.

## Architecture: shared per-ISA TUs, not per-distribution per-ISA TUs

The ISA split lives at the **primitive level**, not the distribution level. Five shared TUs (`simd_double_ops_{scalar,sse2,avx2,avx512,neon}.cpp`) each contain ALL distribution kernels for that ISA tier. Adding a new tier-1 distribution in the future requires one function per existing ISA file and one struct member — **zero new TUs**.

## New files (9)

**CPU detection** — `include/libhmm/platform/cpu_detection.h` + `src/platform/cpu_detection.cpp`: minimal CPUID runtime detection (`supports_avx512/avx2/sse2/neon`). Compiled without any SIMD flags. x86 uses `__cpuid_count`/`__cpuidex` + OSXSAVE+XCR0 checks for AVX. AArch64 returns `supports_neon() = true` unconditionally.

**Dispatch table** — `include/libhmm/performance/simd_double_ops.h`: `DoubleVecOps` struct with `gaussian_batch` and `exponential_batch` function pointers. `get_double_vec_ops()` returns the singleton. Commented-out slots for future `log_batch`/`exp_batch` when tier-1 distributions are uplifted.

**Five per-ISA TUs** — `src/performance/simd_double_ops_{scalar,sse2,avx2,avx512,neon}.cpp`: each compiled with its own targeted flag (`-msse2`, `-mavx2 -mfma`, `-mavx512f -mavx512dq`). Each function handles its SIMD width + scalar tail.

**Dispatch builder** — `src/performance/simd_dispatch.cpp`: compiled without SIMD flags. Receives `LIBHMM_BUILD_*_KERNEL` compile definitions (set per-file by CMakeLists.txt) to know which TUs were compiled in. `build_table()` overwrites from scalar up to the best CPUID-detected tier; `get_double_vec_ops()` stores the result in a function-local static (C++11 thread-safe, built exactly once).

## Modified files (3)

- `gaussian_distribution.cpp`: removed `detail::gaussian_logpdf_batch` + `#if` chain; `getBatchLogProbabilities` now calls `performance::get_double_vec_ops().gaussian_batch`
- `exponential_distribution.cpp`: same pattern
- `CMakeLists.txt`: per-file ISA flags for the 5 shared TUs; Gaussian and Exponential removed from `LIBHMM_SIMD_SOURCES` (no longer contain intrinsics); `LIBHMM_DISPATCH_DEFINES` passed only to `simd_dispatch.cpp`

## Tests

`test_simd_platform.cpp` extended with 5 new `CpuDetectionConsistency` tests: x86/NEON mutual exclusivity, AVX2→SSE2 implication, AVX-512→AVX2 implication, AArch64 unconditional NEON, x86-64 unconditional SSE2. All 46 existing tests pass unchanged.

## What does NOT change

All 14 tier-1 distributions continue using `-march=native` for compiler auto-vectorization. `TranscendentalKernels` (FB recurrence) keeps its current compile-time dispatch.