### PR TITLE
perf: ChiSquared Newton MLE for k; correct fit quality tiers in GOLD_STANDARD_CHECKLIST (closes #49)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides project-scoped guidance to AI agents and contributors working
 
 C++20 Hidden Markov Model library. Zero external dependencies (C++20 standard library only). GTest is fetched via `FetchContent` only for the test suite. Produces both a shared (`hmm`) and static (`hmm_static`) library from a single OBJECT target.
 
-`main` is the stable v4 branch (current release: v4.2.0). Multivariate HMM support is provided via `BasicHmm<Obs>` and `BasicEmissionDistribution<Obs>` templates. `using Hmm = BasicHmm<double>` and `using EmissionDistribution = BasicEmissionDistribution<double>` preserve v3 source compatibility; users consuming only the v3 API can build from `main` unchanged.
+`main` is the stable v4 branch (current release: v4.2.1). Multivariate HMM support is provided via `BasicHmm<Obs>` and `BasicEmissionDistribution<Obs>` templates. `using Hmm = BasicHmm<double>` and `using EmissionDistribution = BasicEmissionDistribution<double>` preserve v3 source compatibility; users consuming only the v3 API can build from `main` unchanged.
 
 ## Session start
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.1] - 2026-07-04
+
+Fit quality audit and ChiSquared Newton MLE release. 47/47 standard correctness tests pass.
+No API changes; no breaking changes.
+
+### Fixed
+
+- **`ChiSquaredDistribution::fit()` — Newton MLE for k** (Tier B → A): replaced the weighted
+  mean (MOM) estimator with Newton–Raphson on the score equation `ψ(k/2) = mean_log_x − log(2)`,
+  using the MOM value as the starting point. Promotes ChiSquared to Tier A alongside the other
+  15 scalar distributions.
+
+### Documentation
+
+- **`docs/GOLD_STANDARD_CHECKLIST.md`** corrected: five distributions (Gamma, Weibull,
+  NegativeBinomial, Beta, StudentT) were already Tier A via Newton/ECM algorithms implemented
+  before v4.2.0; the checklist incorrectly still listed them as Tier C. All six are now
+  accurately documented as Tier A. UniformDistribution is the sole remaining Tier C
+  (MOM defensible in EM context).
+
+---
+
 ## [4.2.0] - 2026-07-04
 
 Multivariate segmental k-means release. 47/47 standard correctness tests pass.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(APPLE)
 endif()
 
 project(libhmm
-    VERSION 4.2.0
+    VERSION 4.2.1
     DESCRIPTION "Modern C++20 Hidden Markov Model Library"
     LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://isocpp.org/std/the-standard)
 [![CMake](https://img.shields.io/badge/CMake-3.20%2B-blue.svg)](https://cmake.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-4.2.0-brightgreen.svg)](https://github.com/OldCrow/libhmm/releases)
+[![Version](https://img.shields.io/badge/Version-4.2.1-brightgreen.svg)](https://github.com/OldCrow/libhmm/releases)
 [![Tests](https://img.shields.io/badge/Tests-47%2F47_Passing-success.svg)](tests/)
 [![SIMD](https://img.shields.io/badge/SIMD-AVX--512%2FAVX2%2FSSE2%2FNEON-blue.svg)](src/distributions/)
 [![CI](https://github.com/OldCrow/libhmm/actions/workflows/ci.yml/badge.svg)](https://github.com/OldCrow/libhmm/actions)

--- a/docs/GOLD_STANDARD_CHECKLIST.md
+++ b/docs/GOLD_STANDARD_CHECKLIST.md
@@ -1,4 +1,4 @@
-# LibHMM Gold Standard Distribution Implementation Checklist
+﻿# LibHMM Gold Standard Distribution Implementation Checklist
 
 This document tracks the implementation status of all probability distributions in libhmm
 according to the "Gold Standard" requirements, plus a fit quality survey added in May 2026.
@@ -89,53 +89,39 @@ These distributions have closed-form weighted MLE. The M-step is correct and opt
 | VonMisesDistribution | μ via atan2, κ via Mardia-Jupp + Newton | Near-optimal; Mardia-Jupp error < 0.003 |
 | BinomialDistribution | p = weighted_mean / n | Exact MLE for p (n fixed as max observation) |
 
-### Tier B — MOM ≈ MLE: gap is small in practice
+### Tier B
 
-Single-parameter distributions where MOM and MLE are very close for typical parameter values.
-
-| Distribution | M-step estimate | Gap to MLE |
-|---|---|---|
-| ChiSquaredDistribution | k = weighted_mean | MOM (E[X]=k). True MLE requires ψ(k/2) = log(mean) − mean_of_log. Gap is small for k > 2. |
+No distributions remain in Tier B as of v4.2.1.
 
 ### Tier C — MOM: gap can be material
 
-Multi-parameter distributions where MOM diverges from MLE for certain parameter ranges.
-These converge to a valid local optimum but may arrive at a suboptimal one.
+One distribution remains Tier C.
 
-| Distribution | M-step estimate | Known limitation |
-|---|---|---|
-| GammaDistribution | k = mean²/var, θ = var/mean | MOM. MLE for k requires solving log(k) − ψ(k) = log(mean) − mean_of_log. MOM is close for k > 1; degrades for k < 0.5. |
-| NegativeBinomialDistribution | p = mean/var, r = mean²/(var−mean) | MOM. MLE for r has no closed form; needs profile likelihood or Newton. |
-| UniformDistribution | a = mean − √(3·var), b = mean + √(3·var) | MOM. MLE (weighted min/max) is unstable in EM context; MOM is defensible. |
-| BetaDistribution | α = mean·f, β = (1−mean)·f | MOM. Degrades when α or β < 0.5. MLE requires digamma Newton. |
-| WeibullDistribution | k and λ from weighted mean/variance | MOM. Gap is significant for k outside [0.5, 3]. MLE for k needs Newton. |
-| StudentTDistribution | μ = weighted_mean, σ = corrected_std, ν from kurtosis | Kurtosis-based ν is noisy when a state covers few observations. ECM algorithm would give exact joint (μ, σ, ν) updates. |
+| Distribution | M-step estimate | Notes |
+||---|---|---|
+|| UniformDistribution | a = mean - sqrt(3*var), b = mean + sqrt(3*var) | MOM. MLE (weighted min/max) is numerically unstable under EM weights; MOM is defensible. |
 
-### Outstanding M-step improvements (priority order)
+### Previously Tier B/C — promoted to Tier A (all resolved by v4.2.1)
 
-1. **StudentTDistribution — ECM algorithm**: Replace kurtosis MOM with the Gaussian scale-mixture
-   EM (Dempster 1977; Murphy 2012 §11.4.5). Per-observation scale weights u_i = (ν+1)/(ν + z_i²/σ²)
-   give closed-form μ and σ updates; ν requires a Newton step. Directly improves financial HMM
-   quality (demonstrated on DAX 2000–2022 vs fHMM benchmark).
+| Distribution | Algorithm | Since |
+||---|---|---|
+|| ChiSquaredDistribution | Newton on psi(k/2) = mean_log_x - log(2) | v4.2.1 |
+|| GammaDistribution | Cheng & Feast (1979) starter + Newton on log(k) - psi(k) = s | pre-v4.2 |
+|| WeibullDistribution | MOM seed + Newton on profile score for k (100 iters) | pre-v4.2 |
+|| NegativeBinomialDistribution | MOM seed + digamma/trigamma Newton for r (200 iters) | pre-v4.2 |
+|| BetaDistribution | MOM seed + digamma Newton for (alpha, beta) (200 iters) | pre-v4.2 |
+|| StudentTDistribution | Full ECM: closed-form mu, sigma; Newton for nu (Liu & Rubin 1994) | pre-v4.2 |
 
-2. **GammaDistribution — Newton MLE for k**: One Newton step from the MOM starting point:
-   k_new = k − (log k − ψ(k) − s) / (1/k − ψ'(k)), s = log(mean) − mean_of_log.
-   Improves ecological movement models (step-length fitting) for sparse states with k < 1.
+### Outstanding M-step work
 
-3. **WeibullDistribution — Newton MLE for k**: Analogous single Newton step. Relevant for
-   reliability and predictive-maintenance HMMs.
-
-4. **NegativeBinomialDistribution — profile likelihood for r**: One-dimensional numerical
-   optimisation starting from MOM estimate. Relevant for count-data HMMs with high dispersion.
-
-5. **BetaDistribution — digamma Newton for (α, β)**: Standard two-parameter iterative MLE.
-   Low priority since Beta is rarely the primary emission in EM-fitted HMMs.
+None. All 15 non-Uniform scalar distributions are Tier A.
 
 ---
 
 ## Current Status Matrix (16 distributions)
 
 All 16 scalar distributions meet the Gold Standard v4.1 interface. 47/47 tests pass on all platforms.
+15 of 16 are Tier A (exact weighted MLE). UniformDistribution is the sole Tier C (MOM defensible in EM context).
 The 3 MV distributions (DiagonalGaussian, FullCovGaussian, IndependentComponents) implement
 `BasicEmissionDistribution<ObservationVectorView>` and are covered by `test_multivariate_distributions`.
 
@@ -151,7 +137,7 @@ The 3 MV distributions (DiagonalGaussian, FullCovGaussian, IndependentComponents
 | JSON I/O | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Rule of Five | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Thread-safe cache | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Fit quality tier | A | A | C | C | B | C | A | A | C | C | C | A | A | A | A | A |
+| Fit quality tier | A | A | A | C | A | A | A | A | A | A | A | A | A | A | A | A |
 
 Key: G=Gaussian, E=Exponential, Ga=Gamma, U=Uniform, Chi=ChiSquared, W=Weibull, Ra=Rayleigh,
 Bi=Binomial, NB=NegativeBinomial, T=StudentT, Be=Beta, LN=LogNormal, Pa=Pareto, Po=Poisson,
@@ -173,22 +159,22 @@ Fit tiers: **A** = exact weighted MLE; **B** = MOM ≈ MLE; **C** = MOM, gap can
 ### Discrete (4)
 1. ✅ DiscreteDistribution — Tier A fit
 2. ✅ BinomialDistribution — Tier A fit
-3. ✅ NegativeBinomialDistribution — ⚠️ Tier C fit (MOM for r)
+3. ✅ NegativeBinomialDistribution — Tier A fit (Newton MLE for r)
 4. ✅ PoissonDistribution — Tier A fit
 
 ### Continuous (12)
 
 5. ✅ GaussianDistribution — Tier A fit
 6. ✅ ExponentialDistribution — Tier A fit
-7. ✅ GammaDistribution — ⚠️ Tier C fit (MOM for k)
+7. ✅ GammaDistribution — Tier A fit (Newton MLE for k)
 8. ✅ LogNormalDistribution — Tier A fit
-9. ✅ BetaDistribution — ⚠️ Tier C fit (MOM for α, β)
-10. ✅ UniformDistribution — ⚠️ Tier C fit (MOM is defensible for uniform)
-11. ✅ WeibullDistribution — ⚠️ Tier C fit (MOM for k)
+9. ✅ BetaDistribution — Tier A fit (digamma Newton for α, β)
+10. ✅ UniformDistribution — Tier C fit (MOM defensible; MLE min/max unstable in EM)
+11. ✅ WeibullDistribution — Tier A fit (Newton MLE for k)
 12. ✅ ParetoDistribution — Tier A fit
 13. ✅ RayleighDistribution — Tier A fit
-14. ✅ StudentTDistribution — ⚠️ Tier C fit (ECM is the priority improvement)
-15. ✅ ChiSquaredDistribution — Tier B fit
+14. ✅ StudentTDistribution — Tier A fit (ECM, Liu & Rubin 1994)
+15. ✅ ChiSquaredDistribution — Tier A fit (Newton MLE, v4.2.1)
 16. ✅ VonMisesDistribution — Tier A fit (Mardia-Jupp ≈ MLE)
 
 ---
@@ -218,4 +204,4 @@ All numeric literals are replaced with named constants from `libhmm::constants`.
 
 ---
 
-*Last updated: 2026-07-04 (libhmm v4.2.0; 11/16 scalar distributions tier-2 SIMD-dispatched)*
+*Last updated: 2026-07-04 (libhmm v4.2.1; 11/16 scalar distributions tier-2 SIMD-dispatched; 15/16 Tier A fit quality)*

--- a/include/libhmm/distributions/chi_squared_distribution.h
+++ b/include/libhmm/distributions/chi_squared_distribution.h
@@ -103,7 +103,7 @@ public:
     [[nodiscard]] double getCumulativeProbability(double x) const noexcept;
 
     void fit(std::span<const double> data) override;
-    /** Weighted MOM: k̂ = weighted_mean. */
+    /** Weighted MLE: Newton–Raphson on ψ(k/2) = mean_w[log x] − log(2). */
     void fit(std::span<const double> data, std::span<const double> weights) override;
     [[nodiscard]] bool isDiscrete() const noexcept override { return false; }
     [[nodiscard]] std::size_t getNumParameters() const noexcept override { return 1; }

--- a/include/libhmm/libhmm.h
+++ b/include/libhmm/libhmm.h
@@ -28,7 +28,7 @@
  * For large projects or when compilation time is critical, consider including
  * only the specific headers you need instead of this master header.
  *
- * @version 4.2.0
+ * @version 4.2.1
  * @author libhmm development team
  */
 

--- a/src/distributions/chi_squared_distribution.cpp
+++ b/src/distributions/chi_squared_distribution.cpp
@@ -1,5 +1,6 @@
 #include "libhmm/distributions/chi_squared_distribution.h"
 #include "libhmm/io/json_utils.h"
+#include "libhmm/math/psi_functions.h"
 #include "libhmm/math/weighted_stats.h"
 #include "libhmm/performance/simd_double_ops.h" // runtime dispatch
 #include <algorithm>
@@ -93,28 +94,73 @@ double ChiSquaredDistribution::sample(std::mt19937_64 &rng) const {
     return dist(rng);
 }
 
+namespace {
+
+/// MLE for Chi-squared(k) via Newton–Raphson on the score equation:
+///   ψ(γ) = s,  γ = k/2,  s = mean_log_x − log(2)
+/// (follows directly from χ²(k) = Gamma(k/2, 2))
+/// Starting estimate: γ₀ = mean_x/2  (MOM seed).
+/// Returns unclamped k = 2·γ; caller applies distribution bounds.
+[[nodiscard]] double chi_squared_mle_solve(double mean_x, double mean_log_x) noexcept {
+    const double s = mean_log_x - std::log(2.0);
+    double gamma = std::max(mean_x * 0.5, 0.5); // MOM seed for γ = k/2
+    for (int i = 0; i < 20; ++i) {
+        const double f = detail::digamma(gamma) - s;
+        const double fp = detail::trigamma(gamma);
+        if (std::fabs(fp) < 1e-15)
+            break;
+        const double dg = f / fp;
+        gamma -= dg;
+        if (gamma <= 0.0)
+            gamma = 1e-10;
+        if (std::fabs(dg) < 1e-10 * gamma)
+            break;
+    }
+    return 2.0 * gamma;
+}
+
+} // anonymous namespace
+
 void ChiSquaredDistribution::fit(std::span<const double> data) {
     if (data.empty())
         throw std::invalid_argument("Cannot fit distribution to empty data");
-    double sum = 0.0;
+    double sum = 0.0, sum_log = 0.0;
+    std::size_t count = 0;
     for (const double v : data) {
         if (!std::isfinite(v) || v < 0.0)
             throw std::invalid_argument(
                 "Chi-squared distribution requires non-negative finite values");
-        sum += v;
+        if (v > 0.0) {
+            sum += v;
+            sum_log += std::log(v);
+            ++count;
+        }
     }
-    double est = std::max(MIN_DEGREES_OF_FREEDOM,
-                          std::min(MAX_DEGREES_OF_FREEDOM, sum / static_cast<double>(data.size())));
-    setDegreesOfFreedom(est);
+    if (count == 0) {
+        reset();
+        return;
+    }
+    const double n = static_cast<double>(count);
+    const double k = chi_squared_mle_solve(sum / n, sum_log / n);
+    setDegreesOfFreedom(std::clamp(k, MIN_DEGREES_OF_FREEDOM, MAX_DEGREES_OF_FREEDOM));
 }
 
 void ChiSquaredDistribution::fit(std::span<const double> data, std::span<const double> weights) {
-    const auto mean = detail::compute_weighted_mean(data, weights);
-    // Guard: near-zero weight → keep current parameters (not reset).
-    if (!mean)
+    double sumW = 0.0, sum_wx = 0.0, sum_wlogx = 0.0;
+    for (std::size_t i = 0; i < data.size(); ++i) {
+        const double v = data[i];
+        const double w = weights[i];
+        if (!std::isfinite(v) || v <= 0.0 || !std::isfinite(w) || w <= 0.0)
+            continue;
+        sumW += w;
+        sum_wx += w * v;
+        sum_wlogx += w * std::log(v);
+    }
+    // Guard: keep current parameters when effective weight is near zero.
+    if (sumW < precision::ZERO || std::isnan(sumW))
         return;
-    double est = std::max(MIN_DEGREES_OF_FREEDOM, std::min(MAX_DEGREES_OF_FREEDOM, *mean));
-    setDegreesOfFreedom(est);
+    const double k = chi_squared_mle_solve(sum_wx / sumW, sum_wlogx / sumW);
+    setDegreesOfFreedom(std::clamp(k, MIN_DEGREES_OF_FREEDOM, MAX_DEGREES_OF_FREEDOM));
 }
 
 void ChiSquaredDistribution::reset() noexcept {

--- a/tests/distributions/test_chi_squared_distribution.cpp
+++ b/tests/distributions/test_chi_squared_distribution.cpp
@@ -112,23 +112,22 @@ TEST(ChiSquaredDistributionTest, Fitting) {
 
     ChiSquaredDistribution chi_dist;
 
-    // Test with data that has known mean
-    std::vector<Observation> data = {1.0, 2.0, 3.0, 4.0, 5.0}; // Mean = 3.0
+    // Newton MLE fit: solve psi(k/2) = mean_log_x - log(2).
+    // The result is NOT the sample mean (that was the old MOM estimator).
+    std::vector<Observation> data = {1.0, 2.0, 3.0, 4.0, 5.0};
     chi_dist.fit(data);
+    EXPECT_GT(chi_dist.getDegreesOfFreedom(), 0.0);
+    EXPECT_TRUE(std::isfinite(chi_dist.getDegreesOfFreedom()));
 
-    // For Chi-squared, MLE estimate of k is the sample mean
-    EXPECT_NEAR(chi_dist.getDegreesOfFreedom(), 3.0, 1e-10);
-
-    // Test with another dataset
-    std::vector<Observation> data2 = {0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5}; // Mean = 4.0
+    std::vector<Observation> data2 = {0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5};
     chi_dist.fit(data2);
-    EXPECT_NEAR(chi_dist.getDegreesOfFreedom(), 4.0, 1e-10);
+    EXPECT_GT(chi_dist.getDegreesOfFreedom(), 0.0);
+    EXPECT_TRUE(std::isfinite(chi_dist.getDegreesOfFreedom()));
 
-    // Test with empty data - should throw exception
+    // Boundary: empty data throws, negative values throw.
     std::vector<Observation> empty_data;
     EXPECT_THROW(chi_dist.fit(empty_data), std::invalid_argument);
 
-    // Test with negative values - should throw exception
     std::vector<Observation> negative_data = {1.0, -2.0, 3.0};
     EXPECT_THROW(chi_dist.fit(negative_data), std::invalid_argument);
 }
@@ -515,26 +514,48 @@ TEST(ChiSquaredDistributionTest, CDFAccuracy) {
 // =============================================================================
 
 TEST(ChiSquaredDistributionTest, WeightedFit) {
-    // Weighted MOM estimator: k̂ = Σ(w_i * x_i) / Σw_i
+    // Newton MLE weighted fit: psi(k/2) = weighted_mean_log_x - log(2).
+    // The result is NOT the weighted mean (that was the old MOM estimator).
     ChiSquaredDistribution chi;
 
-    // Equal weights: weighted mean == sample mean.
+    // Equal weights: fit must produce a positive finite estimate.
     std::vector<double> data = {2.0, 4.0, 6.0, 8.0};
     std::vector<double> weights = {1.0, 1.0, 1.0, 1.0};
     chi.fit(data, weights);
-    EXPECT_NEAR(chi.getDegreesOfFreedom(), 5.0, 1e-10);
+    EXPECT_GT(chi.getDegreesOfFreedom(), 0.0);
+    EXPECT_TRUE(std::isfinite(chi.getDegreesOfFreedom()));
 
-    // Unequal weights: k̂ = (0*2 + 0*4 + 1*6 + 0*8) / 1 = 6.
+    // Unequal weights (single effective observation x=6): estimate is positive finite.
     std::vector<double> w2 = {0.0, 0.0, 1.0, 0.0};
     chi.fit(data, w2);
-    EXPECT_NEAR(chi.getDegreesOfFreedom(), 6.0, 1e-10);
+    EXPECT_GT(chi.getDegreesOfFreedom(), 0.0);
+    EXPECT_TRUE(std::isfinite(chi.getDegreesOfFreedom()));
 
-    // All-zero weights: sumW = 0 triggers the EM-collapse guard and parameters must
-    // not change (same contract as all other distributions with zero weight).
+    // All-zero weights: sumW = 0 triggers the EM-collapse guard; parameters unchanged.
     ChiSquaredDistribution chi2(3.0);
     std::vector<double> zero = {0.0, 0.0, 0.0, 0.0};
     chi2.fit(data, zero);
     EXPECT_NEAR(chi2.getDegreesOfFreedom(), 3.0, 1e-10);
+}
+
+/// Verify Newton MLE exactly recovers k for data whose sufficient statistic
+/// mean_log_x equals the chi-squared(k) expectation E[log X] = psi(k/2) + log(2).
+///
+/// Construction: a dataset of identical values x_exact = exp(psi(k/2) + log(2))
+/// satisfies mean_log_x = psi(k/2) + log(2) exactly, so Newton MLE gives k exactly.
+/// Using k_true = 4 (psi(2) = 1 - euler_gamma ≈ 0.42278).
+TEST(ChiSquaredDistributionTest, NewtonMLEAccuracy) {
+    // psi(2) = 1 - euler_gamma = 0.42278433509846713...
+    // x_exact = exp(psi(2) + log(2)) satisfies the MLE score equation for k=4.
+    constexpr double k_true = 4.0;
+    const double psi2 = 0.42278433509846713; // psi(k/2=2) = 1 - euler_gamma
+    const double x_exact = std::exp(psi2 + std::log(2.0));
+    // 50 identical observations — mean_log_x = log(x_exact) = psi(2)+log(2) exactly.
+    std::vector<double> data(50, x_exact);
+    ChiSquaredDistribution chi;
+    chi.fit(data);
+    // Newton MLE should recover k=4 to near machine precision.
+    EXPECT_NEAR(chi.getDegreesOfFreedom(), k_true, 1e-6);
 }
 
 TEST(ChiSquaredDistributionTest, BatchLogProbabilityMatchesScalar) {


### PR DESCRIPTION
Closes #49.

## Summary

Two changes in one patch:

### 1. ChiSquared Newton MLE (closes #49)

`ChiSquaredDistribution::fit()` now solves the MLE score equation `ψ(k/2) = mean_log_x − log(2)` via Newton–Raphson (using the MOM value as the starting point), replacing the previous `k = weighted_mean` estimator. Promotes ChiSquared from **Tier B → Tier A** fit quality — the last non-Uniform distribution not already at Tier A.

**Test changes:** two tests that hardcoded the old MOM expectation (`k = sample_mean`) are updated to behavioral assertions; a new `NewtonMLEAccuracy` test verifies exact recovery of k=4 when data has exactly the right chi-squared sufficient statistics.

### 2. `GOLD_STANDARD_CHECKLIST.md` audit

Inspecting the source revealed that five distributions listed as Tier C were **already Tier A** in the code (Newton/ECM algorithms implemented before v4.2.0; checklist never updated):
- `GammaDistribution` — Cheng & Feast + Newton
- `WeibullDistribution` — Newton on profile score
- `NegativeBinomialDistribution` — digamma/trigamma Newton
- `BetaDistribution` — digamma Newton for (α, β)
- `StudentTDistribution` — full ECM (Liu & Rubin 1994)

Issues #38–42 commented and closed as already resolved. The checklist now accurately reflects 15/16 Tier A.

## Tests

47/47 pass.

Co-Authored-By: Oz <oz-agent@warp.dev>