### PR TITLE
fix: add getLastLogProbability() to BasicMapBaumWelchTrainer — parity with BasicBaumWelchTrainer (closes #55)

### DIFF
--- a/include/libhmm/training/basic_map_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_map_baum_welch_trainer.h
@@ -76,6 +76,14 @@ public:
     [[nodiscard]] double getPseudoCount() const noexcept { return pseudo_count_; }
 
     /**
+     * @return Total finite E-step log-probability from the last train() call:
+     *         Σ log P(O_k | λ) over all sequences with finite probability.
+     *         Reset to −∞ before each train() call; remains −∞ if no valid
+     *         sequences were found.
+     */
+    [[nodiscard]] double getLastLogProbability() const noexcept { return lastLogProb_; }
+
+    /**
      * @brief Unnormalised log-prior of current HMM parameters.
      *
      * Returns  c · (Σ_{i,j} log A(i,j) + Σ_i log π_i)
@@ -88,6 +96,7 @@ public:
 
 private:
     double pseudo_count_;
+    double lastLogProb_{-std::numeric_limits<double>::infinity()};
 
     static constexpr double LOG_ZERO = detail::LOG_ZERO;
 
@@ -106,12 +115,12 @@ private:
 
     /**
      * @brief Run the E-step for one sequence (same logic as BaumWelchTrainer).
-     * @return true if the sequence contributed; false if skipped.
+     * @return Finite log P(O|λ) if the sequence contributed; −∞ if skipped.
      */
-    [[nodiscard]] static bool accum_one_sequence(const HmmType &hmm, const SeqType &obs,
-                                                 std::size_t N,
-                                                 const std::vector<double> &logTransT,
-                                                 bool hasZeroTransitions, EStepBuffers &bufs);
+    [[nodiscard]] static double accum_one_sequence(const HmmType &hmm, const SeqType &obs,
+                                                   std::size_t N,
+                                                   const std::vector<double> &logTransT,
+                                                   bool hasZeroTransitions, EStepBuffers &bufs);
 
     /**
      * @brief Dirichlet-smoothed log-prior over discrete emission distributions.
@@ -268,18 +277,18 @@ void BasicMapBaumWelchTrainer<Obs>::apply_discrete_smoothing(HmmType &hmm, std::
 }
 
 template <typename Obs>
-bool BasicMapBaumWelchTrainer<Obs>::accum_one_sequence(const HmmType &hmm, const SeqType &obs,
-                                                       std::size_t N,
-                                                       const std::vector<double> &logTransT,
-                                                       bool hasZeroTransitions,
-                                                       EStepBuffers &bufs) {
+double BasicMapBaumWelchTrainer<Obs>::accum_one_sequence(const HmmType &hmm, const SeqType &obs,
+                                                         std::size_t N,
+                                                         const std::vector<double> &logTransT,
+                                                         bool hasZeroTransitions,
+                                                         EStepBuffers &bufs) {
     const std::size_t T = ObsSeqTraits<Obs>::sequence_length(obs);
     if (T == 0)
-        return false;
+        return -std::numeric_limits<double>::infinity();
     BasicForwardBackwardCalculator<Obs> fbc(hmm, obs);
     const double logP = fbc.getLogProbability();
     if (!std::isfinite(logP))
-        return false;
+        return -std::numeric_limits<double>::infinity();
     const double *alphaData = fbc.getLogForwardVariables().data();
     const double *betaData = fbc.getLogBackwardVariables().data();
     for (std::size_t t = 0; t < T; ++t) {
@@ -303,7 +312,7 @@ bool BasicMapBaumWelchTrainer<Obs>::accum_one_sequence(const HmmType &hmm, const
     }
     accumulate_xi(alphaData, betaData, fbc.getLogEmitByTime(), logTransT, logP, T, N,
                   hasZeroTransitions, bufs.transNumT);
-    return true;
+    return logP;
 }
 
 template <typename Obs>
@@ -334,15 +343,21 @@ void BasicMapBaumWelchTrainer<Obs>::train() {
 
     EStepBuffers bufs{emisAccum, emisWts, piNum, transDen, transNumT};
     std::size_t validSeqs = 0;
+    lastLogProb_ = -std::numeric_limits<double>::infinity();
+    double totalLogProb = 0.0;
     for (const auto &obs : this->getObservationLists()) {
-        if (accum_one_sequence(hmm, obs, N, logTransT, hasZeroTransitions, bufs))
+        const double logP = accum_one_sequence(hmm, obs, N, logTransT, hasZeroTransitions, bufs);
+        if (std::isfinite(logP)) {
+            totalLogProb += logP;
             ++validSeqs;
+        }
     }
 
     if (validSeqs == 0) {
         throw std::runtime_error("MapBaumWelchTrainer: no valid observation sequences "
                                  "(all had zero probability under the current model)");
     }
+    lastLogProb_ = totalLogProb;
 
     m_step_pi_map(hmm, N, piNum, c);
     m_step_transitions_map(hmm, N, transNumT, transDen, c);

--- a/tests/training/test_map_baum_welch.cpp
+++ b/tests/training/test_map_baum_welch.cpp
@@ -195,6 +195,38 @@ TEST(MapBaumWelchTest, LogPriorFiniteAndNonPositive) {
 }
 
 // ---------------------------------------------------------------------------
+// getLastLogProbability
+// ---------------------------------------------------------------------------
+
+TEST(MapBaumWelchTest, LastLogProbabilityIsNegInfBeforeTrain) {
+    auto hmm = make_uniform_hmm();
+    auto obs = make_casino_obs();
+    MapBaumWelchTrainer trainer(*hmm, obs, 1.0);
+    EXPECT_EQ(trainer.getLastLogProbability(), -std::numeric_limits<double>::infinity());
+}
+
+TEST(MapBaumWelchTest, LastLogProbabilityFiniteAfterTrain) {
+    auto hmm = make_uniform_hmm();
+    auto obs = make_casino_obs();
+    MapBaumWelchTrainer trainer(*hmm, obs, 1.0);
+    trainer.train();
+    EXPECT_TRUE(std::isfinite(trainer.getLastLogProbability()));
+    EXPECT_LT(trainer.getLastLogProbability(), 0.0);
+}
+
+TEST(MapBaumWelchTest, LastLogProbabilityMatchesManualSum) {
+    // getLastLogProbability() stores the E-step log P(O|\u03bb) computed on the
+    // PRE-M-step model. Evaluate total_logL before calling train() to compare.
+    auto hmm = make_uniform_hmm();
+    auto obs = make_casino_obs();
+    MapBaumWelchTrainer trainer(*hmm, obs, 1.0);
+    const double logL_before = total_logL(*hmm, obs); // pre-train model
+    trainer.train();
+    // getLastLogProbability() must equal the pre-train likelihood.
+    EXPECT_NEAR(trainer.getLastLogProbability(), logL_before, 1e-8);
+}
+
+// ---------------------------------------------------------------------------
 // MAP objective is monotone over multiple iterations
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #55.

## What changed

`BasicMapBaumWelchTrainer::accum_one_sequence` already computed `logP = fbc.getLogProbability()` but discarded it (returned `bool`). This PR:

- Changes `accum_one_sequence` to return `double` (the sequence log-probability, or `-∞` if skipped)
- Accumulates `totalLogProb` in `train()` and stores it as `lastLogProb_`
- Exposes `getLastLogProbability() const noexcept` — identical semantics to `BasicBaumWelchTrainer`

**Semantics:** stores the **pre-M-step** E-step log P(O|λ), reset to `-∞` before each `train()` call.

## Tests

3 new tests in `test_map_baum_welch.cpp`:
- `LastLogProbabilityIsNegInfBeforeTrain` — initial state
- `LastLogProbabilityFiniteAfterTrain` — finite and negative after one pass
- `LastLogProbabilityMatchesManualSum` — equals `total_logL` on the pre-train model (correct semantics)

47/47 pass.

Co-Authored-By: Oz <oz-agent@warp.dev>