### PR TITLE
Fix audit findings: compile-time guards, denormal thresholds, discrete fit, decodePosterior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Build directories
+install/
 build/
 build-*/
 build*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides project-scoped guidance to AI agents and contributors working
 
 C++20 Hidden Markov Model library. Zero external dependencies (C++20 standard library only). GTest is fetched via `FetchContent` only for the test suite. Produces both a shared (`hmm`) and static (`hmm_static`) library from a single OBJECT target.
 
-`main` is the stable v4 branch (current release: v4.2.2). Multivariate HMM support is provided via `BasicHmm<Obs>` and `BasicEmissionDistribution<Obs>` templates. `using Hmm = BasicHmm<double>` and `using EmissionDistribution = BasicEmissionDistribution<double>` preserve v3 source compatibility; users consuming only the v3 API can build from `main` unchanged.
+`main` is the stable v4 branch (current release: v4.2.3). Multivariate HMM support is provided via `BasicHmm<Obs>` and `BasicEmissionDistribution<Obs>` templates. `using Hmm = BasicHmm<double>` and `using EmissionDistribution = BasicEmissionDistribution<double>` preserve v3 source compatibility; users consuming only the v3 API can build from `main` unchanged.
 
 ## Session start
 
@@ -174,9 +174,10 @@ Threading is **not used** in the production path. `ThreadPool` exists in `platfo
 
 The weighted `fit(data, weights)` method is the Baum-Welch M-step. Fit quality varies by distribution:
 
-- **Tier A — exact weighted MLE**: Gaussian, Exponential, Poisson, Discrete, LogNormal, Pareto, Rayleigh, VonMises, Binomial
-- **Tier B — MOM ≈ MLE**: ChiSquared
-- **Tier C — MOM (gap can be material)**: Gamma, Weibull, NegativeBinomial, Uniform, Beta, StudentT
+- **Tier A — exact weighted MLE/EM**: Gaussian, Exponential, Poisson, Discrete, LogNormal, Pareto,
+  Rayleigh, VonMises, Binomial, ChiSquared (Newton MLE, v4.2.1), Gamma, Weibull, NegativeBinomial,
+  Beta, StudentT (Newton/ECME, corrected in v4.2.1 — were implemented before v4.2.0 but mis-labelled)
+- **Tier C — MOM (defensible in EM context)**: Uniform (fixed-range; MOM is exact for uniform support)
 
 Priority M-step improvements are documented in `docs/GOLD_STANDARD_CHECKLIST.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.3] - 2026-07-04
+
+Security / correctness patch. 47/47 tests pass. No API additions; one narrow
+behavior change (see `decodePosterior` below).
+
+### Fixed
+
+- **Compile-time guard against temporary observation sequences** (Finding 3):
+  `BasicForwardBackwardCalculator` and `BasicViterbiCalculator` now declare
+  deleted `SeqType&&` constructor overloads on the *derived* classes. The
+  base-class deletion alone was bypassed when a temporary bound to
+  `const SeqType&` in a derived constructor; the named parameter then reached
+  the base as an lvalue, so the deleted overload never participated. The new
+  derived-class overloads close the gap. This change makes passing a temporary
+  to any calculator constructor a hard compile error, causing the pylibhmm
+  UAF binding sites (`_core.cpp`) to self-announce at compile time.
+- **Denormal guard inconsistency in M-step** (Finding 6):
+  `m_step_transitions` (BW trainer) used `> 0.0` where `m_step_pi` correctly
+  uses `>= precision::ZERO`. The same hazard applied to `m_step_pi_map` and
+  `m_step_transitions_map` in `BasicMapBaumWelchTrainer`. All three now use
+  `>= precision::ZERO`, preventing NaN/inf from denormal gamma underflow.
+- **`DiscreteDistribution::fit(data, weights)` under-normalization** (Finding 7):
+  The weighted fit divided by `sumW` (total weight, including out-of-range
+  observations), leaving the pmf summing to < 1 when any observation fell
+  outside the symbol range. Now accumulates `binnedW` (weight that landed in
+  bins) and divides by that. Removes the compensating renormalization pass from
+  `BasicMapBaumWelchTrainer::apply_discrete_smoothing` that worked around this.
+- **`decodePosterior()` silent failure on zero-probability sequences** (Finding 8):
+  When `logP = -inf`, `logAlpha + logBeta - logP` was NaN; all comparisons
+  returned false, silently producing an all-state-0 sequence. Now throws
+  `std::runtime_error` with a descriptive message when
+  `!std::isfinite(logProbability_)`. **Behavior change**: callers that passed
+  zero-probability sequences to `decodePosterior()` will now receive an
+  exception instead of a garbage result.
+- **Deprecated `volatile` compound assignment** (C++20): five instances of
+  `volatile T += value` in `tools/hotspot_breakdown.cpp`, `tools/bw_hotspot.cpp`,
+  and `tools/fb_contour_sweep.cpp` replaced with explicit read-modify-write.
+- **HMMLib Boost detection in benchmark CMake**: `HMMLIB_READY` was set
+  unconditionally when `hmm.hpp` existed; HMMLib uses `boost::shared_ptr`
+  internally. Now guards with `find_package(Boost QUIET)` and propagates
+  `${Boost_INCLUDE_DIRS}` through `enable_hmmlib()`.
+
+### Hygiene
+
+- `install/` added to `.gitignore`.
+
+---
+
 ## [4.2.2] - 2026-07-04
 
 MapBaumWelchTrainer convergence observability release. 47/47 tests pass.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(APPLE)
 endif()
 
 project(libhmm
-    VERSION 4.2.2
+    VERSION 4.2.3
     DESCRIPTION "Modern C++20 Hidden Markov Model Library"
     LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://isocpp.org/std/the-standard)
 [![CMake](https://img.shields.io/badge/CMake-3.20%2B-blue.svg)](https://cmake.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-4.2.2-brightgreen.svg)](https://github.com/OldCrow/libhmm/releases)
+[![Version](https://img.shields.io/badge/Version-4.2.3-brightgreen.svg)](https://github.com/OldCrow/libhmm/releases)
 [![Tests](https://img.shields.io/badge/Tests-47%2F47_Passing-success.svg)](tests/)
 [![SIMD](https://img.shields.io/badge/SIMD-AVX--512%2FAVX2%2FSSE2%2FNEON-blue.svg)](src/distributions/)
 [![CI](https://github.com/OldCrow/libhmm/actions/workflows/ci.yml/badge.svg)](https://github.com/OldCrow/libhmm/actions)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -65,12 +65,16 @@ if(EXISTS "${LAMP_DIR}/hmmFind")
     set(LAMP_READY ON)
 endif()
 
-# HMMLib is a header-only library (SSE2/NEON intrinsics, no Boost runtime
-# dependency). The Boost check previously here was spurious — HMMLib headers
-# contain no Boost includes. Detect by checking for the canonical header.
+# HMMLib is a header-only library (SSE2/NEON intrinsics) but uses
+# boost::shared_ptr internally; both HMMLib and Boost headers must be present.
 set(HMMLIB_READY OFF)
 if(EXISTS "${HMMLIB_DIR}/HMMlib/hmm.hpp")
-    set(HMMLIB_READY ON)
+    find_package(Boost QUIET)
+    if(Boost_FOUND)
+        set(HMMLIB_READY ON)
+    else()
+        message(WARNING "HMMLib header found but Boost not available; HMMLib-dependent benchmarks will be skipped.")
+    endif()
 elseif(EXISTS "${HMMLIB_DIR}")
     message(WARNING "HMMLib directory found at ${HMMLIB_DIR} but hmm.hpp not found. HMMLib-dependent benchmarks will be skipped.")
 else()
@@ -156,6 +160,7 @@ function(enable_hmmlib target_name)
     target_include_directories(${target_name}
         SYSTEM PRIVATE
             ${HMMLIB_DIR}
+            ${Boost_INCLUDE_DIRS}
     )
 endfunction()
 

--- a/include/libhmm/calculators/basic_calculator.h
+++ b/include/libhmm/calculators/basic_calculator.h
@@ -21,10 +21,14 @@ namespace libhmm {
  * For the scalar alias:
  *   using Calculator = BasicCalculator<double>;
  *
- * @note Passing a temporary observation sequence is a compile error (the
- *       `SeqType&&` constructor overload is deleted). Bind the sequence to a
- *       named variable with sufficient lifetime before constructing a calculator;
- *       the reference must remain valid for the calculator's entire lifetime.
+ * @note Passing a temporary observation sequence to any derived calculator is
+ *       a compile error: both this base class and each derived class delete the
+ *       `SeqType&&` constructor overload.  The base-class deletion alone is
+ *       insufficient because a temporary binds to `const SeqType&` in the
+ *       derived constructor and reaches the base as a named lvalue, bypassing
+ *       the deleted overload.  Bind the sequence to a named variable with
+ *       sufficient lifetime before constructing a calculator; the reference
+ *       must remain valid for the calculator's entire lifetime.
  */
 template <typename Obs>
 class BasicCalculator {

--- a/include/libhmm/calculators/basic_forward_backward_calculator.h
+++ b/include/libhmm/calculators/basic_forward_backward_calculator.h
@@ -66,6 +66,12 @@ public:
     BasicForwardBackwardCalculator &operator=(BasicForwardBackwardCalculator &&) = default;
     ~BasicForwardBackwardCalculator() override = default;
 
+    /// Deleted: passing a temporary observation sequence is UB (dangling reference).
+    /// The base-class deletion is bypassed when a temporary binds to `const SeqType&`
+    /// in a derived constructor; this overload closes that gap on the derived class.
+    BasicForwardBackwardCalculator(const HmmType &, SeqType &&) = delete;
+    BasicForwardBackwardCalculator(HmmType *, SeqType &&) = delete;
+
     /**
      * @brief Re-run with a new observation sequence.
      * Reuses the precomputed log-transition matrices.
@@ -492,6 +498,10 @@ void BasicForwardBackwardCalculator<Obs>::computeLogBackwardMaxReduce(std::size_
 
 template <typename Obs>
 StateSequence BasicForwardBackwardCalculator<Obs>::decodePosterior() const {
+    if (!std::isfinite(logProbability_)) {
+        throw std::runtime_error("decodePosterior: sequence has zero probability under this model "
+                                 "(logP = -inf); posterior decoding is undefined");
+    }
     const std::size_t T = logAlpha_.size1();
     StateSequence result(T);
     // Subtract logProbability_ before the argmax.  The constant cancels in the

--- a/include/libhmm/calculators/basic_viterbi_calculator.h
+++ b/include/libhmm/calculators/basic_viterbi_calculator.h
@@ -53,6 +53,12 @@ public:
     BasicViterbiCalculator &operator=(BasicViterbiCalculator &&) = default;
     ~BasicViterbiCalculator() override = default;
 
+    /// Deleted: passing a temporary observation sequence is UB (dangling reference).
+    /// The base-class deletion is bypassed when a temporary binds to `const SeqType&`
+    /// in a derived constructor; this overload closes that gap on the derived class.
+    BasicViterbiCalculator(const HmmType &, SeqType &&) = delete;
+    BasicViterbiCalculator(HmmType *, SeqType &&) = delete;
+
     /**
      * @brief Run (or re-run) Viterbi decoding on the current observation sequence.
      * @return The most likely state sequence (length T).

--- a/include/libhmm/libhmm.h
+++ b/include/libhmm/libhmm.h
@@ -28,7 +28,7 @@
  * For large projects or when compilation time is critical, consider including
  * only the specific headers you need instead of this master header.
  *
- * @version 4.2.2
+ * @version 4.2.3
  * @author libhmm development team
  */
 

--- a/include/libhmm/training/basic_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_baum_welch_trainer.h
@@ -331,8 +331,12 @@ void BasicBaumWelchTrainer<Obs>::m_step_transitions(HmmType &hmm, std::size_t N,
     Matrix newTrans(N, N);
     for (std::size_t i = 0; i < N; ++i) {
         for (std::size_t j = 0; j < N; ++j) {
-            newTrans(i, j) = (transDen[i] > 0.0) ? transNumT[j * N + i] / transDen[i]
-                                                 : 1.0 / static_cast<double>(N);
+            // Use precision::ZERO (same threshold as m_step_pi) to reject denormal
+            // transDen values — plain > 0.0 admits denormals and the division can
+            // produce NaN/inf when all gamma terms underflow.
+            newTrans(i, j) = (transDen[i] >= constants::precision::ZERO)
+                                 ? transNumT[j * N + i] / transDen[i]
+                                 : 1.0 / static_cast<double>(N);
         }
     }
     hmm.setTrans(newTrans);

--- a/include/libhmm/training/basic_map_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_map_baum_welch_trainer.h
@@ -261,18 +261,6 @@ void BasicMapBaumWelchTrainer<Obs>::apply_discrete_smoothing(HmmType &hmm, std::
             dd.setProbability(static_cast<double>(k),
                               (dd.getSymbolProbability(k) * sumW + c) / denom);
         }
-        // Re-normalize: guards against un-normalized probabilities when
-        // DiscreteDistribution::fit() used an inflated sumW denominator
-        // (e.g. out-of-range observations counted in weight sum but not in
-        // per-symbol bins), which leaves the pre-smoothing pdf summing to < 1.
-        double total = 0.0;
-        for (std::size_t k = 0; k < K; ++k)
-            total += dd.getSymbolProbability(k);
-        if (total > 0.0 && std::isfinite(total)) {
-            const double inv_total = 1.0 / total;
-            for (std::size_t k = 0; k < K; ++k)
-                dd.setProbability(static_cast<double>(k), dd.getSymbolProbability(k) * inv_total);
-        }
     }
 }
 
@@ -427,7 +415,8 @@ void BasicMapBaumWelchTrainer<Obs>::m_step_pi_map(HmmType &hmm, std::size_t N,
     const double denom = piSum + static_cast<double>(N) * c;
     Vector pi(N);
     for (std::size_t i = 0; i < N; ++i)
-        pi(i) = (denom > 0.0) ? (piNum[i] + c) / denom : 1.0 / static_cast<double>(N);
+        pi(i) = (denom >= constants::precision::ZERO) ? (piNum[i] + c) / denom
+                                                      : 1.0 / static_cast<double>(N);
     hmm.setPi(pi);
 }
 
@@ -441,8 +430,9 @@ void BasicMapBaumWelchTrainer<Obs>::m_step_transitions_map(HmmType &hmm, std::si
     for (std::size_t i = 0; i < N; ++i) {
         const double denom = transDen[i] + Nc;
         for (std::size_t j = 0; j < N; ++j) {
-            newTrans(i, j) =
-                (denom > 0.0) ? (transNumT[j * N + i] + c) / denom : 1.0 / static_cast<double>(N);
+            newTrans(i, j) = (denom >= constants::precision::ZERO)
+                                 ? (transNumT[j * N + i] + c) / denom
+                                 : 1.0 / static_cast<double>(N);
         }
     }
     hmm.setTrans(newTrans);

--- a/src/distributions/discrete_distribution.cpp
+++ b/src/distributions/discrete_distribution.cpp
@@ -66,7 +66,9 @@ void DiscreteDistribution::fit(std::span<const double> data) {
 }
 
 void DiscreteDistribution::fit(std::span<const double> data, std::span<const double> weights) {
-    // Weighted empirical probabilities: P(X=k) = Σ(w_i for x_i=k) / Σ(w_i)
+    // Weighted empirical probabilities: P(X=k) = Σ(w_i | x_i=k) / Σ(w_i | x_i in-range)
+    // Dividing by total sumW (including out-of-range observations) would leave the
+    // pmf summing to < 1 when any observations fall outside the symbol range.
     const double sumW = std::accumulate(weights.begin(), weights.end(), 0.0);
     // Guard: keep current parameters when effective weight is near zero.
     // Calling reset() would destroy valid parameters and cause state collapse in EM.
@@ -74,15 +76,23 @@ void DiscreteDistribution::fit(std::span<const double> data, std::span<const dou
         return;
 
     std::fill(pdf_.begin(), pdf_.end(), 0.0);
+    double binnedW = 0.0;
     for (std::size_t i = 0; i < data.size(); ++i) {
         if (data[i] >= 0.0) {
             const auto index = static_cast<std::size_t>(data[i]);
-            if (isValidIndex(index))
+            if (isValidIndex(index)) {
                 pdf_[index] += weights[i];
+                binnedW += weights[i];
+            }
         }
     }
+    // All weight fell outside the symbol range; keep current parameters.
+    if (binnedW < precision::ZERO) {
+        std::fill(pdf_.begin(), pdf_.end(), 0.0); // undo partial accumulation
+        return;
+    }
     for (double &p : pdf_)
-        p /= sumW;
+        p /= binnedW;
     invalidateCache();
 }
 

--- a/tools/bw_hotspot.cpp
+++ b/tools/bw_hotspot.cpp
@@ -221,7 +221,7 @@ BwBreakdown profile_bw(const Hmm &hmm, const ObservationSet &obs, int warmup, in
         const double xi_time = elapsed_ms(t0);
 
         // Sink to prevent elision.
-        g_sink += piNum[0] + transDen[0] + transNum[0] + emisWts[0];
+        g_sink = g_sink + piNum[0] + transDen[0] + transNum[0] + emisWts[0];
 
         if (iter >= warmup) {
             fb_ms_v.push_back(fb_time);

--- a/tools/fb_contour_sweep.cpp
+++ b/tools/fb_contour_sweep.cpp
@@ -263,7 +263,7 @@ Timings run_once(const Hmm &hmm, const ObservationSet &obs) {
         log_probability = log_sum_exp_pairwise(log_probability, log_alpha(t - 1, i));
     }
     out.reduction_ms = elapsed_ms(stage_start);
-    g_sink_double += log_probability;
+    g_sink_double = g_sink_double + log_probability;
 
     out.total_ms = elapsed_ms(total_start);
     return out;

--- a/tools/hotspot_breakdown.cpp
+++ b/tools/hotspot_breakdown.cpp
@@ -272,7 +272,7 @@ ForwardBreakdown profile_forward_backward(const Hmm &hmm, const ObservationSet &
             log_probability = log_sum_exp(log_probability, log_alpha(t - 1, i));
         }
         const double reduction_time = elapsed_ms(stage_start);
-        g_sink_double += log_probability;
+        g_sink_double = g_sink_double + log_probability;
 
         if (iter >= warmup) {
             transition_ms.push_back(trans_time);
@@ -403,8 +403,8 @@ ViterbiBreakdown profile_viterbi(const Hmm &hmm, const ObservationSet &obs, cons
             }
         }
         const double backtrack_time = elapsed_ms(stage_start);
-        g_sink_double += best_val;
-        g_sink_int += sequence[0];
+        g_sink_double = g_sink_double + best_val;
+        g_sink_int = g_sink_int + sequence[0];
 
         if (iter >= warmup) {
             transition_ms.push_back(trans_time);


### PR DESCRIPTION
## Summary

Addresses findings 3, 6, 7, 8, 11 from the 2026-07-04 audit, plus pre-existing tool build warnings and a benchmark CMake correctness fix. This is the libhmm half of the fix; the pylibhmm half (Finding 1 — UAF Holder pattern) follows in a separate PR against that repo.

## Changes

**Finding 3 — Compile-time guard against temporary observation sequences**
Add deleted `SeqType&&` constructor overloads to `BasicForwardBackwardCalculator` and `BasicViterbiCalculator`. The base-class deletion was ineffective: a temporary bound to `const SeqType&` in a derived constructor reached the base as a named lvalue, bypassing the deleted overload. The new derived-class overloads close the gap and will cause the pylibhmm `_core.cpp` bindings to fail to compile at the exact UAF sites (Finding 1), making them self-announcing.

**Finding 6 — Denormal guard inconsistency in M-step**
`m_step_transitions` (BW trainer) used `> 0.0` where `m_step_pi` correctly uses `>= precision::ZERO`. Same hazard in `m_step_pi_map` and `m_step_transitions_map` (MAP trainer). All three aligned to `>= precision::ZERO`.

**Finding 7 — DiscreteDistribution weighted fit under-normalises**
`fit(data, weights)` divided by `sumW` (total weight, including out-of-range observations), leaving the pmf summing to < 1 when any observation fell outside the symbol range. Now accumulates `binnedW` (weight that landed in bins) and divides by that. Removes the compensating renormalisation pass from `apply_discrete_smoothing` in the MAP trainer.

**Finding 8 — decodePosterior silent failure on zero-probability sequences**
When `logP = -inf`, the `logAlpha + logBeta - logP` scores were NaN; all comparisons were false, silently returning all-state-0. Now throws `std::runtime_error` when `!isfinite(logProbability_)`.

**Finding 11 — Hygiene**
Add `install/` to `.gitignore`.

**Benchmark CMake — HMMLib Boost detection**
The previous version incorrectly claimed HMMLib has no Boost dependency and set `HMMLIB_READY ON` unconditionally when `hmm.hpp` existed. HMMLib uses `boost::shared_ptr` internally. Now guards with `find_package(Boost QUIET)` and propagates `${Boost_INCLUDE_DIRS}` through `enable_hmmlib()`.

**Tool warnings**
Fix 5 instances of deprecated compound assignment on `volatile`-qualified types (C++20) in `hotspot_breakdown`, `bw_hotspot`, and `fb_contour_sweep`.

## Verification

- Clean release build: zero errors, zero warnings
- 47/47 ctest binaries pass (932 GTest cases)

## Related

- Finding 1 (UAF in pylibhmm bindings): pylibhmm PR to follow — these guard changes will produce compile errors at the UAF sites in `_core.cpp`
- Findings 4 & 5 (E-step deduplication and memory): deferred to a separate `refactor/estep-dedup` branch

---
[Warp conversation](https://app.warp.dev/conversation/d307185b-6537-4f6a-9a8e-73705f8086eb)
