### PR TITLE
refactor: extract shared BW E-step; eliminate per-state observation copies (Findings 4+5)

### DIFF
--- a/include/libhmm/training/basic_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_baum_welch_trainer.h
@@ -12,8 +12,8 @@
 #include "libhmm/calculators/basic_forward_backward_calculator.h"
 #include "libhmm/detail/log_utils.h"
 #include "libhmm/linalg/linalg_types.h"
-#include "libhmm/performance/transcendental_kernels.h"
 #include "libhmm/training/basic_trainer.h"
+#include "libhmm/training/detail/bw_estep.h"
 
 namespace libhmm {
 
@@ -64,60 +64,9 @@ public:
     [[nodiscard]] double getLastLogProbability() const noexcept { return lastLogProb_; }
 
 private:
-    static constexpr double LOG_ZERO = detail::LOG_ZERO;
-
     double lastLogProb_{-std::numeric_limits<double>::infinity()};
 
-    // -------------------------------------------------------------------------
-    // Emission accumulator types
-    //
-    // EmisElem adapts to the observation type:
-    //   Obs=double             → double              (scalar observation value)
-    //   Obs=ObservationVectorView → ObservationVectorView (non-owning row span)
-    // EmisAccumType is a per-state vector-of-vectors of these elements.
-    // -------------------------------------------------------------------------
-    using EmisElem = std::conditional_t<std::is_same_v<Obs, double>, double, ObservationVectorView>;
-    using EmisAccumType = std::vector<std::vector<EmisElem>>;
-
-    /// Mutable accumulators passed through the E-step as a single aggregate.
-    struct EStepBuffers {
-        EmisAccumType &emisAccum;
-        std::vector<std::vector<double>> &emisWts;
-        std::vector<double> &piNum;
-        std::vector<double> &transDen;
-        std::vector<double> &transNumT;
-    };
-
-    // -------------------------------------------------------------------------
-    // Helpers
-    // -------------------------------------------------------------------------
-
-    /**
-     * @brief Run the E-step for one observation sequence.
-     *
-     * Runs BasicForwardBackwardCalculator, accumulates gamma statistics
-     * (emission data/weights, π numerator, transition denominator) and
-     * xi statistics (expected transition counts) into @p bufs.
-     *
-     * @return finite log-probability if the sequence contributed; -∞ if the
-     *         sequence was skipped (empty or zero probability).
-     */
-    [[nodiscard]] static double accum_one_sequence(const HmmType &hmm, const SeqType &obs,
-                                                   std::size_t N,
-                                                   const std::vector<double> &logTransT,
-                                                   bool hasZeroTransitions, EStepBuffers &bufs);
-
-    /**
-     * @brief Accumulate expected transition counts (xi) for one sequence.
-     *
-     * Dispatches to a branch-free SIMD path (dense model) or a zero-skip path
-     * (sparse model) based on @p hasZeroTransitions.
-     */
-    static void accumulate_xi(const double *logAlphaData, const double *logBetaData,
-                              const std::vector<double> &logEmitByTime,
-                              const std::vector<double> &logTransT, double logP, std::size_t T,
-                              std::size_t N, bool hasZeroTransitions,
-                              std::vector<double> &transNumT) noexcept;
+    using EmisElem = BwEmisElem<Obs>;
 
     /// M-step: normalise piNum and update the HMM initial-state distribution.
     static void m_step_pi(HmmType &hmm, std::size_t N, const std::vector<double> &piNum);
@@ -154,30 +103,28 @@ void BasicBaumWelchTrainer<Obs>::train() {
     bool hasZeroTransitions = false;
     this->precompute_log_trans_flat(hmm, N, logTransT, hasZeroTransitions);
 
-    // Accumulators for π, transitions (shared), and emissions (type-specific).
+    // Accumulators for π, transitions, and emissions.
+    // emisObs: one shared copy of all observation values across all sequences.
+    // emisWts[i]: per-state gamma weights at matching positions.
     std::vector<double> piNum(N, 0.0);
     std::vector<double> transDen(N, 0.0);
     std::vector<double> transNumT(N * N, 0.0);
-    EmisAccumType emisAccum(N);
+    std::vector<EmisElem> emisObs;
     std::vector<std::vector<double>> emisWts(N);
 
-    // Pre-allocate emission buffers on the scalar path to avoid repeated
-    // reallocations when accumulating over many sequences.
-    if constexpr (std::is_same_v<Obs, double>) {
-        const std::size_t totalLen = std::accumulate(
-            this->getObservationLists().begin(), this->getObservationLists().end(), std::size_t{0},
-            [](std::size_t s, const auto &obs) { return s + obs.size(); });
-        for (std::size_t i = 0; i < N; ++i) {
-            emisAccum[i].reserve(totalLen);
-            emisWts[i].reserve(totalLen);
-        }
-    }
+    // Pre-allocate to avoid repeated reallocations.
+    const std::size_t totalLen = std::accumulate(
+        this->getObservationLists().begin(), this->getObservationLists().end(), std::size_t{0},
+        [](std::size_t s, const auto &seq) { return s + ObsSeqTraits<Obs>::sequence_length(seq); });
+    emisObs.reserve(totalLen);
+    for (std::size_t i = 0; i < N; ++i)
+        emisWts[i].reserve(totalLen);
 
-    EStepBuffers bufs{emisAccum, emisWts, piNum, transDen, transNumT};
+    BwEStepBuffers<Obs> bufs{emisObs, emisWts, piNum, transDen, transNumT};
     std::size_t validSeqs = 0;
     double totalLogProb = 0.0;
     for (const auto &obs : this->getObservationLists()) {
-        const double logP = accum_one_sequence(hmm, obs, N, logTransT, hasZeroTransitions, bufs);
+        const double logP = bw_accum_one_sequence(hmm, obs, N, logTransT, hasZeroTransitions, bufs);
         if (std::isfinite(logP)) {
             totalLogProb += logP;
             ++validSeqs;
@@ -205,105 +152,17 @@ void BasicBaumWelchTrainer<Obs>::train() {
     m_step_pi(hmm, N, piNum);
     m_step_transitions(hmm, N, transNumT, transDen);
 
-    // Emission M-step: EmisElem resolves to double (scalar) or
-    // ObservationVectorView (MV), selecting the correct fit() overload.
+    // Emission M-step: emisObs is the shared observation buffer; emisWts[i]
+    // holds the matching per-state gamma weights.  EmisElem resolves to
+    // double (scalar) or ObservationVectorView (MV).
+    const std::size_t M = emisObs.size();
     for (std::size_t i = 0; i < N; ++i) {
-        const std::size_t M = emisAccum[i].size();
         if (M == 0) {
             hmm.getDistribution(i).reset();
             continue;
         }
-        hmm.getDistribution(i).fit(std::span<const EmisElem>(emisAccum[i].data(), M),
+        hmm.getDistribution(i).fit(std::span<const EmisElem>(emisObs.data(), M),
                                    std::span<const double>(emisWts[i].data(), M));
-    }
-}
-
-// ---------------------------------------------------------------------------
-// accum_one_sequence — E-step for a single observation sequence
-// ---------------------------------------------------------------------------
-
-template <typename Obs>
-double BasicBaumWelchTrainer<Obs>::accum_one_sequence(const HmmType &hmm, const SeqType &obs,
-                                                      std::size_t N,
-                                                      const std::vector<double> &logTransT,
-                                                      bool hasZeroTransitions, EStepBuffers &bufs) {
-    const std::size_t T = ObsSeqTraits<Obs>::sequence_length(obs);
-    if (T == 0)
-        return -std::numeric_limits<double>::infinity();
-
-    BasicForwardBackwardCalculator<Obs> fbc(hmm, obs);
-    const double logP = fbc.getLogProbability();
-    if (!std::isfinite(logP))
-        return -std::numeric_limits<double>::infinity();
-
-    const double *alphaData = fbc.getLogForwardVariables().data();
-    const double *betaData = fbc.getLogBackwardVariables().data();
-
-    for (std::size_t t = 0; t < T; ++t) {
-        const double *aRow = alphaData + t * N;
-        const double *bRow = betaData + t * N;
-        // Compute observation value/view once per timestep, outside the state loop.
-        const EmisElem obs_t = [&]() -> EmisElem {
-            if constexpr (std::is_same_v<Obs, double>)
-                return obs(t);
-            else
-                return row_view(obs, t);
-        }();
-        for (std::size_t i = 0; i < N; ++i) {
-            const double g = std::exp(aRow[i] + bRow[i] - logP);
-            bufs.emisAccum[i].push_back(obs_t);
-            bufs.emisWts[i].push_back(g);
-            if (t == 0)
-                bufs.piNum[i] += g;
-            if (t < T - 1)
-                bufs.transDen[i] += g;
-        }
-    }
-
-    // Reuse the FBC's emission buffer — avoids a second emission evaluation.
-    accumulate_xi(alphaData, betaData, fbc.getLogEmitByTime(), logTransT, logP, T, N,
-                  hasZeroTransitions, bufs.transNumT);
-    return logP;
-}
-
-// ---------------------------------------------------------------------------
-// Shared static helpers
-// ---------------------------------------------------------------------------
-
-template <typename Obs>
-void BasicBaumWelchTrainer<Obs>::accumulate_xi(
-    const double *logAlphaData, const double *logBetaData, const std::vector<double> &logEmitByTime,
-    const std::vector<double> &logTransT, double logP, std::size_t T, std::size_t N,
-    bool hasZeroTransitions, std::vector<double> &transNumT) noexcept {
-    if (hasZeroTransitions) {
-        for (std::size_t t = 0; t + 1 < T; ++t) {
-            const double *alphaRow = logAlphaData + t * N;
-            const double *betaNextRow = logBetaData + (t + 1) * N;
-            const double *emitNextRow = logEmitByTime.data() + (t + 1) * N;
-            for (std::size_t j = 0; j < N; ++j) {
-                const double emitBetaNext = emitNextRow[j] + betaNextRow[j] - logP;
-                const double *transCol = logTransT.data() + j * N;
-                double *transNumCol = transNumT.data() + j * N;
-                for (std::size_t i = 0; i < N; ++i) {
-                    if (transCol[i] == LOG_ZERO)
-                        continue;
-                    transNumCol[i] += std::exp(alphaRow[i] + transCol[i] + emitBetaNext);
-                }
-            }
-        }
-    } else {
-        for (std::size_t t = 0; t + 1 < T; ++t) {
-            const double *alphaRow = logAlphaData + t * N;
-            const double *betaNextRow = logBetaData + (t + 1) * N;
-            const double *emitNextRow = logEmitByTime.data() + (t + 1) * N;
-            for (std::size_t j = 0; j < N; ++j) {
-                const double emitBetaNext = emitNextRow[j] + betaNextRow[j] - logP;
-                const double *transCol = logTransT.data() + j * N;
-                double *transNumCol = transNumT.data() + j * N;
-                performance::detail::TranscendentalKernels::accumulate_exp_sum2_bias(
-                    transNumCol, alphaRow, transCol, N, emitBetaNext);
-            }
-        }
     }
 }
 

--- a/include/libhmm/training/basic_map_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_map_baum_welch_trainer.h
@@ -12,8 +12,8 @@
 #include "libhmm/detail/log_utils.h"
 #include "libhmm/distributions/discrete_distribution.h"
 #include "libhmm/linalg/linalg_types.h"
-#include "libhmm/performance/transcendental_kernels.h"
 #include "libhmm/training/basic_trainer.h"
+#include "libhmm/training/detail/bw_estep.h"
 
 namespace libhmm {
 
@@ -100,27 +100,7 @@ private:
 
     static constexpr double LOG_ZERO = detail::LOG_ZERO;
 
-    // Same type-adapting accumulator pattern as BasicBaumWelchTrainer.
-    using EmisElem = std::conditional_t<std::is_same_v<Obs, double>, double, ObservationVectorView>;
-    using EmisAccumType = std::vector<std::vector<EmisElem>>;
-
-    /// Mutable accumulators passed through the E-step as a single aggregate.
-    struct EStepBuffers {
-        EmisAccumType &emisAccum;
-        std::vector<std::vector<double>> &emisWts;
-        std::vector<double> &piNum;
-        std::vector<double> &transDen;
-        std::vector<double> &transNumT;
-    };
-
-    /**
-     * @brief Run the E-step for one sequence (same logic as BaumWelchTrainer).
-     * @return Finite log P(O|λ) if the sequence contributed; −∞ if skipped.
-     */
-    [[nodiscard]] static double accum_one_sequence(const HmmType &hmm, const SeqType &obs,
-                                                   std::size_t N,
-                                                   const std::vector<double> &logTransT,
-                                                   bool hasZeroTransitions, EStepBuffers &bufs);
+    using EmisElem = BwEmisElem<Obs>;
 
     /**
      * @brief Dirichlet-smoothed log-prior over discrete emission distributions.
@@ -135,13 +115,6 @@ private:
      */
     static void apply_discrete_smoothing(HmmType &hmm, std::size_t state,
                                          const std::vector<double> &wts, double c);
-
-    /// Expected transition counts (xi) for one sequence.
-    static void accumulate_xi(const double *logAlphaData, const double *logBetaData,
-                              const std::vector<double> &logEmitByTime,
-                              const std::vector<double> &logTransT, double logP, std::size_t T,
-                              std::size_t N, bool hasZeroTransitions,
-                              std::vector<double> &transNumT) noexcept;
 
     /// MAP M-step for π: add c to each numerator.
     static void m_step_pi_map(HmmType &hmm, std::size_t N, const std::vector<double> &piNum,
@@ -265,45 +238,6 @@ void BasicMapBaumWelchTrainer<Obs>::apply_discrete_smoothing(HmmType &hmm, std::
 }
 
 template <typename Obs>
-double BasicMapBaumWelchTrainer<Obs>::accum_one_sequence(const HmmType &hmm, const SeqType &obs,
-                                                         std::size_t N,
-                                                         const std::vector<double> &logTransT,
-                                                         bool hasZeroTransitions,
-                                                         EStepBuffers &bufs) {
-    const std::size_t T = ObsSeqTraits<Obs>::sequence_length(obs);
-    if (T == 0)
-        return -std::numeric_limits<double>::infinity();
-    BasicForwardBackwardCalculator<Obs> fbc(hmm, obs);
-    const double logP = fbc.getLogProbability();
-    if (!std::isfinite(logP))
-        return -std::numeric_limits<double>::infinity();
-    const double *alphaData = fbc.getLogForwardVariables().data();
-    const double *betaData = fbc.getLogBackwardVariables().data();
-    for (std::size_t t = 0; t < T; ++t) {
-        const double *aRow = alphaData + t * N;
-        const double *bRow = betaData + t * N;
-        const EmisElem obs_t = [&]() -> EmisElem {
-            if constexpr (std::is_same_v<Obs, double>)
-                return obs(t);
-            else
-                return row_view(obs, t);
-        }();
-        for (std::size_t i = 0; i < N; ++i) {
-            const double g = std::exp(aRow[i] + bRow[i] - logP);
-            bufs.emisAccum[i].push_back(obs_t);
-            bufs.emisWts[i].push_back(g);
-            if (t == 0)
-                bufs.piNum[i] += g;
-            if (t < T - 1)
-                bufs.transDen[i] += g;
-        }
-    }
-    accumulate_xi(alphaData, betaData, fbc.getLogEmitByTime(), logTransT, logP, T, N,
-                  hasZeroTransitions, bufs.transNumT);
-    return logP;
-}
-
-template <typename Obs>
 void BasicMapBaumWelchTrainer<Obs>::train() {
     HmmType &hmm = this->getHmmRef();
     const std::size_t N = hmm.getNumStatesModern();
@@ -316,25 +250,22 @@ void BasicMapBaumWelchTrainer<Obs>::train() {
     std::vector<double> piNum(N, 0.0);
     std::vector<double> transDen(N, 0.0);
     std::vector<double> transNumT(N * N, 0.0);
-    EmisAccumType emisAccum(N);
+    std::vector<EmisElem> emisObs;
     std::vector<std::vector<double>> emisWts(N);
 
-    if constexpr (std::is_same_v<Obs, double>) {
-        const std::size_t totalLen = std::accumulate(
-            this->getObservationLists().begin(), this->getObservationLists().end(), std::size_t{0},
-            [](std::size_t s, const auto &obs) { return s + obs.size(); });
-        for (std::size_t i = 0; i < N; ++i) {
-            emisAccum[i].reserve(totalLen);
-            emisWts[i].reserve(totalLen);
-        }
-    }
+    const std::size_t totalLen = std::accumulate(
+        this->getObservationLists().begin(), this->getObservationLists().end(), std::size_t{0},
+        [](std::size_t s, const auto &seq) { return s + ObsSeqTraits<Obs>::sequence_length(seq); });
+    emisObs.reserve(totalLen);
+    for (std::size_t i = 0; i < N; ++i)
+        emisWts[i].reserve(totalLen);
 
-    EStepBuffers bufs{emisAccum, emisWts, piNum, transDen, transNumT};
+    BwEStepBuffers<Obs> bufs{emisObs, emisWts, piNum, transDen, transNumT};
     std::size_t validSeqs = 0;
     lastLogProb_ = -std::numeric_limits<double>::infinity();
     double totalLogProb = 0.0;
     for (const auto &obs : this->getObservationLists()) {
-        const double logP = accum_one_sequence(hmm, obs, N, logTransT, hasZeroTransitions, bufs);
+        const double logP = bw_accum_one_sequence(hmm, obs, N, logTransT, hasZeroTransitions, bufs);
         if (std::isfinite(logP)) {
             totalLogProb += logP;
             ++validSeqs;
@@ -350,16 +281,16 @@ void BasicMapBaumWelchTrainer<Obs>::train() {
     m_step_pi_map(hmm, N, piNum, c);
     m_step_transitions_map(hmm, N, transNumT, transDen, c);
 
-    // Emission M-step: EmisElem selects the correct fit() overload.
-    // On the scalar path, apply Dirichlet smoothing to discrete distributions.
+    // Emission M-step: emisObs is the shared observation buffer; emisWts[i]
+    // holds the matching per-state gamma weights.
+    const std::size_t M = emisObs.size();
     for (std::size_t i = 0; i < N; ++i) {
-        const std::size_t M = emisAccum[i].size();
         auto &dist = hmm.getDistribution(i);
         if (M == 0) {
             dist.reset();
             continue;
         }
-        dist.fit(std::span<const EmisElem>(emisAccum[i].data(), M),
+        dist.fit(std::span<const EmisElem>(emisObs.data(), M),
                  std::span<const double>(emisWts[i].data(), M));
         // apply_discrete_smoothing is a no-op when c==0 or dist is not discrete.
         if constexpr (std::is_same_v<Obs, double>)
@@ -368,45 +299,8 @@ void BasicMapBaumWelchTrainer<Obs>::train() {
 }
 
 // ---------------------------------------------------------------------------
-// Static helpers
+// Static helpers (MAP-specific; E-step functions are in detail/bw_estep.h)
 // ---------------------------------------------------------------------------
-
-template <typename Obs>
-void BasicMapBaumWelchTrainer<Obs>::accumulate_xi(
-    const double *logAlphaData, const double *logBetaData, const std::vector<double> &logEmitByTime,
-    const std::vector<double> &logTransT, double logP, std::size_t T, std::size_t N,
-    bool hasZeroTransitions, std::vector<double> &transNumT) noexcept {
-    if (hasZeroTransitions) {
-        for (std::size_t t = 0; t + 1 < T; ++t) {
-            const double *alphaRow = logAlphaData + t * N;
-            const double *betaNextRow = logBetaData + (t + 1) * N;
-            const double *emitNextRow = logEmitByTime.data() + (t + 1) * N;
-            for (std::size_t j = 0; j < N; ++j) {
-                const double emitBetaNext = emitNextRow[j] + betaNextRow[j] - logP;
-                const double *transCol = logTransT.data() + j * N;
-                double *transNumCol = transNumT.data() + j * N;
-                for (std::size_t i = 0; i < N; ++i) {
-                    if (transCol[i] == LOG_ZERO)
-                        continue;
-                    transNumCol[i] += std::exp(alphaRow[i] + transCol[i] + emitBetaNext);
-                }
-            }
-        }
-    } else {
-        for (std::size_t t = 0; t + 1 < T; ++t) {
-            const double *alphaRow = logAlphaData + t * N;
-            const double *betaNextRow = logBetaData + (t + 1) * N;
-            const double *emitNextRow = logEmitByTime.data() + (t + 1) * N;
-            for (std::size_t j = 0; j < N; ++j) {
-                const double emitBetaNext = emitNextRow[j] + betaNextRow[j] - logP;
-                const double *transCol = logTransT.data() + j * N;
-                double *transNumCol = transNumT.data() + j * N;
-                performance::detail::TranscendentalKernels::accumulate_exp_sum2_bias(
-                    transNumCol, alphaRow, transCol, N, emitBetaNext);
-            }
-        }
-    }
-}
 
 template <typename Obs>
 void BasicMapBaumWelchTrainer<Obs>::m_step_pi_map(HmmType &hmm, std::size_t N,

--- a/include/libhmm/training/detail/bw_estep.h
+++ b/include/libhmm/training/detail/bw_estep.h
@@ -1,0 +1,184 @@
+#pragma once
+
+/**
+ * @file bw_estep.h
+ * @brief Shared Baum-Welch E-step types and functions.
+ *
+ * Extracted from BasicBaumWelchTrainer and BasicMapBaumWelchTrainer to
+ * eliminate the ~150-line near-verbatim duplication that caused drift
+ * between the two (issue #55 / audit Finding 4).
+ *
+ * Finding 5 (redundant per-state observation copies) is also addressed here:
+ * BwEStepBuffers holds a single shared observation vector rather than N
+ * identical per-state copies.  Only the per-state gamma weights differ.
+ *
+ * Internal header — include only from trainer implementations.
+ */
+
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <span>
+#include <type_traits>
+#include <vector>
+
+#include "libhmm/calculators/basic_forward_backward_calculator.h"
+#include "libhmm/detail/log_utils.h"
+#include "libhmm/linalg/linalg_types.h"
+#include "libhmm/performance/transcendental_kernels.h"
+
+namespace libhmm {
+
+// =============================================================================
+// E-step accumulator types
+// =============================================================================
+
+/**
+ * @brief Observation element type for the Baum-Welch E-step.
+ *
+ * `double` on the scalar path; `ObservationVectorView` on the MV path.
+ */
+template <typename Obs>
+using BwEmisElem = std::conditional_t<std::is_same_v<Obs, double>, double, ObservationVectorView>;
+
+/**
+ * @brief Mutable E-step accumulators, shared by BaumWelchTrainer and
+ *        MapBaumWelchTrainer.
+ *
+ * Finding 5 fix: @p emisObs holds one copy of all observations concatenated
+ * across all processed sequences.  @p emisWts[i] holds the matching per-state
+ * gamma weights at each position.  The M-step passes @p emisObs as the data
+ * span and @p emisWts[i] as the weight span for each state's fit() call.
+ * Previously, N identical copies of @p emisObs were stored — one per state.
+ */
+template <typename Obs>
+struct BwEStepBuffers {
+    using EmisElem = BwEmisElem<Obs>;
+
+    std::vector<EmisElem> &emisObs;            ///< Shared observation sequence (one copy)
+    std::vector<std::vector<double>> &emisWts; ///< Per-state gamma weights
+    std::vector<double> &piNum;                ///< π numerator (γ at t=0 per state)
+    std::vector<double> &transDen;             ///< Transition denominator (γ_{t<T-1} per state)
+    std::vector<double> &transNumT;            ///< Expected transition counts, column-major N×N
+};
+
+// =============================================================================
+// Shared E-step functions
+// =============================================================================
+
+/**
+ * @brief Accumulate expected transition counts (xi) for one sequence.
+ *
+ * Observation-type-independent: operates entirely on pre-computed log-space
+ * buffers.  Dispatches to a zero-skip path (sparse transitions) or the
+ * branch-free SIMD path (dense model).
+ *
+ * @param logAlphaData  Row-major T×N forward variables (log-space).
+ * @param logBetaData   Row-major T×N backward variables (log-space).
+ * @param logEmitByTime Time-major T×N log-emission buffer from the FBC.
+ * @param logTransT     Column-major N×N log-transition matrix.
+ * @param logP          log P(O|λ) for this sequence.
+ * @param T             Sequence length.
+ * @param N             Number of states.
+ * @param hasZeroTransitions  True if any A(i,j) = 0 (enables zero-skip path).
+ * @param transNumT     [in/out] Column-major N×N expected transition counts.
+ */
+inline void bw_accumulate_xi(const double *logAlphaData, const double *logBetaData,
+                             const std::vector<double> &logEmitByTime,
+                             const std::vector<double> &logTransT, double logP, std::size_t T,
+                             std::size_t N, bool hasZeroTransitions,
+                             std::vector<double> &transNumT) noexcept {
+    constexpr double LOG_ZERO = detail::LOG_ZERO;
+    if (hasZeroTransitions) {
+        for (std::size_t t = 0; t + 1 < T; ++t) {
+            const double *alphaRow = logAlphaData + t * N;
+            const double *betaNextRow = logBetaData + (t + 1) * N;
+            const double *emitNextRow = logEmitByTime.data() + (t + 1) * N;
+            for (std::size_t j = 0; j < N; ++j) {
+                const double emitBetaNext = emitNextRow[j] + betaNextRow[j] - logP;
+                const double *transCol = logTransT.data() + j * N;
+                double *transNumCol = transNumT.data() + j * N;
+                for (std::size_t i = 0; i < N; ++i) {
+                    if (transCol[i] == LOG_ZERO)
+                        continue;
+                    transNumCol[i] += std::exp(alphaRow[i] + transCol[i] + emitBetaNext);
+                }
+            }
+        }
+    } else {
+        for (std::size_t t = 0; t + 1 < T; ++t) {
+            const double *alphaRow = logAlphaData + t * N;
+            const double *betaNextRow = logBetaData + (t + 1) * N;
+            const double *emitNextRow = logEmitByTime.data() + (t + 1) * N;
+            for (std::size_t j = 0; j < N; ++j) {
+                const double emitBetaNext = emitNextRow[j] + betaNextRow[j] - logP;
+                const double *transCol = logTransT.data() + j * N;
+                double *transNumCol = transNumT.data() + j * N;
+                performance::detail::TranscendentalKernels::accumulate_exp_sum2_bias(
+                    transNumCol, alphaRow, transCol, N, emitBetaNext);
+            }
+        }
+    }
+}
+
+/**
+ * @brief Run the E-step for one observation sequence.
+ *
+ * Runs BasicForwardBackwardCalculator<Obs>, accumulates gamma statistics
+ * (one shared observation entry per timestep, per-state gamma weights,
+ * π numerator, transition denominator) and xi statistics (expected
+ * transition counts) into @p bufs.
+ *
+ * The FBC's log-emission buffer is reused for the xi accumulation pass,
+ * avoiding a second emission evaluation.
+ *
+ * @return Finite log P(O|λ) if the sequence contributed; −∞ if skipped
+ *         (empty sequence or zero probability under the current model).
+ */
+template <typename Obs>
+[[nodiscard]] double bw_accum_one_sequence(const BasicHmm<Obs> &hmm,
+                                           const typename ObsSeqTraits<Obs>::SeqType &obs,
+                                           std::size_t N, const std::vector<double> &logTransT,
+                                           bool hasZeroTransitions, BwEStepBuffers<Obs> &bufs) {
+    using EmisElem = BwEmisElem<Obs>;
+
+    const std::size_t T = ObsSeqTraits<Obs>::sequence_length(obs);
+    if (T == 0)
+        return -std::numeric_limits<double>::infinity();
+
+    BasicForwardBackwardCalculator<Obs> fbc(hmm, obs);
+    const double logP = fbc.getLogProbability();
+    if (!std::isfinite(logP))
+        return -std::numeric_limits<double>::infinity();
+
+    const double *alphaData = fbc.getLogForwardVariables().data();
+    const double *betaData = fbc.getLogBackwardVariables().data();
+
+    for (std::size_t t = 0; t < T; ++t) {
+        const double *aRow = alphaData + t * N;
+        const double *bRow = betaData + t * N;
+        // One observation entry per timestep — shared across all states.
+        const EmisElem obs_t = [&]() -> EmisElem {
+            if constexpr (std::is_same_v<Obs, double>)
+                return obs(t);
+            else
+                return row_view(obs, t);
+        }();
+        bufs.emisObs.push_back(obs_t);
+        for (std::size_t i = 0; i < N; ++i) {
+            const double g = std::exp(aRow[i] + bRow[i] - logP);
+            bufs.emisWts[i].push_back(g);
+            if (t == 0)
+                bufs.piNum[i] += g;
+            if (t < T - 1)
+                bufs.transDen[i] += g;
+        }
+    }
+
+    // Reuse the FBC's emission buffer — avoids a second emission evaluation.
+    bw_accumulate_xi(alphaData, betaData, fbc.getLogEmitByTime(), logTransT, logP, T, N,
+                     hasZeroTransitions, bufs.transNumT);
+    return logP;
+}
+
+} // namespace libhmm


### PR DESCRIPTION
## Summary

Addresses Findings 4 (E-step duplication) and 5 (redundant per-state observation copies) from the 2026-07-04 audit.

## Finding 4 — E-step deduplication

`BasicBaumWelchTrainer` and `BasicMapBaumWelchTrainer` contained near-verbatim copies of ~150 lines of E-step logic (`EStepBuffers`, `accum_one_sequence`, `accumulate_xi`). The duplication had already caused a real regression: v4.2.2 existed solely to restore `getLastLogProbability()` parity that the copies had drifted apart on (issue #55).

**Fix:** Extract the shared E-step into `include/libhmm/training/detail/bw_estep.h`:
- `BwEmisElem<Obs>` — observation element type alias
- `BwEStepBuffers<Obs>` — accumulator aggregate (see Finding 5)
- `bw_accumulate_xi(...)` — `inline` non-template function (was instantiated per `Obs`; body never used `Obs`)
- `bw_accum_one_sequence<Obs>(...)` — function template

Both trainers now `#include` this header and call the shared functions directly.

## Finding 5 — Redundant per-state observation copies

`accum_one_sequence` pushed `obs_t` into `emisAccum[i]` **inside the state loop**, giving all N per-state vectors identical copies of the full observation stream. Only the gamma weights differed per state.

**Fix:** `BwEStepBuffers<Obs>` now holds a single `emisObs` vector (one copy of all observations concatenated across sequences) plus per-state `emisWts[i]`. The M-step `fit()` call receives `span(emisObs)` as data and `span(emisWts[i])` as weights — no API change.

| Model | Old storage | New storage |
|---|---|---|
| 10-state scalar, T=1000 | 10,000 doubles | 1,000 doubles |
| 10-state MV, T=1000 | 10,000 × 16-byte views | 1,000 × 16-byte views |

Pre-allocation (`reserve()`) is now applied to both scalar and MV paths; previously only the scalar path reserved.

## Verification

- 47/47 tests pass (zero warnings)
- Net: 3 files changed, 220 insertions, 283 deletions (the detail header adds ~185 lines; the two trainer headers lose ~468 combined)
