### PR TITLE
chore: bump version to 4.2.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides project-scoped guidance to AI agents and contributors working
 
 C++20 Hidden Markov Model library. Zero external dependencies (C++20 standard library only). GTest is fetched via `FetchContent` only for the test suite. Produces both a shared (`hmm`) and static (`hmm_static`) library from a single OBJECT target.
 
-`main` is the stable v4 branch (current release: v4.2.3). Multivariate HMM support is provided via `BasicHmm<Obs>` and `BasicEmissionDistribution<Obs>` templates. `using Hmm = BasicHmm<double>` and `using EmissionDistribution = BasicEmissionDistribution<double>` preserve v3 source compatibility; users consuming only the v3 API can build from `main` unchanged.
+`main` is the stable v4 branch (current release: v4.2.4). Multivariate HMM support is provided via `BasicHmm<Obs>` and `BasicEmissionDistribution<Obs>` templates. `using Hmm = BasicHmm<double>` and `using EmissionDistribution = BasicEmissionDistribution<double>` preserve v3 source compatibility; users consuming only the v3 API can build from `main` unchanged.
 
 ## Session start
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.4] - 2026-07-04
+
+Infrastructure and refactoring release. 47/47 tests pass. No API changes.
+
+### Added
+
+- **`LIBHMM_PORTABLE` CMake option** (Finding 9, libhmm half): when `ON`,
+  swaps `-march=native` for a portable baseline ISA (`-msse2` / `-march=armv8-a`)
+  on `LIBHMM_SIMD_SOURCES` TUs, so wheels do not SIGILL on machines with a lower
+  ISA than the build host. Runtime-dispatched tier-2 distribution kernels
+  (`DoubleVecOps`) are unaffected. Default: `OFF`. See issue #58 for the
+  long-term plan to extend tier-2 dispatch to these TUs.
+- **ASan/UBSan CI job** (Finding 2, libhmm half): Linux/GCC `asan` job in
+  `ci.yml` mirroring the existing `tsan` job. `-fsanitize=address,undefined`
+  with `-fno-omit-frame-pointer`; `detect_leaks=1`. Would have caught the
+  pylibhmm calculator UAF (Finding 1) at the native layer.
+
+### Refactored
+
+- **E-step deduplication** (Finding 4): extracted `EStepBuffers`,
+  `accum_one_sequence`, and `accumulate_xi` from `BasicBaumWelchTrainer` and
+  `BasicMapBaumWelchTrainer` into `include/libhmm/training/detail/bw_estep.h`.
+  The ~150-line near-verbatim duplication had already caused drift; v4.2.2 was
+  released solely to restore `getLastLogProbability()` parity between copies.
+  `bw_accumulate_xi` is now a single `inline` non-template function.
+- **Per-state observation copy elimination** (Finding 5): `BwEStepBuffers<Obs>`
+  holds one shared `emisObs` vector instead of N identical per-state copies.
+  For a 10-state scalar model over T=1000, E-step observation storage drops
+  from 10,000 doubles to 1,000. Pre-allocation extended to both scalar and MV
+  paths (was scalar-only).
+
+---
+
 ## [4.2.3] - 2026-07-04
 
 Security / correctness patch. 47/47 tests pass. No API additions; one narrow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(APPLE)
 endif()
 
 project(libhmm
-    VERSION 4.2.3
+    VERSION 4.2.4
     DESCRIPTION "Modern C++20 Hidden Markov Model Library"
     LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://isocpp.org/std/the-standard)
 [![CMake](https://img.shields.io/badge/CMake-3.20%2B-blue.svg)](https://cmake.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-4.2.3-brightgreen.svg)](https://github.com/OldCrow/libhmm/releases)
+[![Version](https://img.shields.io/badge/Version-4.2.4-brightgreen.svg)](https://github.com/OldCrow/libhmm/releases)
 [![Tests](https://img.shields.io/badge/Tests-47%2F47_Passing-success.svg)](tests/)
 [![SIMD](https://img.shields.io/badge/SIMD-AVX--512%2FAVX2%2FSSE2%2FNEON-blue.svg)](src/distributions/)
 [![CI](https://github.com/OldCrow/libhmm/actions/workflows/ci.yml/badge.svg)](https://github.com/OldCrow/libhmm/actions)

--- a/include/libhmm/libhmm.h
+++ b/include/libhmm/libhmm.h
@@ -28,7 +28,7 @@
  * For large projects or when compilation time is critical, consider including
  * only the specific headers you need instead of this master header.
  *
- * @version 4.2.3
+ * @version 4.2.4
  * @author libhmm development team
  */
 


### PR DESCRIPTION
Version bump combining PRs #59 (ASan CI + LIBHMM_PORTABLE) and #60 (E-step dedup + per-state copy elimination). No code changes — CHANGELOG, CMakeLists.txt, libhmm.h, README.md, AGENTS.md only.