### PR TITLE
docs: add CITATION.cff, README citing section, and Python data-prep scripts

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+message: "If you use libhmm in your research or software, please cite the arXiv paper below (preferred) or this repository."
+title: "libhmm"
+type: software
+authors:
+  - family-names: Wolfman
+    given-names: Gary
+    orcid: "https://orcid.org/0009-0009-6077-1337"
+repository-code: "https://github.com/OldCrow/libhmm"
+url: "https://github.com/OldCrow/libhmm"
+license: MIT
+version: 4.2.5
+date-released: "2026-07-19"
+keywords:
+  - hidden Markov models
+  - Baum-Welch
+  - Viterbi
+  - C++20
+  - SIMD
+  - time series
+preferred-citation:
+  type: article
+  title: "libhmm: A Modern C++20 Library for Hidden Markov Models with Correct MLE Emission M-Steps"
+  authors:
+    - family-names: Wolfman
+      given-names: Gary
+      orcid: "https://orcid.org/0009-0009-6077-1337"
+  year: 2026
+  journal: "arXiv preprint"
+  url: "https://arxiv.org/abs/2605.29208"
+  identifiers:
+    - type: other
+      value: "arXiv:2605.29208"
+      description: "arXiv preprint identifier"

--- a/PLAN.md
+++ b/PLAN.md
@@ -84,6 +84,17 @@ Last reconciled against live GitHub state: 2026-07-14.
   here instead).
 - clang-tidy is available but disabled in CI (`ENABLE_CLANG_TIDY=OFF`) —
   tracked as GitHub issue #62 (2026-07-14).
+- JOSS submission deferred (2026-07-19): JOSS rejected the paper for
+  insufficient open-source/research uptake of libhmm (newer scope
+  requirement), with an explicit invitation to resubmit once the library
+  is in use in open-source or research projects. PR #20 closed without
+  merging; `joss-paper` retained as a long-lived paper branch (JOSS
+  accepts submission from a named branch). Published arXiv paper:
+  arXiv:2605.29208 (v2, 2026-06-13), source tagged `arxiv-v2` on
+  `joss-paper`. Resubmission checklist when uptake exists: merge `main`
+  into `joss-paper`, refresh benchmarks/figures/version references,
+  gather citation/usage evidence (CITATION.cff on `main` supports this),
+  open new PR + JOSS submission.
 
 ## Cross-Repo Dependencies [OPEN]
 pylibhmm pins this repo via `FetchContent` (`GIT_TAG v4.2.4` in
@@ -97,8 +108,8 @@ verify pylibhmm's pin rather than assuming it's current.
 
 ## Local Machine State [DERIVED]
 Confirmed 2026-07-14: `main` fully in sync with `origin/main` (clean,
-no ahead/behind). `joss-paper` branch (open PR #20, held back pending
-JOSS review per their process, not a repo omission) matches
+no ahead/behind). `joss-paper` branch (PR #20 closed 2026-07-19 after
+JOSS deferral — see Known Gaps; branch retained for resubmission) matches
 `origin/joss-paper` exactly. A local-only stash on `joss-paper`
 containing only regenerated LaTeX build artifacts (`.aux`, `.blg`,
 `.fdb_latexmk`, `.fls`, `.pdf` — no `.tex` source changes) was dropped

--- a/README.md
+++ b/README.md
@@ -261,6 +261,29 @@ No external dependencies. GTest is fetched automatically via CMake `FetchContent
 - [docs/GOLD_STANDARD_CHECKLIST.md](docs/GOLD_STANDARD_CHECKLIST.md) — distribution implementation requirements
 - [docs/STYLE_GUIDE.md](docs/STYLE_GUIDE.md) — coding conventions
 
+## Citing libhmm
+
+If you use libhmm in your research or software, please cite the technical paper:
+
+> Wolfman, G. (2026). *libhmm: A Modern C++20 Library for Hidden Markov Models with
+> Correct MLE Emission M-Steps*. arXiv:2605.29208. https://arxiv.org/abs/2605.29208
+
+```bibtex
+@article{wolfman2026libhmm,
+  author = {Wolfman, Gary},
+  title  = {libhmm: A Modern C++20 Library for Hidden Markov Models
+            with Correct MLE Emission M-Steps},
+  year   = {2026},
+  journal = {arXiv preprint},
+  eprint = {2605.29208},
+  archivePrefix = {arXiv},
+  url    = {https://arxiv.org/abs/2605.29208}
+}
+```
+
+A [CITATION.cff](CITATION.cff) file is included — GitHub's "Cite this repository"
+button generates BibTeX/APA from it automatically.
+
 ## License
 
 MIT License — see [LICENSE](LICENSE) for details.

--- a/scripts/prepare_dax_data.py
+++ b/scripts/prepare_dax_data.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+prepare_dax_data.py — Download DAX and S&P 500 log-returns using yfinance.
+
+Python equivalent of prepare_dax_data.R for systems without R/quantmod.
+
+Usage:
+    python scripts/prepare_dax_data.py [output_dir]
+
+Output:
+    dax_logreturns.csv   — single column: logreturn
+    dax_2000_2022.csv    — Date, Close, logreturn
+    sp500_logreturns.csv — single column: logreturn
+"""
+
+import sys
+import os
+import math
+import yfinance as yf
+import csv
+
+out_dir = sys.argv[1] if len(sys.argv) > 1 else os.path.join(os.environ.get("TEMP", "/tmp"))
+
+
+def fetch_logreturns(ticker: str, start: str, end: str) -> list[tuple]:
+    """Return list of (date, close, logreturn) tuples, NA rows dropped."""
+    df = yf.download(ticker, start=start, end=end, auto_adjust=True, progress=False)
+    # yfinance >=0.2 returns MultiIndex columns; squeeze to a Series
+    close_col = df["Close"]
+    if hasattr(close_col, "squeeze"):
+        close_col = close_col.squeeze()
+    closes = close_col.dropna()
+    rows = []
+    prev = None
+    for date, close in closes.items():
+        if prev is not None:
+            lr = math.log(float(close)) - math.log(float(prev))
+            rows.append((date.strftime("%Y-%m-%d"), float(close), lr))
+        prev = close
+    return rows
+
+
+print("Downloading ^GDAXI (DAX, 2000-01-01 to 2022-12-31)...")
+dax_rows = fetch_logreturns("^GDAXI", "2000-01-01", "2022-12-31")
+print(f"Downloaded {len(dax_rows)} daily log-returns")
+print(f"Date range: {dax_rows[0][0]} to {dax_rows[-1][0]}")
+
+dax_full_path = os.path.join(out_dir, "dax_2000_2022.csv")
+dax_lr_path   = os.path.join(out_dir, "dax_logreturns.csv")
+
+with open(dax_full_path, "w", newline="") as f:
+    w = csv.writer(f)
+    w.writerow(["Date", "Close", "logreturn"])
+    w.writerows(dax_rows)
+
+with open(dax_lr_path, "w", newline="") as f:
+    w = csv.writer(f)
+    w.writerow(["logreturn"])
+    for _, _, lr in dax_rows:
+        w.writerow([lr])
+
+print(f"\nExported:\n  {dax_lr_path} ({len(dax_rows)} rows)\n  {dax_full_path} (full data)")
+
+print("\nDownloading ^GSPC (S&P 500, 2000-01-01 to 2022-12-31)...")
+sp_rows = fetch_logreturns("^GSPC", "2000-01-01", "2022-12-31")
+sp_path = os.path.join(out_dir, "sp500_logreturns.csv")
+with open(sp_path, "w", newline="") as f:
+    w = csv.writer(f)
+    w.writerow(["logreturn"])
+    for _, _, lr in sp_rows:
+        w.writerow([lr])
+print(f"Exported {len(sp_rows)} S&P 500 log-returns -> {sp_path}")
+
+print(f"\nDone. Run: dax_regime_example {out_dir}")
+print(f"       or: sp500_regime_example {out_dir}")

--- a/scripts/prepare_wind_data.py
+++ b/scripts/prepare_wind_data.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+prepare_wind_data.py — Download NOAA ISD wind data for wind_direction_example.
+
+Python equivalent of prepare_wind_data.R for systems without R.
+
+Downloads hourly wind observations from Chicago O'Hare International
+Airport (NOAA ISD station 725300-14819) for 2015, extracts wind direction
+and speed, and exports to a CSV file.
+
+Usage:
+    python scripts/prepare_wind_data.py [output_dir]
+
+Output:
+    ohare_wind_2015.csv — direction_rad, speed_ms columns
+
+Data source:
+    NOAA NCEI (2001): Global Surface Hourly [ISD]. NCEI.
+    https://www.ncei.noaa.gov/data/global-hourly/
+    Station: Chicago O'Hare (USAF 725300, WBAN 14819)
+"""
+
+import sys
+import os
+import csv
+import math
+import urllib.request
+import tempfile
+
+out_dir = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("TEMP", "/tmp")
+
+URL = "https://www.ncei.noaa.gov/data/global-hourly/access/2015/72530094846.csv"
+
+print("Downloading NOAA ISD data for Chicago O'Hare (2015)...")
+tmp = tempfile.NamedTemporaryFile(suffix=".csv", delete=False)
+tmp.close()  # close before writing via urlretrieve (required on Windows)
+try:
+    urllib.request.urlretrieve(URL, tmp.name)
+    print(f"Downloaded to {tmp.name}")
+
+    rows = []
+    with open(tmp.name, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            wnd = row.get("WND", "")
+            parts = wnd.split(",")
+            if len(parts) < 4:
+                continue
+            try:
+                dir_deg = float(parts[0])
+                spd_raw = float(parts[3])
+            except ValueError:
+                continue
+            # 999 = missing direction, 9999 = missing speed, 0 = calm
+            if dir_deg < 0 or dir_deg > 360:
+                continue
+            if spd_raw >= 9000 or spd_raw <= 0:
+                continue
+            dir_rad = dir_deg * math.pi / 180.0
+            speed_ms = spd_raw / 10.0
+            rows.append((dir_rad, speed_ms))
+
+    print(f"Valid wind observations: {len(rows)}")
+    speeds = [r[1] for r in rows]
+    print(f"Speed range: {min(speeds):.1f} to {max(speeds):.1f} m/s")
+
+    out_path = os.path.join(out_dir, "ohare_wind_2015.csv")
+    with open(out_path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["direction_rad", "speed_ms"])
+        w.writerows(rows)
+
+    print(f"\nExported: {out_path} ({len(rows)} rows)")
+    print(f"\nDone. Run: wind_direction_example {out_dir}")
+finally:
+    os.unlink(tmp.name)


### PR DESCRIPTION
Follow-up to #20, which was closed without merging after the JOSS deferral (resubmission invited once libhmm has demonstrated open-source/research uptake). This PR moves the pieces that belong on `main` regardless of JOSS status:

- **CITATION.cff** — software citation metadata for v4.2.5 with `preferred-citation` pointing at the published arXiv paper ([arXiv:2605.29208](https://arxiv.org/abs/2605.29208)). Enables GitHub's "Cite this repository" button, which is how downstream projects and papers produce countable citations — the evidence JOSS asked for.
- **README** — new "Citing libhmm" section with plain-text and BibTeX citations.
- **scripts/prepare_dax_data.py / prepare_wind_data.py** — Python equivalents of the existing R data-prep scripts, ported from `joss-paper` (for systems without R).
- **PLAN.md** — records the JOSS deferral, the resubmission checklist, and the #20 closure.

Not moved (stays on the retained `joss-paper` branch): `paper/` (JOSS draft, arXiv source, figures) and the paper-draft CI workflow. The published arXiv v2 source is tagged `arxiv-v2` on that branch. CONTRIBUTING.md was already on `main` with identical content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)