### PR TITLE
fix(core): reject never-initialised (all-zero pi/trans) models at entry (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Never-initialised models are rejected up front (#78).** A newly
+  constructed `BasicHmm` zero-fills pi and the transition matrix, so an
+  unconfigured model assigns zero probability to every sequence — previously
+  surfacing as a confusing downstream failure ("no valid observation
+  sequences"). New `BasicHmm::validateInitialized()` throws a descriptive
+  `std::runtime_error` naming the zero-init contract and the fix; it is
+  called at `ForwardBackwardCalculator`/`ViterbiCalculator` construction and
+  at `train()` entry of `BaumWelchTrainer`, `MapBaumWelchTrainer`, and
+  `ViterbiTrainer`. `SegmentalKMeansTrainer` is deliberately exempt: it
+  derives pi/trans from its index-partition initial assignments, so an
+  unconfigured model is a legitimate starting point there. Only the all-zero
+  case is checked; normalisation remains the caller's responsibility. The
+  zero-init contract is now documented in the `basic_hmm.h` Doxygen and the
+  README quick-start.
 - **Multi-restart training — `fit_best_of_n()` (#45).** Runs n independent
   Baum-Welch trainings and keeps the model with the highest total
   log-likelihood (`training/fit_best_of_n.h`, works for `Hmm` and `HmmMV`).

--- a/PLAN.md
+++ b/PLAN.md
@@ -30,7 +30,7 @@
   LAMP_HMM comparator only, not libhmm code, and are intentionally left as-is.
 
 ## GitHub Synchronization [DERIVED]
-Last reconciled against live GitHub state: 2026-08-18.
+Last reconciled against live GitHub state: 2026-08-19.
 - GitHub is the collaborator-facing source for issues and milestones; this
   PLAN.md is the agent-facing durable project state. Keep both in sync.
 - When creating, closing, reopening, retitling, or moving a GitHub issue or
@@ -59,12 +59,18 @@ version. Milestone NUMBERS did not change, only titles — #1 is now v4.4.0.
 
 - v4.3.0 — Numerical Correctness & Build Contract (CLOSED, #3): 0 open / 6
   closed — #63, #70, #72, #73, #75, #76. Shipped 2026-08-16.
-- v4.4.0 — Training & Core Usability (open, #1): 1 open / 5 closed.
+- v4.4.0 — Training & Core Usability (open, #1): 3 open / 5 closed.
   - #43 CLOSED 2026-08-18 — BasicHmm::clone(); shipped on dev/v4.4.0.
   - #44 CLOSED 2026-08-18 — sample(hmm, T, rng); shipped on dev/v4.4.0.
   - #45 CLOSED 2026-08-19 — fit_best_of_n() multi-restart; shipped on dev/v4.4.0.
   - #46 OPEN — feat: HMM topology constraints — left-to-right, banded, and skip topologies.
   - #48 OPEN — perf: parallel E-step accumulation across sequences using ThreadPool.
+  - #78 OPEN (filed 2026-08-19) — usability: reject never-initialised
+    (all-zero pi/trans) models at calculator/trainer entry instead of the
+    confusing "no valid observation sequences" downstream failure. Decision
+    on the issue: (b) descriptive throw + (c) docs; uniform default init (a)
+    rejected. Fix in flight on dev/v4.4.0; SegmentalKMeansTrainer is
+    deliberately exempt (it self-initialises pi/trans).
   - #58 CLOSED 2026-08-18 — tier-2 dispatch extension; shipped on dev/v4.4.0.
   - #74 CLOSED 2026-08-18 — clean-room cos/sin + ULP gates; moved onto this
     milestone at closure (it ships in v4.4.0), shipped on dev/v4.4.0.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ ctest --test-dir build -C Release --parallel 4
 #include "libhmm/libhmm.h"
 using namespace libhmm;
 
-// Create a 2-state HMM with Gaussian emissions
+// Create a 2-state HMM with Gaussian emissions.
+// NOTE: a fresh Hmm zero-initialises pi and the transition matrix — setTrans()
+// and setPi() below are required, not optional. Calculators and trainers
+// reject a never-initialised (all-zero) model with a descriptive error.
 Hmm hmm(2);
 
 Matrix trans(2, 2);

--- a/include/libhmm/basic_hmm.h
+++ b/include/libhmm/basic_hmm.h
@@ -30,6 +30,12 @@ namespace libhmm {
  * Default construction (Obs = double only) initialises each state with a
  * GaussianDistribution.  Non-scalar HMMs leave emission slots null until
  * setDistribution() is called.
+ *
+ * @warning A newly constructed BasicHmm zero-initialises both the transition
+ * matrix and pi — it is NOT a usable model until setTrans() and setPi() are
+ * called (or the model is loaded from JSON/XML).  An all-zero model assigns
+ * zero probability to every sequence.  Calculators and trainers reject such
+ * a model up front via validateInitialized().
  */
 template <typename Obs = double>
 class BasicHmm {
@@ -48,6 +54,9 @@ protected:
     }
 
     /// Initialises transition matrix, pi vector, and emission slots.
+    /// Both trans_ and pi_ are deliberately zero-filled (not uniform): the
+    /// caller must supply real probabilities via setTrans()/setPi() before
+    /// the model can score anything.  validateInitialized() enforces this.
     /// For Obs = double: fills each emission slot with a default GaussianDistribution.
     /// For other Obs types: leaves emission slots null (setDistribution() required).
     void initializeMatrices() {
@@ -251,6 +260,52 @@ public:
                 throw std::runtime_error("Emission distribution for state " + std::to_string(i) +
                                          " is null");
             }
+        }
+    }
+
+    /**
+     * @brief Rejects a model whose pi or transition matrix was never set.
+     *
+     * A newly constructed BasicHmm zero-initialises pi and the transition
+     * matrix, so an unconfigured model assigns zero probability to every
+     * sequence.  Calculators and trainers call this before doing any work
+     * so the mistake surfaces as a clear error at the entry point instead
+     * of a confusing downstream failure ("no valid observation sequences").
+     *
+     * Only the all-zero (never-initialised) case is checked; normalisation
+     * of pi and the transition rows is the caller's responsibility.
+     *
+     * @throws std::runtime_error if pi or the transition matrix is all zeros.
+     */
+    void validateInitialized() const {
+        bool anyPi = false;
+        for (std::size_t i = 0; i < pi_.size(); ++i) {
+            if (pi_(i) != 0.0) {
+                anyPi = true;
+                break;
+            }
+        }
+        if (!anyPi) {
+            throw std::runtime_error(
+                "HMM initial state probabilities (pi) are all zero. A newly constructed "
+                "BasicHmm zero-initialises pi and the transition matrix; call setPi() and "
+                "setTrans() (or load a saved model) before training or scoring.");
+        }
+
+        bool anyTrans = false;
+        for (std::size_t i = 0; i < trans_.size1() && !anyTrans; ++i) {
+            for (std::size_t j = 0; j < trans_.size2(); ++j) {
+                if (trans_(i, j) != 0.0) {
+                    anyTrans = true;
+                    break;
+                }
+            }
+        }
+        if (!anyTrans) {
+            throw std::runtime_error(
+                "HMM transition matrix is all zeros. A newly constructed BasicHmm "
+                "zero-initialises pi and the transition matrix; call setPi() and setTrans() "
+                "(or load a saved model) before training or scoring.");
         }
     }
 };

--- a/include/libhmm/calculators/basic_forward_backward_calculator.h
+++ b/include/libhmm/calculators/basic_forward_backward_calculator.h
@@ -53,6 +53,8 @@ public:
      * @param hmm           The HMM (must be validated, states > 0).
      * @param observations  Observation sequence (must be non-empty).
      * @throws std::invalid_argument if observations is empty.
+     * @throws std::runtime_error if the HMM was never initialised (all-zero
+     *         pi/trans — see BasicHmm::validateInitialized()).
      */
     BasicForwardBackwardCalculator(const HmmType &hmm, const SeqType &observations);
 
@@ -221,6 +223,7 @@ BasicForwardBackwardCalculator<Obs>::BasicForwardBackwardCalculator(const HmmTyp
     if (ObsSeqTraits<Obs>::sequence_length(observations) == 0) {
         throw std::invalid_argument("Observation sequence cannot be empty");
     }
+    hmm.validateInitialized();
     precomputeLogTransitions();
     compute();
 }

--- a/include/libhmm/calculators/basic_viterbi_calculator.h
+++ b/include/libhmm/calculators/basic_viterbi_calculator.h
@@ -40,6 +40,8 @@ public:
      * @param hmm          The HMM (must be validated).
      * @param observations Observation sequence (must be non-empty).
      * @throws std::invalid_argument if observations is empty.
+     * @throws std::runtime_error if the HMM was never initialised (all-zero
+     *         pi/trans — see BasicHmm::validateInitialized()).
      */
     BasicViterbiCalculator(const HmmType &hmm, const SeqType &observations);
 
@@ -124,6 +126,7 @@ BasicViterbiCalculator<Obs>::BasicViterbiCalculator(const HmmType &hmm, const Se
     if (ObsSeqTraits<Obs>::sequence_length(observations) == 0) {
         throw std::invalid_argument("Observation sequence cannot be empty");
     }
+    hmm.validateInitialized();
     precomputeLogTransitions();
     static_cast<void>(decode());
 }

--- a/include/libhmm/training/basic_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_baum_welch_trainer.h
@@ -58,7 +58,10 @@ public:
 
     ~BasicBaumWelchTrainer() override = default;
 
-    /** @brief Execute one full EM pass, updating the HMM in place. */
+    /** @brief Execute one full EM pass, updating the HMM in place.
+     *  @throws std::runtime_error if the HMM was never initialised (all-zero
+     *          pi/trans — see BasicHmm::validateInitialized()) or if no
+     *          sequence has nonzero probability under the current model. */
     void train() override;
     /** @return Total E-step log-probability from the last train() call. */
     [[nodiscard]] double getLastLogProbability() const noexcept { return lastLogProb_; }
@@ -96,6 +99,7 @@ BasicBaumWelchTrainer<Obs>::BasicBaumWelchTrainer(HmmType *hmm, const ListType &
 template <typename Obs>
 void BasicBaumWelchTrainer<Obs>::train() {
     HmmType &hmm = this->getHmmRef();
+    hmm.validateInitialized();
     const std::size_t N = hmm.getNumStatesModern();
     lastLogProb_ = -std::numeric_limits<double>::infinity();
 

--- a/include/libhmm/training/basic_map_baum_welch_trainer.h
+++ b/include/libhmm/training/basic_map_baum_welch_trainer.h
@@ -66,7 +66,10 @@ public:
     BasicMapBaumWelchTrainer(BasicMapBaumWelchTrainer &&) = default;
     BasicMapBaumWelchTrainer &operator=(BasicMapBaumWelchTrainer &&) = default;
 
-    /** @brief One MAP-EM pass. @throws std::runtime_error if no valid sequences. */
+    /** @brief One MAP-EM pass.
+     *  @throws std::runtime_error if the HMM was never initialised (all-zero
+     *          pi/trans — see BasicHmm::validateInitialized()) or if no
+     *          valid sequences. */
     void train() override;
 
     /** @param c New pseudo-count. @throws std::invalid_argument if c < 0. */
@@ -241,6 +244,7 @@ void BasicMapBaumWelchTrainer<Obs>::apply_discrete_smoothing(HmmType &hmm, std::
 template <typename Obs>
 void BasicMapBaumWelchTrainer<Obs>::train() {
     HmmType &hmm = this->getHmmRef();
+    hmm.validateInitialized();
     const std::size_t N = hmm.getNumStatesModern();
     const double c = pseudo_count_;
 

--- a/include/libhmm/training/basic_viterbi_trainer.h
+++ b/include/libhmm/training/basic_viterbi_trainer.h
@@ -81,7 +81,9 @@ public:
 
     ~BasicViterbiTrainer() override = default;
 
-    /** @brief Run Viterbi training to convergence or maxIterations. */
+    /** @brief Run Viterbi training to convergence or maxIterations.
+     *  @throws std::runtime_error if the HMM was never initialised (all-zero
+     *          pi/trans — see BasicHmm::validateInitialized()). */
     void train() override;
 
     /** @return true if the last train() call converged. */
@@ -158,6 +160,7 @@ BasicViterbiTrainer<Obs>::BasicViterbiTrainer(HmmType *hmm, const ListType &obsL
 
 template <typename Obs>
 void BasicViterbiTrainer<Obs>::train() {
+    this->getHmmRef().validateInitialized();
     converged_ = false;
     maxItersReached_ = false;
     lastLogProb_ = -std::numeric_limits<double>::infinity();

--- a/tests/calculators/test_calculator_edge_cases.cpp
+++ b/tests/calculators/test_calculator_edge_cases.cpp
@@ -229,6 +229,20 @@ TEST_F(CalculatorEdgeCasesTest, VeryLongSequence_Viterbi_Stable) {
         EXPECT_EQ(seq(i), 0) << "Single-state HMM: all states must be 0";
 }
 
+// Issue #78: constructing a calculator on a never-initialised model
+// (zero-filled pi/trans from construction) must throw a descriptive error
+// instead of silently scoring every sequence as impossible.
+TEST_F(CalculatorEdgeCasesTest, UninitializedModelRejectedAtConstruction) {
+    Hmm fresh(2); // pi and trans still all-zero; default Gaussian emissions
+    ObservationSet obs(3);
+    obs(0) = 0.0;
+    obs(1) = 1.0;
+    obs(2) = 2.0;
+
+    EXPECT_THROW(ForwardBackwardCalculator(fresh, obs), std::runtime_error);
+    EXPECT_THROW(ViterbiCalculator(fresh, obs), std::runtime_error);
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/test_hmm_core.cpp
+++ b/tests/test_hmm_core.cpp
@@ -43,6 +43,39 @@ TEST_F(HmmCoreTest, NegativeStatesThrows) {
     EXPECT_THROW(Hmm(-10), std::invalid_argument);
 }
 
+// validateInitialized: a fresh model is structurally valid (validate() passes)
+// but rejected for use because pi and trans are still all-zero (issue #78).
+TEST_F(HmmCoreTest, ValidateInitializedFreshModelThrows) {
+    Hmm fresh(2);
+    EXPECT_NO_THROW(fresh.validate());
+    EXPECT_THROW(fresh.validateInitialized(), std::runtime_error);
+}
+
+TEST_F(HmmCoreTest, ValidateInitializedPiOnlyThrows) {
+    Hmm hmm(2);
+    Vector pi(2);
+    pi(0) = 0.6;
+    pi(1) = 0.4;
+    hmm.setPi(pi);
+    // Transition matrix still all-zero.
+    EXPECT_THROW(hmm.validateInitialized(), std::runtime_error);
+}
+
+TEST_F(HmmCoreTest, ValidateInitializedFullySetPasses) {
+    Hmm hmm(2);
+    Vector pi(2);
+    pi(0) = 0.6;
+    pi(1) = 0.4;
+    hmm.setPi(pi);
+    Matrix trans(2, 2);
+    trans(0, 0) = 0.7;
+    trans(0, 1) = 0.3;
+    trans(1, 0) = 0.4;
+    trans(1, 1) = 0.6;
+    hmm.setTrans(trans);
+    EXPECT_NO_THROW(hmm.validateInitialized());
+}
+
 // Matrix and Vector Operations
 TEST_F(HmmCoreTest, SetPiVector) {
     Vector pi(2);

--- a/tests/training/test_training_edge_cases.cpp
+++ b/tests/training/test_training_edge_cases.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "libhmm/training/viterbi_trainer.h"
 #include "libhmm/training/baum_welch_trainer.h"
+#include "libhmm/training/segmental_kmeans_trainer.h"
 #include "libhmm/hmm.h"
 #include "libhmm/distributions/distributions.h"
 #include <memory>
@@ -423,6 +424,47 @@ TEST_F(TrainingEdgeCasesTest, BaumWelchTrainerAllLength1EmitsDiagnostic) {
         for (std::size_t j = 0; j < 2; ++j)
             EXPECT_TRUE(std::isfinite(discreteHmm_->getTrans()(i, j)));
     }
+}
+
+// Issue #78: a never-initialised model (zero-filled pi/trans from
+// construction) must be rejected at train() entry with a descriptive error,
+// not surface later as "no valid observation sequences".
+TEST_F(TrainingEdgeCasesTest, TrainOnUninitializedModelThrowsDescriptively) {
+    ObservationLists obs;
+    ObservationSet seq(3);
+    seq(0) = 0.0;
+    seq(1) = 1.0;
+    seq(2) = 2.0;
+    obs.push_back(seq);
+
+    Hmm fresh(2); // pi and trans still all-zero
+
+    BaumWelchTrainer bw(fresh, obs);
+    try {
+        bw.train();
+        FAIL() << "expected std::runtime_error";
+    } catch (const std::runtime_error &e) {
+        EXPECT_NE(std::string(e.what()).find("setPi()"), std::string::npos);
+    }
+
+    ViterbiTrainer vt(fresh, obs);
+    EXPECT_THROW(vt.train(), std::runtime_error);
+}
+
+// Issue #78 exemption: SegmentalKMeansTrainer deliberately accepts a
+// never-initialised model — it derives pi/trans from its index-partition
+// initial assignments before the first Viterbi pass.
+TEST_F(TrainingEdgeCasesTest, SegmentalKMeansTrainsFromUninitializedModel) {
+    ObservationLists obs;
+    ObservationSet seq(8);
+    for (std::size_t t = 0; t < 8; ++t)
+        seq(t) = (t < 4) ? 0.0 : 5.0;
+    obs.push_back(seq);
+
+    Hmm fresh(2); // all-zero pi/trans; default Gaussian emissions
+    SegmentalKMeansTrainer trainer(fresh, obs);
+    EXPECT_NO_THROW(trainer.train());
+    EXPECT_NO_THROW(fresh.validateInitialized());
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Closes #78.

## What

A newly constructed `BasicHmm` zero-fills pi and the transition matrix, so a model used without `setPi()`/`setTrans()` assigns zero probability to every sequence — previously surfacing as the confusing downstream error `BaumWelchTrainer: no valid observation sequences (all had zero probability under the current model)`. This bit during test authoring for #45.

Per the decision on #78, this implements options (b) + (c); uniform default init (a) was rejected as a behaviour change to every fresh model with nonzero compat risk.

- **New `BasicHmm::validateInitialized()`** — throws a descriptive `std::runtime_error` (matching `validate()`'s exception type) when pi or the transition matrix is all-zero. Only the never-initialised case is checked; normalisation stays the caller's responsibility.
- **Call sites**: `ForwardBackwardCalculator`/`ViterbiCalculator` construction, and `train()` entry of `BaumWelchTrainer`, `MapBaumWelchTrainer`, `ViterbiTrainer`.
- **`SegmentalKMeansTrainer` is deliberately exempt**: it derives pi/trans from its index-partition initial assignments before the first Viterbi pass (its `learnTrans()` has a uniform fallback for zero-count rows, so the model is populated before any calculator is constructed). A regression test codifies the exemption.
- **Docs (c)**: zero-init `@warning` in the `basic_hmm.h` class Doxygen, `@throws` clauses on the affected entry points, and a note in the README quick-start.
- `fit_best_of_n()` needs no change: an uninitialised input model makes every restart throw and the descriptive error is rethrown.

## Behavioural note

No valid program changes behaviour. Code that previously ran a calculator/trainer on a never-initialised model got -inf/degenerate results or the generic trainer throw; it now gets the descriptive throw at the entry point.

## Testing

- 6 new tests: `validateInitialized()` unit tests (fresh model throws, pi-only throws, fully-set passes), trainer entry throw with message check, calculator construction throw (FB + Viterbi), segmental k-means exemption regression.
- Full suite: 49/49 pass locally (Windows/MSVC, Release, `-LE "known_broken|benchmark"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)