### PR TITLE
v4.4.1 — Correctness patch: ten defensive-review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.4.1] - 2026-08-26
+
+Correctness patch: the ten fix-now findings from the 2026-08-21 defensive
+review (milestone v4.4.1). Bug fixes only — no API surface change beyond
+the documented new throws.
 
 ### Changed
 - The shared library no longer links with `-undefined dynamic_lookup` on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `diagonal_gaussian_distribution.h` / `full_covariance_gaussian_distribution.h`
   no longer include `io/json_utils.h` (layer inversion; the forward
   declaration in `distribution_base.h` suffices).
+- `json::Reader::read_double` no longer runs `strtod` past the end of a
+  non-NUL-terminated `string_view`: the candidate token is copied into a
+  bounded NUL-terminated buffer, so `from_json` on a substring, memory-mapped
+  file, or network buffer cannot over-read, and the read position cannot
+  advance past the view (#87).
+- Von Mises `fit()` no longer stores κ = NaN for R̄ ≥ 0.9993 (~2° angular
+  dispersion — ordinary data): the Newton solver forms A = I₁/I₀ via
+  `one_minus_bessel_ratio` (no I₀ overflow above κ ≈ 714) and saturates a
+  non-finite update to the parameter maximum (#84).
+- SSE2 `log_pd` prescales subnormal inputs by 2⁵⁴ like the AVX2/AVX-512/NEON
+  variants; the whole subnormal range previously compressed to −709.09
+  instead of the exact log, a silent finite likelihood error on SSE2-tier
+  hosts (#85).
+- `sin_pd(−0.0)` returns −0.0 on every SIMD tier, matching `std::sin`; the
+  sign of zero was dropped in the core's final add. The trig ULP gates now
+  assert `signbit` on the ±0 specials, which the lattice metric cannot see
+  (#81).
+- AVX-512 tier selection requires the full F+DQ+BW+VL feature set the kernels
+  are compiled for (previously AVX512F alone — an F-without-DQ part such as
+  Knights Landing would SIGILL on the first batch call); AVX2 selection
+  additionally requires FMA3 (#83).
+- StudentT's location parameter μ is validated finite in the constructor,
+  `setLocation()`, and therefore JSON load — previously NaN/inf μ was
+  accepted silently and made every probability NaN (#90).
+- `from_json`/`from_json_mv` reject NaN, infinite, or negative entries in
+  `pi` and `trans` (normalisation is still left to the trainers); previously
+  such values loaded silently and produced NaN log-likelihoods (#91).
+- The count distributions (Discrete, Poisson, Binomial, NegativeBinomial)
+  bound-check a finite observation against their own domain before the
+  double→int cast; an out-of-range cast is UB and ISA-dependent (x86 yields
+  INT_MIN, AArch64 saturates to INT_MAX, so e.g.
+  `Poisson::getLogProbability(1e15)` differed between x86 and ARM). Out-of-
+  range values now uniformly score zero probability / −inf (#88).
+- The legacy stream reader bounds `States:` at 4096 before any allocation
+  (a large count previously attempted a huge `trans_` allocation; `-1`
+  parsed as ULLONG_MAX) and `XMLFileReader` translates `bad_alloc`/
+  `logic_error` into its documented `std::runtime_error` (#89).
 
 ### Changed
 - `fit_best_of_n()` is `[[nodiscard]]`, matching the other v4.4.0 APIs.
+- `getBatchLogProbabilities(observations, out)` now throws
+  `std::invalid_argument` when `out` is shorter than `observations`, on all
+  16 concrete overrides and the CRTP fallback (which previously only
+  `assert`ed). This was an unchecked out-of-bounds heap write; the
+  calculators always sized `out` correctly, but external callers were one
+  short span away from heap corruption (#86).
 - Trig ULP-gate specials table leads with +inf/−inf/NaN so the 4/8-wide
   tiers evaluate them inside the vector body rather than the scalar tail
   (`scripts/gen_trig_ulp_vectors.py`, regenerated `.inc`).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(APPLE)
 endif()
 
 project(libhmm
-    VERSION 4.4.0
+    VERSION 4.4.1
     DESCRIPTION "Modern C++20 Hidden Markov Model Library"
     LANGUAGES CXX
 )

--- a/PLAN.md
+++ b/PLAN.md
@@ -36,7 +36,7 @@
   LAMP_HMM comparator only, not libhmm code, and are intentionally left as-is.
 
 ## GitHub Synchronization [DERIVED]
-Last reconciled against live GitHub state: 2026-08-23.
+Last reconciled against live GitHub state: 2026-08-26.
 - GitHub is the collaborator-facing source for issues and milestones; this
   PLAN.md is the agent-facing durable project state. Keep both in sync.
 - When creating, closing, reopening, retitling, or moving a GitHub issue or
@@ -77,21 +77,10 @@ version. Milestone NUMBERS did not change, only titles — #1 is now v4.4.0.
   second exists because its items change fitted values in the last bits and
   #94 needs a benchmark pass first, so they must not gate the safety patch.
   Source-breaking items are parked on a named major.
-- v4.4.1 — Correctness patch (open, #4): 10 open / 0 closed.
-  - #86 OPEN — batch out-span length guard (OOB write today; fix adds a
-    `std::invalid_argument` throw — CHANGELOG "Changed", not just "Fixed").
-  - #87 OPEN — JSON `read_double` bounded copy (strtod overrun).
-  - #84 OPEN — von Mises `fit()` κ = NaN for R̄ ≥ 0.99930.
-  - #85 OPEN — SSE2 `log_pd` subnormal prescale.
-  - #83 OPEN — AVX-512 (DQ/BW/VL) and AVX2 (FMA) CPUID masks + CMake probes.
-  - #90 OPEN — StudentT location validation (ctor, setter, JSON).
-  - #91 OPEN — JSON `pi`/`trans` value validation.
-  - #88 OPEN — count-distribution double→int casts (x86/AArch64 parity test).
-  - #89 OPEN — legacy `States:` bound + exception contract.
-  - #81 OPEN — `sin_pd(−0)` one-blend fix, mirror libstats #98; land the
-    signbit assertions with it.
-  Exit: every regression test named on the issues in place; ASan/TSan legs
-  green; the #88 test green on the macOS/AArch64 leg.
+- v4.4.1 — Correctness patch (CLOSED, #4): 0 open / 10 closed — #81, #83,
+  #84, #85, #86, #87, #88, #89, #90, #91. Shipped 2026-08-26 (PR #102, all
+  nine CI legs green; exit criteria met). Session record: the v4.4.1
+  Milestone Record section below.
 - v4.4.2 — Fit accuracy & kernel hygiene (open, #5): 6 open / 0 closed.
   - #92 OPEN — Student-t centred scale step (both overloads).
   - #100 OPEN — LogNormal/Student-t effective-weight denominators; gammap
@@ -145,6 +134,39 @@ version. Milestone NUMBERS did not change, only titles — #1 is now v4.4.0.
   Fetch the full closed-unmilestoned list via `gh issue list --state closed
   --json number,title,milestone -q '.[] | select(.milestone == null)'` if ever
   needed.
+
+## v4.4.1 Milestone Record [DERIVED]
+### Shipped 2026-08-26 (developed on dev/v4.4.1, merged via PR #102)
+Ten defensive-review fixes, three parallel worktree sub-agents (distributions
+/ I/O / SIMD-platform, disjoint file sets), coordinator QA before push.
+Red-before-green demonstrated for every regression test where reachable;
+recorded exceptions: #86 (pre-fix run IS heap corruption — reproduced as
+STATUS_HEAP_CORRUPTION), #89's 200000-states case (320 GB commit; reasoned),
+#88 on x86 (UB invisible — CVTTSD2SI's INT_MIN coincidentally routes to the
+reject path; the macOS/AArch64 CI leg is the discriminating run and passed),
+#83 contract asserts (pass on any conforming host; the mask-value guard was
+shown red under a one-bit perturbation instead).
+Durable findings beyond the issue texts:
+- #87's issue-text repro was non-discriminating (`checked_size` already
+  rejected it); the landed discriminator is
+  `JsonReader.ReadDoubleDoesNotReadPastViewBounds`.
+- #81's pre-fix red reproduced only on the SSE2 tier under MSVC/Zen 4 —
+  AVX2/AVX-512 codegen happened to preserve the sign there; fix applied to
+  all four tiers per spec, NEON validated by the macOS leg.
+- #86's guard also replaced the Release-no-op `assert` in the CRTP default
+  (distribution_base.h): all 16 concrete overrides + fallback now throw.
+- #88's fix additionally covered `DiscreteDistribution::setProbability`
+  (same pattern, same class), and NegBin `fit()` now keeps k as double
+  throughout; Poisson CDF gained a castless normal-approximation branch for
+  k > INT_MAX.
+- One CI iteration: missing `<cstring>` for `std::memcpy` in a new test —
+  MSVC/AppleClang provide it transitively, libstdc++ does not, so all four
+  Linux legs failed one compile. Countermeasure used before the re-push and
+  worth repeating: `g++ -fsyntax-only` over every changed TU with the local
+  mingw g++ (libstdc++) catches this class on this Windows machine.
+- check_cxx_compiler_flag with a space-separated two-flag string verified
+  empirically to work under g++ (with a bogus-flag control) before trusting
+  the #83 CMake probe change.
 
 ## v4.4.0 Milestone Record [DERIVED]
 ### Shipped 2026-08-19 (developed on dev/v4.4.0, merged to main at release)
@@ -450,10 +472,13 @@ refuted). Full ledger in the session artifact; issues carry the detail.
   #91).
 
 ## Next Steps
-- **v4.4.1 — Correctness patch** is next: ten issues, each a few lines plus
-  its regression test; start with #86/#87 (memory safety), then #84/#85,
-  #83, #90/#91, #88/#89, #81. Bump `[Unreleased]` in CHANGELOG to 4.4.1 at
-  release and coordinate the pylibhmm pin.
+- ~~v4.4.1 — Correctness patch~~ **SHIPPED 2026-08-26** (see Milestone
+  Record). pylibhmm `GIT_TAG` bumped to v4.4.1 in the same session — verify
+  its CI/canary went green; a pylibhmm point release on the new pin is that
+  repo's call.
+- **v4.4.2 — Fit accuracy & kernel hygiene** is next: six issues; #94
+  requires its benchmark pass BEFORE the `LIBHMM_SIMD_SOURCES` trim, and
+  the exit criteria want per-tier accuracy tests for #92/#100.
 - ~~Bump pylibhmm's `GIT_TAG` to v4.4.0~~ **DONE 2026-08-22** — pylibhmm
   0.11.0 released on the v4.4.0 pin; its pin-currency canary is green.
   Re-bump at v4.4.1.

--- a/cmake/SimdDispatch.cmake
+++ b/cmake/SimdDispatch.cmake
@@ -36,9 +36,15 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
     set(COMPILER_SUPPORTS_NEON ON)
     message(STATUS "SIMD compiler support — NEON: ON (AArch64 baseline)")
 elseif(NOT MSVC)
-    check_cxx_compiler_flag("-mavx512f" COMPILER_SUPPORTS_AVX512F)
+    # Probe the exact flag sets actually passed to the per-ISA TUs below
+    # (-mavx512f;-mavx512dq and -mavx2;-mfma), not just the bare ISA flag —
+    # hygiene fix for issue #83c: a compiler that accepted -mavx512f but
+    # rejected -mavx512dq (or -mavx2 without -mfma) would otherwise pass this
+    # probe and then fail compiling the real TU. Cannot fire on any compiler
+    # at or above the GCC 12 / Clang 14 floor this project requires.
+    check_cxx_compiler_flag("-mavx512f -mavx512dq" COMPILER_SUPPORTS_AVX512F)
     check_cxx_compiler_flag("-mavx" COMPILER_SUPPORTS_AVX)
-    check_cxx_compiler_flag("-mavx2" COMPILER_SUPPORTS_AVX2)
+    check_cxx_compiler_flag("-mavx2 -mfma" COMPILER_SUPPORTS_AVX2)
     check_cxx_compiler_flag("-msse4.2" COMPILER_SUPPORTS_SSE42)
     message(
         STATUS

--- a/include/libhmm/detail/simd_math_helpers.h
+++ b/include/libhmm/detail/simd_math_helpers.h
@@ -269,7 +269,13 @@ static inline void trig_cores_8pd(__m512d r, __m512d rlo, __m512d &s_core,
     const __m512i bit1 = _mm512_and_si512(_mm512_srli_epi64(n64, 1), one_i);
     const __m512d sv = _mm512_mask_blend_pd(swap, s_core, c_core);
     const __m512d sign_v = _mm512_castsi512_pd(_mm512_slli_epi64(bit1, 63));
-    return _mm512_xor_pd(sv, sign_v);
+    const __m512d result = _mm512_xor_pd(sv, sign_v);
+    // IEEE sign-of-zero (issue #81): for x = -0 the core computes
+    // (-0) + (+0) = +0, dropping the sign; sin(+/-0) must be +/-0 exactly.
+    // x == 0 matches both zeros and no other double, so blend x itself
+    // back in.
+    const __mmask8 zmask = _mm512_cmp_pd_mask(x, _mm512_setzero_pd(), _CMP_EQ_OQ);
+    return _mm512_mask_blend_pd(zmask, result, x);
 }
 
 // log1p: log(1+x). Uses 8-term polynomial for |x|<1e-4 to avoid catastrophic
@@ -497,7 +503,12 @@ static inline void trig_cores_4pd(__m256d r, __m256d rlo, __m256d &s_core,
     const __m256d swap_mask = _mm256_castsi256_pd(_mm256_sub_epi64(_mm256_setzero_si256(), bit0));
     const __m256d sv = _mm256_blendv_pd(s_core, c_core, swap_mask);
     const __m256d sign_v = _mm256_castsi256_pd(_mm256_slli_epi64(bit1, 63));
-    return _mm256_xor_pd(sv, sign_v);
+    const __m256d result = _mm256_xor_pd(sv, sign_v);
+    // IEEE sign-of-zero (issue #81): for x = -0 the core computes
+    // (-0) + (+0) = +0, dropping the sign; sin(+/-0) must be +/-0 exactly.
+    // x == 0 matches both zeros and no other double, so blend x itself
+    // back in.
+    return _mm256_blendv_pd(result, x, _mm256_cmp_pd(x, _mm256_setzero_pd(), _CMP_EQ_OQ));
 }
 
 // log1p: 8-term polynomial for |x|<1e-4 to avoid catastrophic cancellation.
@@ -735,7 +746,12 @@ static inline void trig_cores_2pd(__m128d r, __m128d rlo, __m128d &s_core,
     const __m128d swap_mask = _mm_castsi128_pd(_mm_sub_epi64(_mm_setzero_si128(), bit0));
     const __m128d sv = sse2_blend(swap_mask, c_core, s_core);
     const __m128d sign_v = _mm_castsi128_pd(_mm_slli_epi64(bit1, 63));
-    return _mm_xor_pd(sv, sign_v);
+    const __m128d result = _mm_xor_pd(sv, sign_v);
+    // IEEE sign-of-zero (issue #81): for x = -0 the core computes
+    // (-0) + (+0) = +0, dropping the sign; sin(+/-0) must be +/-0 exactly.
+    // x == 0 matches both zeros and no other double, so blend x itself
+    // back in.
+    return sse2_blend(_mm_cmpeq_pd(x, _mm_setzero_pd()), x, result);
 }
 
 // log1p: 8-term polynomial for |x|<1e-4. No FMA on SSE2 — uses mul+add.
@@ -965,7 +981,12 @@ static inline void trig_cores_2pd(float64x2_t r, float64x2_t rlo, float64x2_t &s
     const uint64x2_t swap = vtstq_u64(qu, vdupq_n_u64(1));
     const uint64x2_t sgn = vshlq_n_u64(vandq_u64(vshrq_n_u64(qu, 1), vdupq_n_u64(1)), 63);
     const float64x2_t sv = vbslq_f64(swap, c_core, s_core);
-    return vreinterpretq_f64_u64(veorq_u64(vreinterpretq_u64_f64(sv), sgn));
+    const float64x2_t result = vreinterpretq_f64_u64(veorq_u64(vreinterpretq_u64_f64(sv), sgn));
+    // IEEE sign-of-zero (issue #81): for x = -0 the core computes
+    // (-0) + (+0) = +0, dropping the sign; sin(+/-0) must be +/-0 exactly.
+    // x == 0 matches both zeros and no other double, so blend x itself
+    // back in.
+    return vbslq_f64(vceqq_f64(x, vdupq_n_f64(0.0)), x, result);
 }
 
 // log1p: 8-term polynomial for |x|<1e-4 with FMA. AArch64 NEON.

--- a/include/libhmm/detail/simd_math_helpers.h
+++ b/include/libhmm/detail/simd_math_helpers.h
@@ -551,12 +551,23 @@ static inline void trig_cores_4pd(__m256d r, __m256d rlo, __m256d &s_core,
     const __m128d is_inf = _mm_cmpeq_pd(x, pos_inf);
     const __m128d is_nan = _mm_cmpunord_pd(x, x);
 
-    const __m128i xi = _mm_castpd_si128(x);
+    // Subnormal prescale (issue #85): without this, the exponent-extraction
+    // path below treats a subnormal's biased exponent (0) as if it belonged
+    // to a normal number, compressing the whole subnormal range. Ported from
+    // the AVX2/AVX-512/NEON log_pd overloads in this same file: scale by 2^54
+    // (exact — power-of-two) and subtract 54 back out of the exponent.
+    const __m128d min_normal = _mm_set1_pd(2.2250738585072014e-308);
+    const __m128d scale_up = _mm_set1_pd(18014398509481984.0); // 2^54
+    const __m128d is_denormal = _mm_cmplt_pd(x, min_normal);
+    const __m128d sx = sse2_blend(is_denormal, _mm_mul_pd(x, scale_up), x);
+
+    const __m128i xi = _mm_castpd_si128(sx);
     __m128i exp_i = _mm_srli_epi64(xi, 52);
     exp_i = _mm_and_si128(exp_i, _mm_set1_epi64x(0x7FFLL));
     const __m128i exp_i32 = _mm_shuffle_epi32(exp_i, _MM_SHUFFLE(0, 0, 2, 0));
     __m128d e = _mm_cvtepi32_pd(exp_i32);
     e = _mm_sub_pd(e, _mm_set1_pd(1023.0));
+    e = sse2_blend(is_denormal, _mm_sub_pd(e, _mm_set1_pd(54.0)), e);
 
     __m128d m =
         _mm_castsi128_pd(_mm_or_si128(_mm_and_si128(xi, _mm_set1_epi64x(0x000FFFFFFFFFFFFFLL)),

--- a/include/libhmm/distributions/basic_emission_distribution.h
+++ b/include/libhmm/distributions/basic_emission_distribution.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <random>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -68,10 +70,32 @@ public:
      * Override for SIMD vectorization.
      *
      * Precondition: observations.size() == out.size()
+     *
+     * @throws std::invalid_argument if out.size() < observations.size() (#86).
+     *         Every concrete override must call checkBatchSpans() first to
+     *         enforce this before writing into out.
      */
     virtual void getBatchLogProbabilities(std::span<const Obs> observations,
                                           std::span<double> out) const = 0;
 
+protected:
+    /**
+     * @brief Validate that the output span is long enough for a batch write.
+     *
+     * getBatchLogProbabilities() writes exactly n_obs values into out[0..n_obs).
+     * A shorter out span would write out of bounds, so every override must
+     * call this first (#86: previously unchecked, an OOB heap write).
+     *
+     * @throws std::invalid_argument if n_out < n_obs.
+     */
+    static void checkBatchSpans(std::size_t n_obs, std::size_t n_out) {
+        if (n_out < n_obs) {
+            throw std::invalid_argument(
+                "getBatchLogProbabilities: out span is shorter than observations span");
+        }
+    }
+
+public:
     // =========================================================================
     // Parameter estimation
     // =========================================================================

--- a/include/libhmm/distributions/discrete_distribution.h
+++ b/include/libhmm/distributions/discrete_distribution.h
@@ -193,12 +193,13 @@ public:
      */
     void setProbability(double o, double value) {
         validateProbabilityValue(value);
-        // Guard before cast: negative float → size_t is UB
-        if (std::isnan(o) || std::isinf(o) || o < 0.0)
+        // Guard before cast: negative float -> size_t is UB, and so is a
+        // value too large to represent (#88: same class of bug as
+        // getProbability()/getLogProbability(); not one of the issue's
+        // listed .cpp sites, but the identical pattern in the same class).
+        if (std::isnan(o) || std::isinf(o) || o < 0.0 || o >= static_cast<double>(numSymbols_))
             throw std::out_of_range("Observation index out of range");
         const auto index = static_cast<std::size_t>(o);
-        if (!isValidIndex(index))
-            throw std::out_of_range("Observation index out of range");
         pdf_[index] = value;
         invalidateCache();
     }

--- a/include/libhmm/distributions/distribution_base.h
+++ b/include/libhmm/distributions/distribution_base.h
@@ -89,7 +89,7 @@ public:
 
     void getBatchLogProbabilities(std::span<const Obs> observations,
                                   std::span<double> out) const override {
-        assert(observations.size() == out.size());
+        this->checkBatchSpans(observations.size(), out.size());
         for (std::size_t i = 0; i < observations.size(); ++i) {
             out[i] = this->getLogProbability(observations[i]);
         }

--- a/include/libhmm/distributions/poisson_distribution.h
+++ b/include/libhmm/distributions/poisson_distribution.h
@@ -66,13 +66,21 @@ private:
     }
 
     /**
-     * Validates that k is a valid count (non-negative integer)
+     * Validates that k is a valid count (non-negative integer) representable
+     * as an int.
+     *
+     * #88: the upper bound rejects values that would overflow the
+     * `static_cast<int>(k)` every call site performs after this check --
+     * casting a finite double above INT_MAX to int is undefined behaviour
+     * ([conv.fpint]) and is ISA-dependent (x86 CVTTSD2SI yields INT_MIN,
+     * AArch64 FCVTZS saturates to INT_MAX).
      *
      * @param k Value to validate
      * @return true if k is a valid count, false otherwise
      */
     static bool isValidCount(double k) noexcept {
-        return k >= 0.0 && std::floor(k) == k && std::isfinite(k);
+        return k >= 0.0 && k <= static_cast<double>(std::numeric_limits<int>::max()) &&
+               std::floor(k) == k && std::isfinite(k);
     }
 
     friend std::istream &operator>>(std::istream &is, libhmm::PoissonDistribution &distribution);

--- a/include/libhmm/distributions/student_t_distribution.h
+++ b/include/libhmm/distributions/student_t_distribution.h
@@ -106,7 +106,7 @@ public:
     /**
      * @brief Constructor with degrees of freedom, location, and scale
      * @param degrees_of_freedom Degrees of freedom parameter (ν > 0)
-     * @param location Location parameter (μ)
+     * @param location Location parameter (μ), must be finite
      * @param scale Scale parameter (σ > 0)
      * @throws std::invalid_argument if parameters are invalid
      */
@@ -169,8 +169,9 @@ public:
     /**
      * @brief Set the location parameter
      * @param location New location parameter (μ)
+     * @throws std::invalid_argument if location is not finite
      */
-    void setLocation(double location) { location_ = location; }
+    void setLocation(double location);
 
     /**
      * @brief Get the scale parameter

--- a/include/libhmm/platform/cpu_detection.h
+++ b/include/libhmm/platform/cpu_detection.h
@@ -24,7 +24,8 @@ namespace libhmm::platform {
 inline constexpr unsigned kAvx512RequiredMask =
     (1u << 16) | (1u << 17) | (1u << 30) | (1u << 31); // F | DQ | BW | VL
 
-/// @returns true if the runtime CPU + OS support AVX-512F/DQ.
+/// @returns true if the runtime CPU + OS support AVX-512 F/DQ/BW/VL
+/// (kAvx512RequiredMask).
 /// Always false on non-x86 platforms.
 bool supports_avx512() noexcept;
 

--- a/include/libhmm/platform/cpu_detection.h
+++ b/include/libhmm/platform/cpu_detection.h
@@ -13,6 +13,17 @@
 
 namespace libhmm::platform {
 
+/// Bitmask on CPUID leaf 7 EBX required for libhmm's AVX-512 tier: F (bit 16),
+/// DQ (bit 17), BW (bit 30), VL (bit 31) -- exactly what /arch:AVX512 licenses
+/// and what simd_double_ops_avx512.cpp's -mavx512f -mavx512dq compile flags
+/// require (issue #83: F alone is not enough -- the AVX-512DQ intrinsics used
+/// there, e.g. _mm512_cvtepi64_pd, SIGILL on an F-without-DQ part such as
+/// Knights Landing/Mill). Exposed so tests/platform/test_simd_platform.cpp can
+/// regression-guard the exact value: a one-bit perturbation here must fail
+/// that test.
+inline constexpr unsigned kAvx512RequiredMask =
+    (1u << 16) | (1u << 17) | (1u << 30) | (1u << 31); // F | DQ | BW | VL
+
 /// @returns true if the runtime CPU + OS support AVX-512F/DQ.
 /// Always false on non-x86 platforms.
 bool supports_avx512() noexcept;

--- a/src/distributions/beta_distribution.cpp
+++ b/src/distributions/beta_distribution.cpp
@@ -362,6 +362,7 @@ std::istream &operator>>(std::istream &is, BetaDistribution &distribution) {
 
 void BetaDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                 std::span<double> out) const {
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     performance::get_double_vec_ops().beta_batch(
         observations.data(), out.data(), observations.size(), alphaMinus1_, betaMinus1_, -logBeta_);

--- a/src/distributions/binomial_distribution.cpp
+++ b/src/distributions/binomial_distribution.cpp
@@ -246,6 +246,7 @@ void BinomialDistribution::getBatchLogProbabilities(std::span<const double> obse
     // three arguments are integers), so the blocker is the gather, exactly as
     // for Poisson and Discrete. The old claim that this "uses lgamma
     // internally" was wrong about its own code; corrected 2026-08-16.
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = BinomialDistribution::getLogProbability(observations[i]);

--- a/src/distributions/binomial_distribution.cpp
+++ b/src/distributions/binomial_distribution.cpp
@@ -23,11 +23,15 @@ double BinomialDistribution::getProbability(double value) const {
         return math::ZERO_DOUBLE;
     }
 
-    // Round to nearest integer and check if it's in valid range
-    auto k = static_cast<int>(std::round(value));
-    if (k < 0 || k > n_) {
+    // Round to nearest integer and check if it's in valid range.
+    // #88: the range check against n_ must happen on the rounded double,
+    // before the cast to int -- casting an out-of-range finite double is UB
+    // ([conv.fpint]) and is ISA-dependent.
+    const double rounded = std::round(value);
+    if (rounded < 0.0 || rounded > static_cast<double>(n_)) {
         return math::ZERO_DOUBLE;
     }
+    auto k = static_cast<int>(rounded);
 
     // Handle edge cases
     if (p_ == math::ZERO_DOUBLE) {
@@ -76,8 +80,13 @@ void BinomialDistribution::fit(std::span<const double> data) {
     double sum = 0.0;
     std::size_t validCount = 0;
     for (const double val : data) {
-        if (val >= 0.0 && std::isfinite(val)) {
-            const auto intVal = static_cast<int>(std::round(val));
+        // #88: bound-check the rounded value against INT_MAX before casting
+        // -- n_ is not yet known during unweighted fit, so INT_MAX is the
+        // only available domain bound here.
+        const double rounded = std::round(val);
+        if (val >= 0.0 && std::isfinite(val) &&
+            rounded <= static_cast<double>(std::numeric_limits<int>::max())) {
+            const auto intVal = static_cast<int>(rounded);
             maxObs = std::max(maxObs, intVal);
             sum += static_cast<double>(intVal);
             ++validCount;
@@ -108,8 +117,11 @@ void BinomialDistribution::fit(std::span<const double> data, std::span<const dou
     int maxObs = 0;
     double sumWX = 0.0;
     for (std::size_t i = 0; i < data.size(); ++i) {
-        if (data[i] >= 0.0 && std::isfinite(data[i]) && weights[i] > 0.0) {
-            const auto intVal = static_cast<int>(std::round(data[i]));
+        // #88: bound-check before casting -- see the unweighted fit() above.
+        const double rounded = std::round(data[i]);
+        if (data[i] >= 0.0 && std::isfinite(data[i]) && weights[i] > 0.0 &&
+            rounded <= static_cast<double>(std::numeric_limits<int>::max())) {
+            const auto intVal = static_cast<int>(rounded);
             maxObs = std::max(maxObs, intVal);
             sumWX += weights[i] * static_cast<double>(intVal);
         }
@@ -157,11 +169,13 @@ double BinomialDistribution::getLogProbability(double value) const noexcept {
         return -std::numeric_limits<double>::infinity();
     }
 
-    // Round to nearest integer and check if it's in valid range
-    auto k = static_cast<int>(std::round(value));
-    if (k < 0 || k > n_) {
+    // Round to nearest integer and check if it's in valid range.
+    // #88: bound-check before casting -- see getProbability().
+    const double rounded = std::round(value);
+    if (rounded < 0.0 || rounded > static_cast<double>(n_)) {
         return -std::numeric_limits<double>::infinity();
     }
+    auto k = static_cast<int>(rounded);
 
     // Handle edge cases
     if (p_ == math::ZERO_DOUBLE) {
@@ -183,15 +197,18 @@ double BinomialDistribution::getCumulativeProbability(double value) const noexce
         return math::ZERO_DOUBLE;
     }
 
-    auto k = static_cast<int>(std::floor(value));
-
-    // Handle boundary cases
-    if (k < 0) {
+    // #88: bound-check the floored value before casting -- see
+    // getProbability(). Any value at or beyond n_ (including one too large
+    // to represent as int) has cumulative probability 1.0, so it is safe to
+    // resolve that case before the cast.
+    const double floored = std::floor(value);
+    if (floored < 0.0) {
         return math::ZERO_DOUBLE;
     }
-    if (k >= n_) {
+    if (floored >= static_cast<double>(n_)) {
         return math::ONE;
     }
+    auto k = static_cast<int>(floored);
 
     // Compute CDF as cumulative sum: P(X <= k) = sum_{i=0}^{k} P(X = i)
     double cdf = math::ZERO_DOUBLE;

--- a/src/distributions/chi_squared_distribution.cpp
+++ b/src/distributions/chi_squared_distribution.cpp
@@ -203,6 +203,7 @@ std::istream &operator>>(std::istream &is, ChiSquaredDistribution &dist) {
 
 void ChiSquaredDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                       std::span<double> out) const {
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     performance::get_double_vec_ops().chisq_batch(observations.data(), out.data(),
                                                   observations.size(), cached_half_k_minus_one_,

--- a/src/distributions/discrete_distribution.cpp
+++ b/src/distributions/discrete_distribution.cpp
@@ -226,6 +226,7 @@ void DiscreteDistribution::getBatchLogProbabilities(std::span<const double> obse
     // the index lookups, but the per-element index-validation branch limits
     // vectorization benefit. The cached log-probability table is already optimal
     // for the scalar case.
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = DiscreteDistribution::getLogProbability(observations[i]);

--- a/src/distributions/discrete_distribution.cpp
+++ b/src/distributions/discrete_distribution.cpp
@@ -14,11 +14,14 @@ namespace libhmm {
  * @return Probability mass for the given value, 0.0 if out of range
  */
 double DiscreteDistribution::getProbability(double x) const {
-    if (std::isnan(x) || std::isinf(x) || x < math::ZERO_DOUBLE)
+    // #88: compare against numSymbols_ before casting to std::size_t --
+    // casting an out-of-range finite double is UB ([conv.fpint]) and the
+    // result is ISA-dependent, so the bound must be checked on the double
+    // itself rather than relying on isValidIndex() after the cast.
+    if (std::isnan(x) || std::isinf(x) || x < math::ZERO_DOUBLE ||
+        x >= static_cast<double>(numSymbols_))
         return math::ZERO_DOUBLE;
     const auto index = static_cast<std::size_t>(x);
-    if (!isValidIndex(index))
-        return math::ZERO_DOUBLE;
     assert(pdf_[index] <= 1.0 && pdf_[index] >= 0.0);
     return pdf_[index];
 }
@@ -47,12 +50,11 @@ void DiscreteDistribution::fit(std::span<const double> data) {
     std::fill(pdf_.begin(), pdf_.end(), 0.0);
     std::size_t validCount = 0;
     for (const double val : data) {
-        if (val >= 0.0) {
+        // #88: bound-check before casting -- see getProbability().
+        if (val >= 0.0 && val < static_cast<double>(numSymbols_)) {
             const auto index = static_cast<std::size_t>(val);
-            if (isValidIndex(index)) {
-                pdf_[index]++;
-                ++validCount;
-            }
+            pdf_[index]++;
+            ++validCount;
         }
     }
     if (validCount == 0) {
@@ -78,12 +80,11 @@ void DiscreteDistribution::fit(std::span<const double> data, std::span<const dou
     std::fill(pdf_.begin(), pdf_.end(), 0.0);
     double binnedW = 0.0;
     for (std::size_t i = 0; i < data.size(); ++i) {
-        if (data[i] >= 0.0) {
+        // #88: bound-check before casting -- see getProbability().
+        if (data[i] >= 0.0 && data[i] < static_cast<double>(numSymbols_)) {
             const auto index = static_cast<std::size_t>(data[i]);
-            if (isValidIndex(index)) {
-                pdf_[index] += weights[i];
-                binnedW += weights[i];
-            }
+            pdf_[index] += weights[i];
+            binnedW += weights[i];
         }
     }
     // All weight fell outside the symbol range; keep current parameters.
@@ -125,16 +126,16 @@ std::string DiscreteDistribution::toString() const {
  * Uses cached log probabilities for maximum performance
  */
 double DiscreteDistribution::getLogProbability(double value) const noexcept {
-    // Validate input - discrete distributions only accept non-negative integer values
-    if (std::isnan(value) || std::isinf(value) || value < math::ZERO_DOUBLE) {
+    // Validate input - discrete distributions only accept non-negative integer values.
+    // #88: the upper-bound check against numSymbols_ must happen before the
+    // cast -- see getProbability().
+    if (std::isnan(value) || std::isinf(value) || value < math::ZERO_DOUBLE ||
+        value >= static_cast<double>(numSymbols_)) {
         return -std::numeric_limits<double>::infinity();
     }
 
     // Convert to integer index
     const auto index = static_cast<std::size_t>(value);
-    if (!isValidIndex(index)) {
-        return -std::numeric_limits<double>::infinity();
-    }
 
     ensureCache();
     return cachedLogProbs_[index];

--- a/src/distributions/exponential_distribution.cpp
+++ b/src/distributions/exponential_distribution.cpp
@@ -190,6 +190,7 @@ bool ExponentialDistribution::operator==(const ExponentialDistribution &other) c
 
 void ExponentialDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                        std::span<double> out) const {
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     performance::get_double_vec_ops().exponential_batch(
         observations.data(), out.data(), observations.size(), logLambda_, negLambda_);

--- a/src/distributions/gamma_distribution.cpp
+++ b/src/distributions/gamma_distribution.cpp
@@ -235,6 +235,7 @@ bool GammaDistribution::operator==(const GammaDistribution &other) const {
 
 void GammaDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                  std::span<double> out) const {
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     performance::get_double_vec_ops().gamma_batch(observations.data(), out.data(),
                                                   observations.size(), kMinus1_, 1.0 / theta_,

--- a/src/distributions/gaussian_distribution.cpp
+++ b/src/distributions/gaussian_distribution.cpp
@@ -236,6 +236,7 @@ double GaussianDistribution::sample(std::mt19937_64 &rng) const {
 
 void GaussianDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                     std::span<double> out) const {
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     const double log_norm = -0.5 * math::LN_2PI - logStandardDeviation_;
     performance::get_double_vec_ops().gaussian_batch(observations.data(), out.data(),

--- a/src/distributions/log_normal_distribution.cpp
+++ b/src/distributions/log_normal_distribution.cpp
@@ -210,6 +210,7 @@ std::istream &operator>>(std::istream &is, libhmm::LogNormalDistribution &distri
 }
 void LogNormalDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                      std::span<double> out) const {
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     performance::get_double_vec_ops().lognormal_batch(
         observations.data(), out.data(), observations.size(), mean_, negHalfSigmaSquaredInv_,

--- a/src/distributions/negative_binomial_distribution.cpp
+++ b/src/distributions/negative_binomial_distribution.cpp
@@ -25,11 +25,15 @@ double NegativeBinomialDistribution::getProbability(double value) const {
         return math::ZERO_DOUBLE;
     }
 
-    // Round to nearest integer and check if it's in valid range
-    auto k = static_cast<int>(std::round(value));
-    if (k < 0) {
+    // Round to nearest integer and check if it's in valid range.
+    // #88: bound-check against INT_MAX before casting -- casting an
+    // out-of-range finite double to int is UB ([conv.fpint]) and is
+    // ISA-dependent.
+    const double rounded = std::round(value);
+    if (rounded < 0.0 || rounded > static_cast<double>(std::numeric_limits<int>::max())) {
         return math::ZERO_DOUBLE;
     }
+    auto k = static_cast<int>(rounded);
 
     // Handle edge cases
     if (p_ == math::ONE) {
@@ -236,11 +240,13 @@ double NegativeBinomialDistribution::getLogProbability(double value) const noexc
         return -std::numeric_limits<double>::infinity();
     }
 
-    // Round to nearest integer and check if it's in valid range
-    auto k = static_cast<int>(std::round(value));
-    if (k < 0) {
+    // Round to nearest integer and check if it's in valid range.
+    // #88: bound-check before casting -- see getProbability().
+    const double rounded = std::round(value);
+    if (rounded < 0.0 || rounded > static_cast<double>(std::numeric_limits<int>::max())) {
         return -std::numeric_limits<double>::infinity();
     }
+    auto k = static_cast<int>(rounded);
 
     // Handle edge cases
     if (p_ == math::ONE) {
@@ -258,12 +264,18 @@ double NegativeBinomialDistribution::getCumulativeProbability(double value) cons
         return math::ZERO_DOUBLE;
     }
 
-    auto k = static_cast<int>(std::floor(value));
-
-    // Handle boundary cases
-    if (k < 0) {
+    // #88: bound-check before casting -- see getProbability(). A value this
+    // large has effectively certain cumulative probability, but the caller
+    // asked for the sum-based CDF, so clamp to a cast-safe value rather than
+    // special-casing 1.0 here.
+    const double floored = std::floor(value);
+    if (floored < 0.0) {
         return math::ZERO_DOUBLE;
     }
+    if (floored > static_cast<double>(std::numeric_limits<int>::max())) {
+        return math::ONE;
+    }
+    auto k = static_cast<int>(floored);
 
     // Compute CDF as cumulative sum: P(X <= k) = sum_{i=0}^{k} P(X = i)
     // For efficiency, we limit computation to reasonable range

--- a/src/distributions/negative_binomial_distribution.cpp
+++ b/src/distributions/negative_binomial_distribution.cpp
@@ -323,6 +323,7 @@ void NegativeBinomialDistribution::getBatchLogProbabilities(std::span<const doub
     // per-parameter constant. So this is one lgamma per element, not three,
     // and it is the only real instance of the dependency that Poisson's and
     // Binomial's comments used to claim as well (corrected 2026-08-16).
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = NegativeBinomialDistribution::getLogProbability(observations[i]);

--- a/src/distributions/pareto_distribution.cpp
+++ b/src/distributions/pareto_distribution.cpp
@@ -190,6 +190,7 @@ std::istream &operator>>(std::istream &is, libhmm::ParetoDistribution &distribut
 
 void ParetoDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                   std::span<double> out) const {
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     performance::get_double_vec_ops().pareto_batch(
         observations.data(), out.data(), observations.size(), kPlus1_, xm_, logK_ + kLogXm_);

--- a/src/distributions/poisson_distribution.cpp
+++ b/src/distributions/poisson_distribution.cpp
@@ -224,6 +224,7 @@ void PoissonDistribution::getBatchLogProbabilities(std::span<const double> obser
     // the gather to index that table by k — the same blocker as Discrete, and
     // libstats settled empirically that x86 hardware gather is too expensive to
     // pay for (its #33; table kernels are a NEON technique, not an x86 one).
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = PoissonDistribution::getLogProbability(observations[i]);

--- a/src/distributions/poisson_distribution.cpp
+++ b/src/distributions/poisson_distribution.cpp
@@ -154,6 +154,15 @@ double PoissonDistribution::getCumulativeProbability(double k) const noexcept {
         return math::ZERO_DOUBLE;
     }
 
+    // #88: k above INT_MAX cannot be cast to int without UB. Route it through
+    // the same normal-approximation formula used below for large kInt, but
+    // computed directly from the double so no cast occurs.
+    if (k > static_cast<double>(std::numeric_limits<int>::max())) {
+        ensureCache();
+        const double z = (std::floor(k) + 0.5 - lambda_) * invSqrtLambda_;
+        return 0.5 * (1.0 + std::erf(z / math::SQRT_2));
+    }
+
     const auto kInt = static_cast<int>(std::floor(k));
 
     // For very large k or lambda, the cumulative sum becomes computationally expensive

--- a/src/distributions/rayleigh_distribution.cpp
+++ b/src/distributions/rayleigh_distribution.cpp
@@ -155,6 +155,7 @@ std::istream &operator>>(std::istream &is, RayleighDistribution &distribution) {
 
 void RayleighDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                     std::span<double> out) const {
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     // inv2sigma_sq = 1/(2σ²) = -negHalfInvSigmaSquared_ (negate cached negative value)
     // log_norm = -2*log(σ)

--- a/src/distributions/student_t_distribution.cpp
+++ b/src/distributions/student_t_distribution.cpp
@@ -388,6 +388,7 @@ void StudentTDistribution::updateCache() const noexcept {
 
 void StudentTDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                     std::span<double> out) const {
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     performance::get_double_vec_ops().student_t_batch(
         observations.data(), out.data(), observations.size(), location_, cached_inv_scale_,

--- a/src/distributions/student_t_distribution.cpp
+++ b/src/distributions/student_t_distribution.cpp
@@ -23,6 +23,10 @@ StudentTDistribution::StudentTDistribution(double degrees_of_freedom)
 StudentTDistribution::StudentTDistribution(double degrees_of_freedom, double location, double scale)
     : degrees_of_freedom_(degrees_of_freedom), location_(location), scale_(scale) {
     validateParameters(degrees_of_freedom);
+    // #90: location was never validated, so a NaN/inf mu silently made every
+    // probability NaN instead of throwing at construction time.
+    if (!std::isfinite(location))
+        throw std::invalid_argument("Location parameter must be a finite number");
     if (std::isnan(scale) || std::isinf(scale) || scale <= 0.0)
         throw std::invalid_argument("Scale parameter must be a positive finite number");
     updateCache();
@@ -261,6 +265,20 @@ void StudentTDistribution::setDegreesOfFreedom(double degrees_of_freedom) {
     validateParameters(degrees_of_freedom);
     degrees_of_freedom_ = degrees_of_freedom;
     invalidateCache();
+}
+
+void StudentTDistribution::setLocation(double location) {
+    // #90: previously a bare inline assignment with no validation -- an
+    // oversight, not policy (every other setter in this class, and every
+    // other distribution's location-like setter, rejects non-finite input).
+    // No invalidateCache(): none of the cached fields (cached_inv_scale_,
+    // cached_log_scale_, cached_log_normalization_,
+    // cached_normalization_factor_, cached_half_nu_, cached_half_nu_plus_one_,
+    // cached_log_gamma_half_nu_, cached_log_gamma_half_nu_plus_one_) depend on
+    // location_ -- see updateCache().
+    if (!std::isfinite(location))
+        throw std::invalid_argument("Location parameter must be a finite number");
+    location_ = location;
 }
 
 void StudentTDistribution::setScale(double scale) {

--- a/src/distributions/uniform_distribution.cpp
+++ b/src/distributions/uniform_distribution.cpp
@@ -222,6 +222,7 @@ void UniformDistribution::getBatchLogProbabilities(std::span<const double> obser
     // blend under -march=native / /arch:AVX512.
     // Tier 2 with explicit intrinsics would replicate that same compare/blend
     // pattern for marginal gain; the auto-vectorized version is near-optimal.
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     for (std::size_t i = 0; i < observations.size(); ++i) {
         out[i] = UniformDistribution::getLogProbability(observations[i]);

--- a/src/distributions/von_mises_distribution.cpp
+++ b/src/distributions/von_mises_distribution.cpp
@@ -133,6 +133,7 @@ double VonMisesDistribution::getLogProbability(double value) const noexcept {
 
 void VonMisesDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                     std::span<double> out) const {
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     performance::get_double_vec_ops().vonmises_batch(
         observations.data(), out.data(), observations.size(), mu_, kappa_, logNormaliser_);

--- a/src/distributions/von_mises_distribution.cpp
+++ b/src/distributions/von_mises_distribution.cpp
@@ -49,16 +49,26 @@ namespace {
     // The Mardia–Jupp approximation is already close; typically 3–5 iterations
     // suffice to reach |dk| < 1e-12.
     for (int iter = 0; iter < 20 && kappa > 0.0; ++iter) {
-        const double i0 = detail::bessel_i0(kappa);
-        const double i1 = detail::bessel_i1(kappa);
-        if (i0 <= 0.0)
-            break;
-        const double A = i1 / i0;
+        // #84: A = I1(kappa)/I0(kappa) formed via one_minus_bessel_ratio
+        // instead of a direct I1/I0 division. I0(kappa) overflows to +inf
+        // above kappa ~= 713.99, which turned A into inf/inf = NaN and
+        // poisoned the whole Newton loop for R_bar >= ~0.9993 (ordinary
+        // angular dispersion, not an edge case). one_minus_bessel_ratio
+        // switches to a tier-independent asymptotic series above that
+        // threshold with no I0 evaluation at all.
+        const double A = 1.0 - detail::one_minus_bessel_ratio(kappa);
         const double Ap = 1.0 - A * A - A / kappa;
         if (std::fabs(Ap) < 1e-15)
             break;
         const double dk = (A - R_bar) / Ap;
         kappa -= dk;
+        if (!std::isfinite(kappa)) {
+            // Belt-and-suspenders: if anything still produces a non-finite
+            // update, saturate to the same point-mass value used above for
+            // R_bar >= 1.0 rather than storing NaN.
+            kappa = thresholds::MAX_DISTRIBUTION_PARAMETER;
+            break;
+        }
         if (kappa < 0.0) {
             kappa = 0.0;
             break;

--- a/src/distributions/weibull_distribution.cpp
+++ b/src/distributions/weibull_distribution.cpp
@@ -333,6 +333,7 @@ std::istream &operator>>(std::istream &is, WeibullDistribution &distribution) {
 
 void WeibullDistribution::getBatchLogProbabilities(std::span<const double> observations,
                                                    std::span<double> out) const {
+    checkBatchSpans(observations.size(), out.size());
     ensureCache();
     // log_norm = log(k) - k*log(λ);  neg_k_log_lambda = -k*log(λ)
     // pow term: exp(k*log(x) + neg_k_log_lambda) = exp(k*(log(x) - log(λ))) = (x/λ)^k

--- a/src/hmm.cpp
+++ b/src/hmm.cpp
@@ -312,14 +312,28 @@ const std::unordered_map<std::string, StreamParserFn> &stream_parsers() {
 } // anonymous namespace
 
 std::istream &operator>>(std::istream &is, libhmm::Hmm &hmm) {
+    // Legacy stream states-count bound. Kept in step with kMaxHmmStates in
+    // src/io/hmm_json.cpp (currently 4096); the two formats accept the same
+    // maximum HMM size. Promoting this to a shared header would be a clean
+    // option if a third format ever needs the same bound.
+    constexpr std::size_t kMaxLegacyStates = 4096;
+
     std::string s, t;
     std::size_t states = 0;
 
     is >> s >> s >> s >> s; // "Hidden Markov Model parameters"
     is >> s >> s;           // "States:"
-    states = std::stoull(s);
-    if (states == 0)
-        throw std::runtime_error("Invalid number of states in HMM input");
+    try {
+        states = std::stoull(s);
+    } catch (const std::exception &) {
+        throw std::runtime_error("Invalid number of states in HMM input: \"" + s + "\"");
+    }
+    // Bound the count before any allocation: std::stoull accepts a leading
+    // '-' (wrapping to a huge unsigned value), and an in-range but oversized
+    // count (e.g. 200000) would attempt a 200000x200000 trans_ matrix.
+    if (states == 0 || states > kMaxLegacyStates)
+        throw std::runtime_error("Invalid number of states in HMM input: must be in [1, " +
+                                 std::to_string(kMaxLegacyStates) + "]");
 
     hmm = Hmm(states);
     Vector pi(states);

--- a/src/io/hmm_json.cpp
+++ b/src/io/hmm_json.cpp
@@ -39,6 +39,18 @@ std::size_t checked_size(double raw, double lo, double hi, const char *err_msg) 
     return static_cast<std::size_t>(raw);
 }
 
+/// Validate a JSON-read weight vector (pi entries, or one row of trans).
+/// Every entry must be finite and non-negative; normalisation is NOT checked
+/// here (trainers renormalise). Shared by both from_json and from_json_mv.
+/// @throws std::runtime_error naming @p what if any entry is NaN, infinite, or negative.
+void check_weights(const std::vector<double> &values, const char *what) {
+    for (double v : values) {
+        if (!std::isfinite(v) || v < 0.0)
+            throw std::runtime_error(std::string("HMM JSON: ") + what +
+                                     " entries must be finite and non-negative");
+    }
+}
+
 // =============================================================================
 // Scalar distribution factory
 
@@ -183,9 +195,12 @@ Hmm from_json(std::string_view src) {
 
     expect_key(r.read_key(), "pi");
     const auto pi_data = r.read_double_array(N);
+    check_weights(pi_data, "pi");
 
     expect_key(r.read_key(), "trans");
     const auto trans_rows = r.read_double_matrix(N, N);
+    for (const auto &row : trans_rows)
+        check_weights(row, "trans");
 
     expect_key(r.read_key(), "distributions");
     auto emis = read_distribution_array(r, N);
@@ -376,9 +391,12 @@ HmmMV from_json_mv(std::string_view src) {
 
     expect_key(r.read_key(), "pi");
     const auto pi_data = r.read_double_array(N);
+    check_weights(pi_data, "pi");
 
     expect_key(r.read_key(), "trans");
     const auto trans_rows = r.read_double_matrix(N, N);
+    for (const auto &row : trans_rows)
+        check_weights(row, "trans");
 
     expect_key(r.read_key(), "distributions");
     auto emis = read_mv_distribution_array(r, N);

--- a/src/io/json_utils.cpp
+++ b/src/io/json_utils.cpp
@@ -1,7 +1,9 @@
 #include "libhmm/io/json_utils.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
@@ -148,15 +150,32 @@ double Reader::read_double() {
     // std::strtod provides the same consumed-position semantics and is portable.
     // write_double() imbues std::locale::classic() so the decimal separator is
     // always '.' — strtod uses the same convention under the default C locale.
-    const char *begin = src_.data() + pos_;
+    //
+    // strtod() is a NUL-terminated-string API with no length parameter, but
+    // src_ is a caller-supplied string_view that may not be NUL-terminated at
+    // all (a substring, a memory-mapped file, a network buffer) — handing it
+    // src_.data() + pos_ directly would let the scan run past src_.size().
+    // Copy the candidate token into a small NUL-terminated stack buffer sized
+    // to the lesser of 63 bytes and the remaining view instead: 64 bytes
+    // covers any double a writer can emit (max_digits10 = 17 digits, plus
+    // sign, decimal point, and exponent), and bounding the copy by the
+    // remaining view size means the parse — and the pos_ advance below — can
+    // never reach past src_.size().
+    constexpr std::size_t kMaxTokenLen = 63;
+    const std::size_t available = src_.size() - pos_;
+    const std::size_t token_len = std::min(kMaxTokenLen, available);
+    char buf[kMaxTokenLen + 1];
+    std::memcpy(buf, src_.data() + pos_, token_len);
+    buf[token_len] = '\0';
+
     char *end_ptr = nullptr;
     errno = 0;
-    const double value = std::strtod(begin, &end_ptr);
-    if (end_ptr == begin)
+    const double value = std::strtod(buf, &end_ptr);
+    if (end_ptr == buf)
         throw std::runtime_error("json::Reader: failed to parse number");
     if (errno == ERANGE)
         throw std::runtime_error("json::Reader: number out of range");
-    pos_ = static_cast<std::size_t>(end_ptr - src_.data());
+    pos_ += static_cast<std::size_t>(end_ptr - buf);
     return value;
 }
 

--- a/src/io/xml_file_reader.cpp
+++ b/src/io/xml_file_reader.cpp
@@ -49,6 +49,14 @@ Hmm XMLFileReader::read(const std::filesystem::path &filepath) {
 
     } catch (const std::ios_base::failure &e) {
         throw std::runtime_error("I/O operation failed: " + std::string(e.what()));
+    } catch (const std::bad_alloc &e) {
+        // header documents runtime_error/invalid_argument only; translate
+        // rather than let an oversized/malformed states count escape raw.
+        throw std::runtime_error("I/O operation failed: " + std::string(e.what()));
+    } catch (const std::logic_error &e) {
+        // Covers std::invalid_argument, std::out_of_range, std::length_error
+        // (e.g. a non-numeric or oversized legacy States: value).
+        throw std::runtime_error("I/O operation failed: " + std::string(e.what()));
     }
 }
 
@@ -125,6 +133,14 @@ Hmm XMLFileReader::readFromStream(std::ifstream &stream) {
         return hmm;
 
     } catch (const std::ios_base::failure &e) {
+        throw std::runtime_error("Stream I/O error: " + std::string(e.what()));
+    } catch (const std::bad_alloc &e) {
+        // header documents runtime_error/invalid_argument only; translate
+        // rather than let an oversized/malformed states count escape raw.
+        throw std::runtime_error("Stream I/O error: " + std::string(e.what()));
+    } catch (const std::logic_error &e) {
+        // Covers std::invalid_argument, std::out_of_range, std::length_error
+        // (e.g. a non-numeric or oversized legacy States: value).
         throw std::runtime_error("Stream I/O error: " + std::string(e.what()));
     }
 }

--- a/src/platform/cpu_detection.cpp
+++ b/src/platform/cpu_detection.cpp
@@ -82,6 +82,9 @@ bool detect_avx2() noexcept {
     if (!os_and_cpu_support_avx())
         return false;
     int info[4] = {};
+    run_cpuid(1, 0, info);
+    if (!((info[2] >> 12) & 1)) // ECX bit 12: FMA3 — no shipping AVX2 part lacks it
+        return false;
     run_cpuid(7, 0, info);
     return (info[1] >> 5) & 1; // EBX bit 5: AVX2
 }
@@ -96,7 +99,10 @@ bool detect_avx512() noexcept {
         return false;
     int info[4] = {};
     run_cpuid(7, 0, info);
-    return (info[1] >> 16) & 1; // EBX bit 16: AVX-512F
+    // Require F + DQ + BW + VL (see kAvx512RequiredMask): F alone is not
+    // enough — the AVX-512DQ intrinsics the AVX-512 TU and this header's
+    // 8-wide section use SIGILL on an F-without-DQ part (issue #83).
+    return (static_cast<unsigned>(info[1]) & kAvx512RequiredMask) == kAvx512RequiredMask;
 }
 
 #endif // LIBHMM_CPU_X86

--- a/tests/distributions/test_binomial_distribution.cpp
+++ b/tests/distributions/test_binomial_distribution.cpp
@@ -480,6 +480,36 @@ TEST(BinomialDistributionTest, Caching) {
     EXPECT_EQ(logProb1, logProb2);
 }
 
+/**
+ * Issue #88: a value above n_ must be range-checked before being rounded and
+ * cast to int, not after. Before the fix, `k = static_cast<int>(std::round(
+ * value))` ran unconditionally and the k > n_ rejection happened on the
+ * already-cast (UB, for a large enough value) int.
+ */
+TEST(BinomialDistributionTest, CastOverflowGuard) {
+    BinomialDistribution binomial(10, 0.5);
+
+    EXPECT_TRUE(std::isinf(binomial.getLogProbability(1e15)));
+    EXPECT_LT(binomial.getLogProbability(1e15), 0.0);
+    EXPECT_EQ(binomial.getProbability(1e12), 0.0);
+
+    std::vector<double> obs = {0.0, 5.0, 1e15, 10.0};
+    std::vector<double> out(obs.size());
+    binomial.getBatchLogProbabilities(obs, out);
+    EXPECT_TRUE(std::isinf(out[2]));
+    EXPECT_LT(out[2], 0.0);
+
+    // fit() must not crash or invoke UB when an out-of-range element is present.
+    std::vector<Observation> fitData = {1.0, 2.0, 1e15, 3.0};
+    EXPECT_NO_THROW(binomial.fit(fitData));
+    EXPECT_TRUE(std::isfinite(static_cast<double>(binomial.getN())));
+    EXPECT_TRUE(std::isfinite(binomial.getP()));
+
+    std::vector<double> weights = {1.0, 1.0, 1.0, 1.0};
+    EXPECT_NO_THROW(binomial.fit(fitData, weights));
+    EXPECT_TRUE(std::isfinite(binomial.getP()));
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/distributions/test_discrete_distribution.cpp
+++ b/tests/distributions/test_discrete_distribution.cpp
@@ -500,6 +500,37 @@ TEST(DiscreteDistributionTest, Caching) {
     EXPECT_NE(newEntropy, entropy1); // Should be different after change
 }
 
+/**
+ * Issue #88: values above numSymbols_ (in particular, ones large enough to
+ * overflow std::size_t on cast) must not be cast before the range check.
+ * Before the fix, getProbability()/getLogProbability() cast first and
+ * checked isValidIndex() after -- the cast itself is UB for a finite double
+ * this large ([conv.fpint]), and the result is ISA-dependent.
+ */
+TEST(DiscreteDistributionTest, CastOverflowGuard) {
+    DiscreteDistribution discrete(5);
+
+    EXPECT_TRUE(std::isinf(discrete.getLogProbability(1e15)));
+    EXPECT_LT(discrete.getLogProbability(1e15), 0.0);
+    EXPECT_EQ(discrete.getProbability(1e12), 0.0);
+
+    std::vector<double> obs = {0.0, 1.0, 1e15, 2.0};
+    std::vector<double> out(obs.size());
+    discrete.getBatchLogProbabilities(obs, out);
+    EXPECT_TRUE(std::isinf(out[2]));
+    EXPECT_LT(out[2], 0.0);
+
+    // fit() must not crash or invoke UB when an out-of-range element is present;
+    // it should simply be excluded from the empirical distribution.
+    std::vector<Observation> fitData = {0.0, 1.0, 1e15, 2.0};
+    EXPECT_NO_THROW(discrete.fit(fitData));
+    EXPECT_NEAR(discrete.getProbabilitySum(), 1.0, 1e-10);
+
+    std::vector<double> weights = {1.0, 1.0, 1.0, 1.0};
+    EXPECT_NO_THROW(discrete.fit(fitData, weights));
+    EXPECT_NEAR(discrete.getProbabilitySum(), 1.0, 1e-10);
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/distributions/test_gaussian_distribution.cpp
+++ b/tests/distributions/test_gaussian_distribution.cpp
@@ -296,6 +296,16 @@ TEST(GaussianDistributionTest, Performance) {
     EXPECT_LT(sum_log_pdf, 0.0);
 }
 
+// Issue #86: getBatchLogProbabilities ignored out.size(), writing past the
+// end of a shorter out span (OOB heap write). Gaussian is the tier-2
+// (DoubleVecOps-dispatched) representative.
+TEST(GaussianDistributionTest, BatchLogProbabilitiesRejectsShortOutSpan) {
+    GaussianDistribution gaussian(0.0, 1.0);
+    std::vector<double> obs(100, 1.0);
+    std::vector<double> out(10);
+    EXPECT_THROW(gaussian.getBatchLogProbabilities(obs, out), std::invalid_argument);
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/distributions/test_negative_binomial_distribution.cpp
+++ b/tests/distributions/test_negative_binomial_distribution.cpp
@@ -597,6 +597,40 @@ TEST(NegativeBinomialDistributionTest, Performance) {
     EXPECT_LT(fitTimePerPoint, 20.0);  // Less than 20 μs per data point for fitting
 }
 
+/**
+ * Issue #88: a value above INT_MAX must not be cast to int in
+ * getProbability()/getLogProbability()/getCumulativeProbability(). Before the
+ * fix, `k = static_cast<int>(std::round(value))` ran unconditionally --
+ * casting a finite double this large is UB ([conv.fpint]) and ISA-dependent.
+ *
+ * fit() itself never casts to int (k is kept as a double for the Newton-
+ * Raphson MLE solver), so the fit() case here is a defensive regression
+ * guard rather than a reproduction of the cast UB.
+ */
+TEST(NegativeBinomialDistributionTest, CastOverflowGuard) {
+    NegativeBinomialDistribution negbinom(5.0, 0.5);
+
+    EXPECT_TRUE(std::isinf(negbinom.getLogProbability(1e15)));
+    EXPECT_LT(negbinom.getLogProbability(1e15), 0.0);
+    EXPECT_EQ(negbinom.getProbability(1e12), 0.0);
+
+    std::vector<double> obs = {0.0, 1.0, 1e15, 2.0};
+    std::vector<double> out(obs.size());
+    negbinom.getBatchLogProbabilities(obs, out);
+    EXPECT_TRUE(std::isinf(out[2]));
+    EXPECT_LT(out[2], 0.0);
+
+    std::vector<Observation> fitData = {1.0, 2.0, 3.0, 4.0, 5.0, 1e15};
+    EXPECT_NO_THROW(negbinom.fit(fitData));
+    EXPECT_TRUE(std::isfinite(negbinom.getR()));
+    EXPECT_TRUE(std::isfinite(negbinom.getP()));
+
+    std::vector<double> weights = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+    EXPECT_NO_THROW(negbinom.fit(fitData, weights));
+    EXPECT_TRUE(std::isfinite(negbinom.getR()));
+    EXPECT_TRUE(std::isfinite(negbinom.getP()));
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/distributions/test_poisson_distribution.cpp
+++ b/tests/distributions/test_poisson_distribution.cpp
@@ -393,6 +393,35 @@ TEST(PoissonDistributionTest, BatchLogProbabilitiesRejectsShortOutSpan) {
     EXPECT_THROW(poisson.getBatchLogProbabilities(obs, out), std::invalid_argument);
 }
 
+/**
+ * Issue #88: values above INT_MAX must not be cast to int. Before the fix,
+ * isValidCount() only checked k >= 0 and finiteness, so a value like 1e15
+ * reached `static_cast<int>(k)` -- UB, ISA-dependent (x86 CVTTSD2SI yields
+ * INT_MIN, which the k > n_ style range checks incidentally reject; AArch64
+ * FCVTZS saturates to INT_MAX and returns a large finite log-probability).
+ */
+TEST(PoissonDistributionTest, CastOverflowGuard) {
+    PoissonDistribution poisson(5.0);
+
+    EXPECT_TRUE(std::isinf(poisson.getLogProbability(1e15)));
+    EXPECT_LT(poisson.getLogProbability(1e15), 0.0);
+    EXPECT_EQ(poisson.getProbability(1e12), 0.0);
+
+    // Batch path: the overflowing element must not corrupt or crash the batch.
+    std::vector<double> obs = {1.0, 2.0, 1e15, 3.0};
+    std::vector<double> out(obs.size());
+    poisson.getBatchLogProbabilities(obs, out);
+    EXPECT_TRUE(std::isinf(out[2]));
+    EXPECT_LT(out[2], 0.0);
+
+    // fit() must not crash or invoke UB when an out-of-range element is present.
+    // Poisson's fit() never casts to int (lambda is the plain sample mean), so
+    // this is a defensive regression guard rather than a UB reproduction.
+    std::vector<Observation> fitData = {1.0, 2.0, 1e15, 3.0};
+    EXPECT_NO_THROW(poisson.fit(fitData));
+    EXPECT_TRUE(std::isfinite(poisson.getLambda()));
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/distributions/test_poisson_distribution.cpp
+++ b/tests/distributions/test_poisson_distribution.cpp
@@ -381,6 +381,18 @@ TEST(PoissonDistributionTest, Caching) {
     EXPECT_EQ(logProb1, logProb2);
 }
 
+/**
+ * Issue #86: getBatchLogProbabilities must reject an out span shorter than
+ * the observations span instead of writing past its end. Poisson is the
+ * tier-1 (scalar-loop) representative.
+ */
+TEST(PoissonDistributionTest, BatchLogProbabilitiesRejectsShortOutSpan) {
+    PoissonDistribution poisson(2.0);
+    std::vector<double> obs(100, 3.0);
+    std::vector<double> out(10);
+    EXPECT_THROW(poisson.getBatchLogProbabilities(obs, out), std::invalid_argument);
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/distributions/test_student_t_distribution.cpp
+++ b/tests/distributions/test_student_t_distribution.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "libhmm/distributions/student_t_distribution.h"
+#include "libhmm/io/json_utils.h"
 #include <memory>
 #include <vector>
 #include <cmath>
@@ -440,6 +441,61 @@ TEST(StudentTDistributionTest, Performance) {
     EXPECT_LT(pdfTimePerCall, 10.0);   // Less than 10 μs per PDF call
     EXPECT_LT(logPdfTimePerCall, 5.0); // Less than 5 μs per log PDF call
     EXPECT_LT(fitTimePerPoint, 50.0);  // Less than 50 μs per data point for fitting
+}
+
+// ============================================================================
+// Issue #90: location parameter (mu) was never validated -- setLocation() was
+// a bare inline assignment and the 3-arg constructor validated df/scale but
+// not location. A NaN/inf mu silently made every probability NaN instead of
+// throwing.
+// ============================================================================
+
+TEST(StudentTDistributionTest, ConstructorRejectsNonFiniteLocation) {
+    EXPECT_THROW(StudentTDistribution(3.0, std::numeric_limits<double>::quiet_NaN(), 1.0),
+                 std::invalid_argument);
+    EXPECT_THROW(StudentTDistribution(3.0, std::numeric_limits<double>::infinity(), 1.0),
+                 std::invalid_argument);
+    EXPECT_THROW(StudentTDistribution(3.0, -std::numeric_limits<double>::infinity(), 1.0),
+                 std::invalid_argument);
+    EXPECT_NO_THROW(StudentTDistribution(3.0, 2.5, 1.0));
+}
+
+TEST(StudentTDistributionTest, SetLocationRejectsNonFiniteValue) {
+    StudentTDistribution t_dist(3.0, 0.0, 1.0);
+    EXPECT_THROW(t_dist.setLocation(std::numeric_limits<double>::quiet_NaN()),
+                 std::invalid_argument);
+    EXPECT_THROW(t_dist.setLocation(std::numeric_limits<double>::infinity()),
+                 std::invalid_argument);
+    // Location unchanged after the rejected calls.
+    EXPECT_EQ(t_dist.getLocation(), 0.0);
+
+    t_dist.setLocation(2.5);
+    EXPECT_EQ(t_dist.getLocation(), 2.5);
+}
+
+TEST(StudentTDistributionTest, FromJsonRejectsNonFiniteLocation) {
+    // Reader positioned as it would be inside read_distribution() -- after
+    // the dispatch has already consumed {"type":"StudentT",.
+    libhmm::json::Reader r(R"("df":3.0,"mu":nan,"sigma":1.0})");
+    EXPECT_THROW(static_cast<void>(StudentTDistribution::from_json(r)), std::invalid_argument);
+}
+
+// ============================================================================
+// Basic setter coverage (metrics sweep flagged setScale/VonMises::setMu/
+// setKappa as untested; setScale added here alongside the #90 work).
+// ============================================================================
+
+TEST(StudentTDistributionTest, SetScale) {
+    StudentTDistribution t_dist(3.0, 0.0, 1.0);
+    t_dist.setScale(2.5);
+    EXPECT_EQ(t_dist.getScale(), 2.5);
+
+    EXPECT_THROW(t_dist.setScale(0.0), std::invalid_argument);
+    EXPECT_THROW(t_dist.setScale(-1.0), std::invalid_argument);
+    EXPECT_THROW(t_dist.setScale(std::numeric_limits<double>::quiet_NaN()), std::invalid_argument);
+    EXPECT_THROW(t_dist.setScale(std::numeric_limits<double>::infinity()), std::invalid_argument);
+    // Rejected calls must not change the scale.
+    EXPECT_EQ(t_dist.getScale(), 2.5);
 }
 
 /**

--- a/tests/distributions/test_von_mises_distribution.cpp
+++ b/tests/distributions/test_von_mises_distribution.cpp
@@ -533,6 +533,81 @@ TEST(VonMisesDistribution, SetKappa) {
 }
 
 // ============================================================================
+// Issue #84: kappa_from_r_bar produced NaN for R_bar >= ~0.9993 (ordinary
+// angular dispersion, ~2 degrees). Above that, I0(kappa) overflows inside the
+// Newton loop's direct I1/I0 division, poisoning kappa with NaN, which fit()
+// then stored.
+//
+// Reference kappa values solve I1(kappa)/I0(kappa) = R_bar via mpmath
+// (dps=80, mp.findroot with a Mardia-Jupp seed). Essentials of the generator
+// (full script: scratch/gen_vonmises_kappa_ref.py, not checked in):
+//
+//   def r_bar_of(amplitude, n):
+//       s_cos = s_sin = mpf(0)
+//       for i in range(n):
+//           theta = amplitude * sin(2*pi*i/n)
+//           s_cos += cos(theta); s_sin += sin(theta)
+//       return sqrt(s_cos**2 + s_sin**2) / n
+//
+//   def solve_kappa(r_bar):
+//       f = lambda k: besseli(1, k) / besseli(0, k) - r_bar
+//       seed = 1 / (r_bar**3 - 4*r_bar**2 + 3*r_bar)   # Mardia-Jupp seed
+//       return mp.findroot(f, seed)
+//
+// Results (N = 1000):
+//   amplitude=0.05  R_bar=0.999375097649  kappa=800.375245557
+//   amplitude=0.03  R_bar=0.999775012656  kappa=2222.59731055
+//
+// Assert on getKappa()/getLogProbability(), NOT getCircularVariance():
+// one_minus_bessel_ratio(NaN) deliberately returns 1.0, so
+// getCircularVariance() would hide the very NaN this test exists to catch.
+// ============================================================================
+
+namespace {
+double mean_resultant_length_angles(const std::vector<double> &angles) {
+    double s_cos = 0.0, s_sin = 0.0;
+    for (double theta : angles) {
+        s_cos += std::cos(theta);
+        s_sin += std::sin(theta);
+    }
+    return std::sqrt(s_cos * s_cos + s_sin * s_sin) / static_cast<double>(angles.size());
+}
+
+std::vector<double> sinusoidal_angles(double amplitude, int n) {
+    std::vector<double> angles(n);
+    for (int i = 0; i < n; ++i)
+        angles[i] = amplitude * std::sin(TWO_PI * i / n);
+    return angles;
+}
+} // namespace
+
+TEST(VonMisesDistribution, FitOnNearlyDegenerateAnglesGivesFiniteKappa) {
+    struct Case {
+        double amplitude;
+        double reference_kappa;
+    };
+    constexpr Case kCases[] = {
+        {0.05, 800.375245557},
+        {0.03, 2222.59731055},
+    };
+    constexpr int N = 1000;
+
+    for (const auto &c : kCases) {
+        const std::vector<double> angles = sinusoidal_angles(c.amplitude, N);
+        // Sanity-check this test's own R_bar is in the regime #84 describes.
+        ASSERT_GE(mean_resultant_length_angles(angles), 0.9993) << "amplitude=" << c.amplitude;
+
+        VonMisesDistribution d;
+        d.fit(angles);
+
+        ASSERT_TRUE(std::isfinite(d.getKappa())) << "amplitude=" << c.amplitude;
+        ASSERT_TRUE(std::isfinite(d.getLogProbability(0.0))) << "amplitude=" << c.amplitude;
+        EXPECT_NEAR(d.getKappa(), c.reference_kappa, 1e-3 * c.reference_kappa)
+            << "amplitude=" << c.amplitude;
+    }
+}
+
+// ============================================================================
 // toString
 // ============================================================================
 

--- a/tests/distributions/test_von_mises_distribution.cpp
+++ b/tests/distributions/test_von_mises_distribution.cpp
@@ -503,6 +503,36 @@ TEST(VonMisesDistribution, FitWeightedIgnoresInfObservations) {
 }
 
 // ============================================================================
+// Setters (#90: previously untested)
+// ============================================================================
+
+TEST(VonMisesDistribution, SetMu) {
+    VonMisesDistribution d(0.0, 2.0);
+    d.setMu(1.5);
+    EXPECT_NEAR(d.getMu(), 1.5, 1e-12);
+    EXPECT_DOUBLE_EQ(d.getKappa(), 2.0); // unaffected
+
+    // setMu wraps to (-pi, pi], same as the constructor.
+    d.setMu(4.0);
+    EXPECT_NEAR(d.getMu(), 4.0 - TWO_PI, 1e-12);
+
+    EXPECT_THROW(d.setMu(std::numeric_limits<double>::quiet_NaN()), std::invalid_argument);
+    EXPECT_THROW(d.setMu(std::numeric_limits<double>::infinity()), std::invalid_argument);
+}
+
+TEST(VonMisesDistribution, SetKappa) {
+    VonMisesDistribution d(0.5, 1.0);
+    d.setKappa(3.0);
+    EXPECT_DOUBLE_EQ(d.getKappa(), 3.0);
+    EXPECT_NEAR(d.getMu(), 0.5, 1e-12); // unaffected
+
+    EXPECT_THROW(d.setKappa(-0.1), std::invalid_argument);
+    EXPECT_THROW(d.setKappa(std::numeric_limits<double>::quiet_NaN()), std::invalid_argument);
+    EXPECT_THROW(d.setKappa(std::numeric_limits<double>::infinity()), std::invalid_argument);
+    EXPECT_NO_THROW(d.setKappa(0.0)); // uniform distribution is allowed
+}
+
+// ============================================================================
 // toString
 // ============================================================================
 

--- a/tests/io/test_hmm_json.cpp
+++ b/tests/io/test_hmm_json.cpp
@@ -370,6 +370,20 @@ TEST(JsonReader, ReadDoubleAtEofThrows) {
     EXPECT_THROW(static_cast<void>(r.read_double()), std::runtime_error);
 }
 
+// Regression for #87: read_double() must never consume characters beyond the
+// declared string_view, even when the backing buffer (still live, and not
+// followed by a NUL within the view) continues with more digits. A view that
+// ignores its own bound reads the extra digits from the live backing storage
+// and returns the wrong, longer number; a correctly bounded read stops at the
+// view's edge. This is a more direct, deterministic discriminator for the
+// underlying bug than routing through from_json(), where the accidental
+// larger value happens to be caught by the unrelated states-count cap.
+TEST(JsonReader, ReadDoubleDoesNotReadPastViewBounds) {
+    const std::string backing = "12345678999";        // 11 digits, no delimiter in view
+    Reader r(std::string_view(backing).substr(0, 3)); // view is "123"
+    EXPECT_EQ(r.read_double(), 123.0);
+}
+
 TEST(JsonReader, ReadDoubleArrayValid) {
     Reader r("[1.0, 2.0, 3.0]");
     auto v = r.read_double_array();
@@ -449,6 +463,23 @@ TEST(HmmJsonErrors, RejectsReorderedKeys) {
 TEST(HmmJsonErrors, RejectsOversizedInput) {
     const std::string oversized(11UL * 1024UL * 1024UL, ' ');
     EXPECT_THROW(static_cast<void>(from_json(oversized)), std::runtime_error);
+}
+
+// =============================================================================
+// Non-NUL-terminated string_view safety (#87)
+//
+// from_json() takes a string_view, not a NUL-terminated string. read_double()
+// must not read past the view's bounds even when the underlying buffer
+// continues beyond it (e.g. a substr() of a larger string).
+// =============================================================================
+
+TEST(HmmJsonSanitization, TruncatedViewDoesNotOverread) {
+    // The full string continues past the 11-byte prefix with "56789}", so a
+    // read_double() that ignores the view's bound would parse "3456789" out
+    // of the tail of `big` instead of failing on the truncated document.
+    std::string big = "{\"states\":3456789}";
+    EXPECT_THROW(static_cast<void>(from_json(std::string_view(big).substr(0, 11))),
+                 std::runtime_error);
 }
 
 int main(int argc, char **argv) {

--- a/tests/io/test_hmm_json.cpp
+++ b/tests/io/test_hmm_json.cpp
@@ -482,6 +482,49 @@ TEST(HmmJsonSanitization, TruncatedViewDoesNotOverread) {
                  std::runtime_error);
 }
 
+// =============================================================================
+// NaN/Inf/negative rejection in pi and trans (#91)
+//
+// checked_size() bounds sizes but nothing previously inspected pi/trans
+// *values*: NaN, infinity, and negative weights were silently accepted.
+// =============================================================================
+
+TEST(HmmJsonSanitization, PiWithNanThrows) {
+    const std::string json = "{\"states\":1,\"pi\":[nan],\"trans\":[[1.0]],"
+                             "\"distributions\":[{\"type\":\"Gaussian\",\"mu\":0,\"sigma\":1}]}";
+    EXPECT_THROW(static_cast<void>(from_json(json)), std::runtime_error);
+}
+
+TEST(HmmJsonSanitization, PiWithInfThrows) {
+    const std::string json = "{\"states\":1,\"pi\":[inf],\"trans\":[[1.0]],"
+                             "\"distributions\":[{\"type\":\"Gaussian\",\"mu\":0,\"sigma\":1}]}";
+    EXPECT_THROW(static_cast<void>(from_json(json)), std::runtime_error);
+}
+
+TEST(HmmJsonSanitization, PiWithNegativeThrows) {
+    const std::string json = "{\"states\":1,\"pi\":[-1.0],\"trans\":[[1.0]],"
+                             "\"distributions\":[{\"type\":\"Gaussian\",\"mu\":0,\"sigma\":1}]}";
+    EXPECT_THROW(static_cast<void>(from_json(json)), std::runtime_error);
+}
+
+TEST(HmmJsonSanitization, TransWithNanThrows) {
+    const std::string json = "{\"states\":1,\"pi\":[1.0],\"trans\":[[nan]],"
+                             "\"distributions\":[{\"type\":\"Gaussian\",\"mu\":0,\"sigma\":1}]}";
+    EXPECT_THROW(static_cast<void>(from_json(json)), std::runtime_error);
+}
+
+TEST(HmmJsonSanitization, TransWithNegativeThrows) {
+    const std::string json = "{\"states\":1,\"pi\":[1.0],\"trans\":[[-5.0]],"
+                             "\"distributions\":[{\"type\":\"Gaussian\",\"mu\":0,\"sigma\":1}]}";
+    EXPECT_THROW(static_cast<void>(from_json(json)), std::runtime_error);
+}
+
+TEST(HmmJsonSanitization, ValidPiAndTransAccepted) {
+    const std::string json = "{\"states\":1,\"pi\":[1.0],\"trans\":[[1.0]],"
+                             "\"distributions\":[{\"type\":\"Gaussian\",\"mu\":0,\"sigma\":1}]}";
+    EXPECT_NO_THROW(static_cast<void>(from_json(json)));
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/io/test_hmm_json_mv.cpp
+++ b/tests/io/test_hmm_json_mv.cpp
@@ -319,6 +319,34 @@ TEST(MvJsonErrors, RejectsOversizedDimensionsManifest) {
 }
 
 // =============================================================================
+// NaN/Inf/negative rejection in pi and trans, MV path (#91)
+// =============================================================================
+
+TEST(MvJsonSanitization, PiWithNanThrows) {
+    const std::string bad =
+        R"({"libhmm_version":"4","obs_type":"multivariate","dimensions":2,"states":1,)"
+        R"("pi":[nan],"trans":[[1.0]],)"
+        R"("distributions":[{"type":"DiagonalGaussian","dim":2,"mean":[0.0,0.0],"var":[1.0,1.0]}]})"; // NOLINT
+    EXPECT_THROW(static_cast<void>(from_json_mv(bad)), std::runtime_error);
+}
+
+TEST(MvJsonSanitization, TransWithNegativeThrows) {
+    const std::string bad =
+        R"({"libhmm_version":"4","obs_type":"multivariate","dimensions":2,"states":1,)"
+        R"("pi":[1.0],"trans":[[-5.0]],)"
+        R"("distributions":[{"type":"DiagonalGaussian","dim":2,"mean":[0.0,0.0],"var":[1.0,1.0]}]})"; // NOLINT
+    EXPECT_THROW(static_cast<void>(from_json_mv(bad)), std::runtime_error);
+}
+
+TEST(MvJsonSanitization, ValidPiAndTransAccepted) {
+    const std::string good =
+        R"({"libhmm_version":"4","obs_type":"multivariate","dimensions":2,"states":1,)"
+        R"("pi":[1.0],"trans":[[1.0]],)"
+        R"("distributions":[{"type":"DiagonalGaussian","dim":2,"mean":[0.0,0.0],"var":[1.0,1.0]}]})"; // NOLINT
+    EXPECT_NO_THROW(static_cast<void>(from_json_mv(good)));
+}
+
+// =============================================================================
 // Scalar from_json still works (backward compat unchanged)
 // =============================================================================
 

--- a/tests/io/test_hmm_stream_io.cpp
+++ b/tests/io/test_hmm_stream_io.cpp
@@ -522,6 +522,76 @@ TEST_F(HmmStreamIOTest, ParseDiscreteSymbolCountOverflowThrows) {
     EXPECT_THROW(iss >> hmm, std::runtime_error);
 }
 
+// =============================================================================
+// Legacy States: count bound (#89)
+//
+// operator>> must reject an out-of-range or malformed States: count before
+// any allocation is attempted. States: 200000 is intentionally NOT exercised
+// pre-fix here (it would attempt an unbounded ~320 GB allocation on this
+// machine); the other three are cheap in both the broken and fixed states.
+// =============================================================================
+
+TEST_F(HmmStreamIOTest, StatesCountAboveUint32RangeThrows) {
+    const std::string stream_str = R"(Hidden Markov Model parameters
+  States: 4294967296
+  Pi: [ 1.0 ]
+  Transmission matrix:
+   [ 1.0 ]
+  Emissions:
+   State 0: Gaussian Distribution:
+)";
+    std::istringstream iss(stream_str);
+    Hmm hmm(1);
+    EXPECT_THROW(iss >> hmm, std::runtime_error);
+}
+
+// NOTE: pre-fix, this allocates an unbounded ~320 GB (states=200000 makes a
+// 200000x200000 Matrix). Do not run this test pre-fix on a real machine —
+// exclude it with --gtest_filter=-*StatesCountWayAboveCapThrows* when
+// capturing red evidence for the other three cases. Post-fix the bound check
+// runs before any allocation, so this is cheap.
+TEST_F(HmmStreamIOTest, StatesCountWayAboveCapThrows) {
+    const std::string stream_str = R"(Hidden Markov Model parameters
+  States: 200000
+  Pi: [ 1.0 ]
+  Transmission matrix:
+   [ 1.0 ]
+  Emissions:
+   State 0: Gaussian Distribution:
+)";
+    std::istringstream iss(stream_str);
+    Hmm hmm(1);
+    EXPECT_THROW(iss >> hmm, std::runtime_error);
+}
+
+TEST_F(HmmStreamIOTest, StatesCountNegativeThrows) {
+    const std::string stream_str = R"(Hidden Markov Model parameters
+  States: -1
+  Pi: [ 1.0 ]
+  Transmission matrix:
+   [ 1.0 ]
+  Emissions:
+   State 0: Gaussian Distribution:
+)";
+    std::istringstream iss(stream_str);
+    Hmm hmm(1);
+    EXPECT_THROW(iss >> hmm, std::runtime_error);
+}
+
+TEST_F(HmmStreamIOTest, StatesCountNonNumericThrows) {
+    const std::string stream_str = R"(Hidden Markov Model parameters
+  States: abc
+  Pi: [ 1.0 ]
+  Transmission matrix:
+   [ 1.0 ]
+  Emissions:
+   State 0: Gaussian Distribution:
+)";
+    std::istringstream iss(stream_str);
+    Hmm hmm(1);
+    EXPECT_THROW(iss >> hmm, std::runtime_error);
+}
+
 TEST_F(HmmStreamIOTest, MultipleDistributionTypesInSameHMM) {
     // Create HMM with multiple different distribution types including the new ones
     Hmm hmm(3);

--- a/tests/performance/test_transcendental_kernels.cpp
+++ b/tests/performance/test_transcendental_kernels.cpp
@@ -28,6 +28,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <cstring>
 #include <limits>
 #include <numeric>
 #include <span>

--- a/tests/performance/test_transcendental_kernels.cpp
+++ b/tests/performance/test_transcendental_kernels.cpp
@@ -53,6 +53,10 @@ double sum_exp_sum3_minus_max_scalar(const double *a, const double *b, const dou
 void accumulate_exp_sum2_bias_scalar(double *dst, const double *a, const double *b,
                                      std::size_t size, double bias) noexcept;
 void log1p_inplace_scalar(double *data, std::size_t size) noexcept;
+// log_batch_<tier>: forward-declared here (not above with the recurrence
+// kernels) so section 9's subnormal-prescale regression (issue #85) can call
+// each compiled-in tier's log_pd wrapper directly.
+void log_batch_scalar(const double *in, double *out, std::size_t n) noexcept;
 
 #if defined(LIBHMM_BUILD_SSE2_KERNEL)
 double reduce_max_sum2_sse2(const double *a, const double *b, std::size_t size) noexcept;
@@ -65,6 +69,7 @@ double sum_exp_sum3_minus_max_sse2(const double *a, const double *b, const doubl
 void accumulate_exp_sum2_bias_sse2(double *dst, const double *a, const double *b, std::size_t size,
                                    double bias) noexcept;
 void log1p_inplace_sse2(double *data, std::size_t size) noexcept;
+void log_batch_sse2(const double *in, double *out, std::size_t n) noexcept;
 #endif
 
 #if defined(LIBHMM_BUILD_AVX2_KERNEL)
@@ -78,6 +83,7 @@ double sum_exp_sum3_minus_max_avx2(const double *a, const double *b, const doubl
 void accumulate_exp_sum2_bias_avx2(double *dst, const double *a, const double *b, std::size_t size,
                                    double bias) noexcept;
 void log1p_inplace_avx2(double *data, std::size_t size) noexcept;
+void log_batch_avx2(const double *in, double *out, std::size_t n) noexcept;
 #endif
 
 #if defined(LIBHMM_BUILD_AVX512_KERNEL)
@@ -91,6 +97,7 @@ double sum_exp_sum3_minus_max_avx512(const double *a, const double *b, const dou
 void accumulate_exp_sum2_bias_avx512(double *dst, const double *a, const double *b,
                                      std::size_t size, double bias) noexcept;
 void log1p_inplace_avx512(double *data, std::size_t size) noexcept;
+void log_batch_avx512(const double *in, double *out, std::size_t n) noexcept;
 #endif
 
 #if defined(LIBHMM_BUILD_NEON_KERNEL)
@@ -104,6 +111,7 @@ double sum_exp_sum3_minus_max_neon(const double *a, const double *b, const doubl
 void accumulate_exp_sum2_bias_neon(double *dst, const double *a, const double *b, std::size_t size,
                                    double bias) noexcept;
 void log1p_inplace_neon(double *data, std::size_t size) noexcept;
+void log_batch_neon(const double *in, double *out, std::size_t n) noexcept;
 #endif
 
 } // namespace libhmm::performance::detail
@@ -648,6 +656,99 @@ TEST(TranscendentalKernelsTierParity, NeonMatchesScalar) {
     run_tier_parity("neon", pd::reduce_max_sum2_neon, pd::sum_exp_sum2_minus_max_neon,
                     pd::reduce_max_sum3_neon, pd::sum_exp_sum3_minus_max_neon,
                     pd::accumulate_exp_sum2_bias_neon, pd::log1p_inplace_neon);
+}
+#endif
+
+// =========================================================================
+// 9. log_pd subnormal-prescale regression (issue #85).
+//
+// The AVX-512/AVX2/NEON log_pd all scale a subnormal input by 2^54 and
+// subtract 54 from the extracted exponent before the SLEEF core runs; the
+// SSE2 log_pd lacked that prescale, so its exponent-extraction path treated
+// a subnormal's biased exponent (0) as though it belonged to a normal
+// number, compressing the entire subnormal range [4.9e-324, 2.2e-308] to a
+// single wrong result (log_pd(5e-324) landed at -709.09 instead of
+// -744.44). Runs the SAME input vector through EVERY compiled-in tier's
+// log_batch_<tier> directly (bypassing DoubleVecOps) so a future per-tier
+// asymmetry of this shape cannot recur silently. Pre-fix this failed on the
+// SSE2 tier only.
+// =========================================================================
+
+double logUlpDistance(double got, double ref) {
+    if (std::isnan(ref))
+        return std::isnan(got) ? 0.0 : 1e18;
+    if (!std::isfinite(ref))
+        return (got == ref) ? 0.0 : 1e18;
+    if (!std::isfinite(got))
+        return 1e18;
+    // Sign-magnitude -> monotonic-order int64 (same trick as
+    // test_trig_ulp_gates.cpp's trigUlpError): plain integer subtraction is
+    // then the ULP distance, including across the sign of the result.
+    const auto ordered = [](double v) -> std::int64_t {
+        std::int64_t i;
+        std::memcpy(&i, &v, sizeof i);
+        return i < 0 ? static_cast<std::int64_t>(0x8000000000000000ULL) - i : i;
+    };
+    const std::int64_t g = ordered(got);
+    const std::int64_t r = ordered(ref);
+    return static_cast<double>(g > r ? g - r : r - g);
+}
+
+using LogBatchFn = void (*)(const double *, double *, std::size_t) noexcept;
+
+// {5e-324, 1e-310} are subnormal; 2.2250738585072014e-308 is DBL_MIN (the
+// smallest normal, i.e. the boundary the prescale must switch off at); 1.0
+// is an ordinary normal input included so the fix is checked not to disturb
+// the already-correct normal path.
+void run_log_subnormal_gate(const char *tier, LogBatchFn log_fn) {
+    static constexpr double kInputs[] = {5e-324, 1e-310, 2.2250738585072014e-308, 1.0};
+    constexpr std::size_t n = sizeof(kInputs) / sizeof(kInputs[0]);
+    double out[n];
+    log_fn(kInputs, out, n);
+    for (std::size_t i = 0; i < n; ++i) {
+        const double ref = std::log(kInputs[i]);
+        const double ulp = logUlpDistance(out[i], ref);
+        EXPECT_LE(ulp, 1.0) << tier << " log_batch(" << kInputs[i] << ") = " << out[i]
+                            << ", expected " << ref << " (" << ulp << " ULP)";
+    }
+}
+
+TEST(LogSubnormalPrescale, Scalar) {
+    run_log_subnormal_gate("scalar", pd::log_batch_scalar);
+}
+
+#if defined(LIBHMM_BUILD_SSE2_KERNEL)
+TEST(LogSubnormalPrescale, Sse2) {
+    if (!libhmm::platform::supports_sse2()) {
+        GTEST_SKIP() << "SSE2 not supported on this CPU";
+    }
+    run_log_subnormal_gate("sse2", pd::log_batch_sse2);
+}
+#endif
+
+#if defined(LIBHMM_BUILD_AVX2_KERNEL)
+TEST(LogSubnormalPrescale, Avx2) {
+    if (!libhmm::platform::supports_avx2()) {
+        GTEST_SKIP() << "AVX2 not supported on this CPU";
+    }
+    run_log_subnormal_gate("avx2", pd::log_batch_avx2);
+}
+#endif
+
+#if defined(LIBHMM_BUILD_AVX512_KERNEL)
+TEST(LogSubnormalPrescale, Avx512) {
+    if (!libhmm::platform::supports_avx512()) {
+        GTEST_SKIP() << "AVX-512 not supported on this CPU";
+    }
+    run_log_subnormal_gate("avx512", pd::log_batch_avx512);
+}
+#endif
+
+#if defined(LIBHMM_BUILD_NEON_KERNEL)
+TEST(LogSubnormalPrescale, Neon) {
+    // NEON is the mandatory AArch64 baseline ISA -- always available when
+    // this TU is compiled in.
+    run_log_subnormal_gate("neon", pd::log_batch_neon);
 }
 #endif
 

--- a/tests/performance/test_trig_ulp_gates.cpp
+++ b/tests/performance/test_trig_ulp_gates.cpp
@@ -347,6 +347,69 @@ TEST(TrigUlpGates, Neon) {
 #endif
 
 // =========================================================================
+// Sign-of-zero regression (issue #81): sin(+/-0) must preserve the sign of
+// its input; cos(+/-0) == 1 regardless of sign and is therefore unaffected
+// (not tested here). Every tier's quadrant-reduction core computes
+// s_core = r + (r*u*P(u) + rlo); for x = -0.0 that reduces to
+// (-0) + (+0), which IEEE 754 rounds to +0, dropping the sign before the
+// quadrant recombination ever runs. The ULP lattice metric used by the main
+// gate above cannot see this defect (it maps +0 and -0 to the same
+// ordinal), so this needs its own explicit std::signbit assertions.
+// Pre-fix this failed on every SIMD tier; the scalar tier is unaffected
+// (sin_batch_scalar calls std::sin directly, which already preserves the
+// sign of zero).
+// =========================================================================
+
+void run_sign_of_zero_gate(const char *tier, CosSinFn sin_fn) {
+    double in[2] = {0.0, -0.0};
+    double out[2] = {0.0, 0.0};
+    sin_fn(in, out, 2);
+    EXPECT_EQ(out[0], 0.0) << tier << " sin(+0) must be +0";
+    EXPECT_FALSE(std::signbit(out[0])) << tier << " sin(+0) must not be negative";
+    EXPECT_EQ(out[1], 0.0) << tier << " sin(-0) must be -0";
+    EXPECT_TRUE(std::signbit(out[1])) << tier << " sin(-0) must be negative";
+}
+
+TEST(TrigSignOfZero, Scalar) {
+    run_sign_of_zero_gate("scalar", pd::sin_batch_scalar);
+}
+
+#if defined(LIBHMM_BUILD_SSE2_KERNEL)
+TEST(TrigSignOfZero, Sse2) {
+    if (!libhmm::platform::supports_sse2()) {
+        GTEST_SKIP() << "SSE2 not supported on this CPU";
+    }
+    run_sign_of_zero_gate("sse2", pd::sin_batch_sse2);
+}
+#endif
+
+#if defined(LIBHMM_BUILD_AVX2_KERNEL)
+TEST(TrigSignOfZero, Avx2) {
+    if (!libhmm::platform::supports_avx2()) {
+        GTEST_SKIP() << "AVX2 not supported on this CPU";
+    }
+    run_sign_of_zero_gate("avx2", pd::sin_batch_avx2);
+}
+#endif
+
+#if defined(LIBHMM_BUILD_AVX512_KERNEL)
+TEST(TrigSignOfZero, Avx512) {
+    if (!libhmm::platform::supports_avx512()) {
+        GTEST_SKIP() << "AVX-512 not supported on this CPU";
+    }
+    run_sign_of_zero_gate("avx512", pd::sin_batch_avx512);
+}
+#endif
+
+#if defined(LIBHMM_BUILD_NEON_KERNEL)
+TEST(TrigSignOfZero, Neon) {
+    // NEON is the mandatory AArch64 baseline ISA — always available when this
+    // TU is compiled in.
+    run_sign_of_zero_gate("neon", pd::sin_batch_neon);
+}
+#endif
+
+// =========================================================================
 // Specials gate: domain-edge / beyond-domain / ±Inf / NaN, at the libm
 // budget for every tier (the beyond-domain points route through the same
 // per-lane scalar std::cos/std::sin fixup regardless of which tier's vector

--- a/tests/platform/test_simd_platform.cpp
+++ b/tests/platform/test_simd_platform.cpp
@@ -213,3 +213,78 @@ TEST(CpuDetectionConsistency, X86_64AlwaysReportsSSE2) {
     EXPECT_FALSE(libhmm::platform::supports_neon());
 #endif
 }
+
+// ============================================================================
+// AVX-512 / AVX2 feature-mask contract (issue #83)
+//
+// detect_avx512()/detect_avx2() (src/platform/cpu_detection.cpp) gate on more
+// than the bare "AVX-512F" / "AVX2" bits: AVX-512 additionally requires
+// DQ + BW + VL (what /arch:AVX512 licenses and what the AVX-512 kernel TU's
+// AVX-512DQ intrinsics, e.g. _mm512_cvtepi64_pd, need to not SIGILL), and
+// AVX2 additionally requires FMA3 (leaf 1 ECX bit 12) since the AVX2 kernel
+// TU is compiled -mavx2 -mfma and executes FMA intrinsics directly. This CPU
+// (Zen 4) and every CI runner satisfy both extended contracts, so the two
+// "Implies" tests below hold both before and after the fix and only document
+// it; Avx512RequiredMaskExactValue is the part that can actually fail a
+// regression — it was hand-verified red under a deliberate one-bit
+// perturbation of kAvx512RequiredMask (dropping VL) and green again restored,
+// per issue #83's fix.
+// ============================================================================
+
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
+#define LIBHMM_TEST_CPU_X86
+#endif
+
+#ifdef LIBHMM_TEST_CPU_X86
+#if defined(_MSC_VER)
+#include <intrin.h> // __cpuidex
+#else
+#include <cpuid.h> // __cpuid_count
+#endif
+
+namespace {
+
+// Mirrors cpu_detection.cpp's run_cpuid: CPUID itself is always safe to
+// execute regardless of compile flags, so this test file (deliberately not
+// compiled with LIBHMM_BEST_SIMD_FLAGS) can call it directly.
+void test_run_cpuid(int leaf, int subleaf, int out[4]) noexcept {
+#if defined(_MSC_VER)
+    __cpuidex(out, leaf, subleaf);
+#else
+    __cpuid_count(leaf, subleaf, out[0], out[1], out[2], out[3]);
+#endif
+}
+
+} // namespace
+
+// Regression guard: pins the exact AVX-512 feature mask value. A one-bit
+// perturbation (e.g. dropping VL, bit 31) must fail this assertion.
+TEST(CpuDetectionConsistency, Avx512RequiredMaskExactValue) {
+    constexpr unsigned expected = (1u << 16) | (1u << 17) | (1u << 30) | (1u << 31);
+    EXPECT_EQ(libhmm::platform::kAvx512RequiredMask, expected);
+}
+
+TEST(CpuDetectionConsistency, Avx512ImpliesFullFeatureMask) {
+    if (!libhmm::platform::supports_avx512()) {
+        GTEST_SKIP() << "AVX-512 not supported on this CPU";
+    }
+    int info[4] = {};
+    test_run_cpuid(7, 0, info);
+    const unsigned ebx = static_cast<unsigned>(info[1]);
+    EXPECT_TRUE((ebx >> 17) & 1u) << "AVX-512DQ (bit 17) must be set";
+    EXPECT_TRUE((ebx >> 30) & 1u) << "AVX-512BW (bit 30) must be set";
+    EXPECT_TRUE((ebx >> 31) & 1u) << "AVX-512VL (bit 31) must be set";
+    EXPECT_EQ(ebx & libhmm::platform::kAvx512RequiredMask, libhmm::platform::kAvx512RequiredMask);
+}
+
+TEST(CpuDetectionConsistency, Avx2ImpliesFma3) {
+    if (!libhmm::platform::supports_avx2()) {
+        GTEST_SKIP() << "AVX2 not supported on this CPU";
+    }
+    int info[4] = {};
+    test_run_cpuid(1, 0, info);
+    EXPECT_TRUE((static_cast<unsigned>(info[2]) >> 12) & 1u)
+        << "FMA3 (leaf 1 ECX bit 12) must be set";
+}
+
+#endif // LIBHMM_TEST_CPU_X86


### PR DESCRIPTION
Implements all ten issues on milestone [v4.4.1 — Correctness patch](https://github.com/OldCrow/libhmm/milestone/4), from the 2026-08-21 defensive review. Bug fixes only — no API surface change beyond the documented new throws.

## Memory safety
- #86 — `getBatchLogProbabilities` now throws `std::invalid_argument` when `out` is shorter than `observations` (previously an OOB heap write; reproduced as `STATUS_HEAP_CORRUPTION` pre-fix). All 16 concrete overrides plus the CRTP fallback (whose Release-mode `assert` was a no-op).
- #87 — `json::Reader::read_double` parses from a bounded NUL-terminated buffer instead of running `strtod` past a non-NUL-terminated `string_view`.

## Numerical correctness
- #84 — von Mises `fit()` no longer stores κ = NaN for R̄ ≥ 0.9993: Newton solver forms A via `one_minus_bessel_ratio` (no I₀ overflow), plus a finite-guard. κ verified against mpmath references.
- #85 — SSE2 `log_pd` gets the subnormal 2⁵⁴ prescale the other tiers already had; per-tier regression test runs the same vector through every tier.
- #81 — `sin_pd(−0.0)` returns −0.0 on all four tiers (libstats#98 port); ULP gates gain explicit `signbit` assertions on the ±0 specials.

## Dispatch safety
- #83 — AVX-512 tier requires F+DQ+BW+VL (was F alone — SIGILL on F-without-DQ parts); AVX2 tier additionally requires FMA3; CMake probes test the exact flag sets passed.

## Input validation
- #90 — StudentT location μ validated finite (ctor, `setLocation`, JSON).
- #91 — JSON loader rejects NaN/inf/negative `pi`/`trans` entries (both scalar and MV paths).
- #88 — count distributions bound-check before double→int casts (UB, ISA-dependent — the new tests are the x86/AArch64 parity gate).
- #89 — legacy `States:` bounded at 4096 before allocation; `XMLFileReader` translates `bad_alloc`/`logic_error` to its documented `runtime_error`.

Every fix carries its issue-named regression test, demonstrated red-before-green where reachable (exceptions recorded on the issues/PLAN). Local: Zen 4 / MSVC, full suite 51/51 on the merged tree. The macOS/AArch64 leg is the decisive one for #88 (cast parity) and #81 (NEON); ASan for #86/#87.

Issues intentionally carry no closing keywords — they will be closed with comments at release per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)